### PR TITLE
feat: add SQLite database support with file-based connections

### DIFF
--- a/apps/desktop/.npmrc
+++ b/apps/desktop/.npmrc
@@ -1,3 +1,4 @@
-electron_mirror=https://npmmirror.com/mirrors/electron/
-electron_builder_binaries_mirror=https://npmmirror.com/mirrors/electron-builder-binaries/
+# Use official electron releases from GitHub
+# electron_mirror=https://npmmirror.com/mirrors/electron/
+# electron_builder_binaries_mirror=https://npmmirror.com/mirrors/electron-builder-binaries/
 shamefully-hoist=true

--- a/apps/desktop/src/main/adapters/sqlite-adapter.ts
+++ b/apps/desktop/src/main/adapters/sqlite-adapter.ts
@@ -1,0 +1,485 @@
+import Database from 'better-sqlite3'
+import * as fs from 'fs'
+import type {
+  ConnectionConfig,
+  SchemaInfo,
+  TableInfo,
+  ColumnInfo,
+  QueryField,
+  ForeignKeyInfo,
+  TableDefinition,
+  ColumnDefinition,
+  ConstraintDefinition,
+  IndexDefinition,
+  SequenceInfo,
+  CustomTypeInfo
+} from '@shared/index'
+import type { DatabaseAdapter, AdapterQueryResult, ExplainResult } from '../db-adapter'
+
+/**
+ * SQLite type affinity mapping
+ * SQLite has 5 type affinities: TEXT, NUMERIC, INTEGER, REAL, BLOB
+ */
+function normalizeSQLiteType(rawType: string | null): string {
+  if (!rawType) return 'BLOB'
+
+  const type = rawType.toUpperCase()
+
+  // Direct matches
+  if (type === 'INTEGER' || type === 'INT') return 'integer'
+  if (type === 'TEXT') return 'text'
+  if (type === 'REAL' || type === 'FLOAT' || type === 'DOUBLE') return 'real'
+  if (type === 'BLOB') return 'blob'
+  if (type === 'NUMERIC') return 'numeric'
+
+  // Common type aliases
+  if (type.includes('INT')) return 'integer'
+  if (type.includes('CHAR') || type.includes('CLOB') || type.includes('TEXT')) return 'text'
+  if (type.includes('REAL') || type.includes('FLOA') || type.includes('DOUB')) return 'real'
+  if (type.includes('BLOB')) return 'blob'
+
+  // Numeric types
+  if (type.includes('NUM') || type.includes('DEC')) return 'numeric'
+  if (type === 'BOOLEAN') return 'boolean'
+  if (type === 'DATE' || type === 'TIME') return type.toLowerCase()
+
+  // Default to numeric affinity
+  return rawType.toLowerCase()
+}
+
+/**
+ * SQLite database adapter
+ */
+export class SQLiteAdapter implements DatabaseAdapter {
+  readonly dbType = 'sqlite' as const
+
+  /**
+   * Test connection by attempting to open the database file
+   */
+  async connect(config: ConnectionConfig): Promise<void> {
+    const filePath = config.filePath || config.database
+
+    if (!filePath) {
+      throw new Error('SQLite requires a file path')
+    }
+
+    // Check if file exists
+    if (!fs.existsSync(filePath)) {
+      throw new Error(`Database file not found: ${filePath}`)
+    }
+
+    // Try to open the database
+    try {
+      const db = new Database(filePath, { readonly: true, fileMustExist: true })
+      // Test query to ensure it's a valid SQLite database
+      db.prepare('SELECT sqlite_version()').get()
+      db.close()
+    } catch (error) {
+      throw new Error(`Invalid SQLite database: ${error instanceof Error ? error.message : String(error)}`)
+    }
+  }
+
+  /**
+   * Execute a query and return results
+   */
+  async query(config: ConnectionConfig, sql: string): Promise<AdapterQueryResult> {
+    const filePath = config.filePath || config.database
+    if (!filePath) {
+      throw new Error('SQLite requires a file path')
+    }
+
+    const db = new Database(filePath, { readonly: true })
+
+    try {
+      const stmt = db.prepare(sql)
+      const rows = stmt.all() as Record<string, unknown>[]
+
+      // Extract field metadata from statement
+      const columns = stmt.columns()
+      const fields: QueryField[] = columns.map((col) => ({
+        name: col.name,
+        dataType: normalizeSQLiteType(col.type),
+        dataTypeID: undefined
+      }))
+
+      return {
+        rows,
+        fields,
+        rowCount: rows.length
+      }
+    } finally {
+      db.close()
+    }
+  }
+
+  /**
+   * Execute a parameterized statement (for INSERT/UPDATE/DELETE)
+   */
+  async execute(
+    config: ConnectionConfig,
+    sql: string,
+    params: unknown[]
+  ): Promise<{ rowCount: number | null }> {
+    const filePath = config.filePath || config.database
+    if (!filePath) {
+      throw new Error('SQLite requires a file path')
+    }
+
+    const db = new Database(filePath)
+
+    try {
+      const stmt = db.prepare(sql)
+      const info = stmt.run(...params)
+      return { rowCount: info.changes }
+    } finally {
+      db.close()
+    }
+  }
+
+  /**
+   * Execute multiple statements in a transaction
+   */
+  async executeTransaction(
+    config: ConnectionConfig,
+    statements: Array<{ sql: string; params: unknown[] }>
+  ): Promise<{ rowsAffected: number; results: Array<{ rowCount: number | null }> }> {
+    const filePath = config.filePath || config.database
+    if (!filePath) {
+      throw new Error('SQLite requires a file path')
+    }
+
+    const db = new Database(filePath)
+
+    try {
+      // Enable WAL mode for better concurrency
+      db.pragma('journal_mode = WAL')
+
+      const results: Array<{ rowCount: number | null }> = []
+      let totalRowsAffected = 0
+
+      // Start transaction
+      db.prepare('BEGIN').run()
+
+      try {
+        for (const { sql, params } of statements) {
+          const stmt = db.prepare(sql)
+          const info = stmt.run(...params)
+          results.push({ rowCount: info.changes })
+          totalRowsAffected += info.changes
+        }
+
+        // Commit transaction
+        db.prepare('COMMIT').run()
+
+        return { rowsAffected: totalRowsAffected, results }
+      } catch (error) {
+        // Rollback on error
+        db.prepare('ROLLBACK').run()
+        throw error
+      }
+    } finally {
+      db.close()
+    }
+  }
+
+  /**
+   * Fetch database schemas, tables, and columns
+   * SQLite doesn't have schemas - we return a single 'main' schema
+   */
+  async getSchemas(config: ConnectionConfig): Promise<SchemaInfo[]> {
+    const filePath = config.filePath || config.database
+    if (!filePath) {
+      throw new Error('SQLite requires a file path')
+    }
+
+    const db = new Database(filePath, { readonly: true })
+
+    try {
+      // Get all tables and views
+      const tablesAndViews = db
+        .prepare(
+          `
+          SELECT name, type
+          FROM sqlite_master
+          WHERE type IN ('table', 'view')
+            AND name NOT LIKE 'sqlite_%'
+          ORDER BY name
+        `
+        )
+        .all() as Array<{ name: string; type: string }>
+
+      const tables: TableInfo[] = []
+
+      for (const item of tablesAndViews) {
+        const columns = await this.getTableColumns(db, item.name)
+        const estimatedRowCount = this.getTableRowCount(db, item.name)
+
+        tables.push({
+          name: item.name,
+          type: item.type === 'view' ? 'view' : 'table',
+          columns,
+          estimatedRowCount
+        })
+      }
+
+      return [
+        {
+          name: 'main',
+          tables
+        }
+      ]
+    } finally {
+      db.close()
+    }
+  }
+
+  /**
+   * Get columns for a table with foreign key information
+   */
+  private async getTableColumns(db: Database.Database, tableName: string): Promise<ColumnInfo[]> {
+    // Get column info from PRAGMA
+    const columnInfo = db.prepare(`PRAGMA table_info("${tableName}")`).all() as Array<{
+      cid: number
+      name: string
+      type: string
+      notnull: number
+      dflt_value: string | null
+      pk: number
+    }>
+
+    // Get foreign keys
+    const foreignKeys = db.prepare(`PRAGMA foreign_key_list("${tableName}")`).all() as Array<{
+      id: number
+      seq: number
+      table: string
+      from: string
+      to: string
+      on_update: string
+      on_delete: string
+      match: string
+    }>
+
+    // Create foreign key map
+    const fkMap = new Map<string, ForeignKeyInfo>()
+    for (const fk of foreignKeys) {
+      fkMap.set(fk.from, {
+        constraintName: `fk_${tableName}_${fk.id}`,
+        referencedSchema: 'main',
+        referencedTable: fk.table,
+        referencedColumn: fk.to
+      })
+    }
+
+    // Map columns
+    const columns: ColumnInfo[] = columnInfo.map((col) => ({
+      name: col.name,
+      dataType: normalizeSQLiteType(col.type),
+      isNullable: col.notnull === 0,
+      isPrimaryKey: col.pk > 0,
+      defaultValue: col.dflt_value ?? undefined,
+      ordinalPosition: col.cid + 1,
+      foreignKey: fkMap.get(col.name)
+    }))
+
+    return columns
+  }
+
+  /**
+   * Get estimated row count for a table
+   */
+  private getTableRowCount(db: Database.Database, tableName: string): number | undefined {
+    try {
+      const result = db.prepare(`SELECT COUNT(*) as count FROM "${tableName}"`).get() as {
+        count: number
+      }
+      return result.count
+    } catch {
+      return undefined
+    }
+  }
+
+  /**
+   * Get query execution plan
+   * SQLite uses EXPLAIN QUERY PLAN instead of PostgreSQL's EXPLAIN
+   */
+  async explain(
+    config: ConnectionConfig,
+    sql: string,
+    _analyze: boolean
+  ): Promise<ExplainResult> {
+    const filePath = config.filePath || config.database
+    if (!filePath) {
+      throw new Error('SQLite requires a file path')
+    }
+
+    const db = new Database(filePath, { readonly: true })
+
+    try {
+      const startTime = performance.now()
+
+      // SQLite doesn't have EXPLAIN ANALYZE, just EXPLAIN QUERY PLAN
+      const explainQuery = `EXPLAIN QUERY PLAN ${sql}`
+      const stmt = db.prepare(explainQuery)
+      const planRows = stmt.all()
+
+      const durationMs = performance.now() - startTime
+
+      return {
+        plan: planRows,
+        durationMs
+      }
+    } finally {
+      db.close()
+    }
+  }
+
+  /**
+   * Get table DDL definition
+   * Reverse engineer table structure for the table designer
+   */
+  async getTableDDL(
+    config: ConnectionConfig,
+    _schema: string,
+    table: string
+  ): Promise<TableDefinition> {
+    const filePath = config.filePath || config.database
+    if (!filePath) {
+      throw new Error('SQLite requires a file path')
+    }
+
+    const db = new Database(filePath, { readonly: true })
+
+    try {
+      // Get table creation SQL
+      const createSql = db
+        .prepare(
+          `
+          SELECT sql
+          FROM sqlite_master
+          WHERE type='table' AND name=?
+        `
+        )
+        .get(table) as { sql: string } | undefined
+
+      if (!createSql) {
+        throw new Error(`Table not found: ${table}`)
+      }
+
+      // Get column info
+      const columnInfo = db.prepare(`PRAGMA table_info("${table}")`).all() as Array<{
+        cid: number
+        name: string
+        type: string
+        notnull: number
+        dflt_value: string | null
+        pk: number
+      }>
+
+      // Build column definitions
+      const columns: ColumnDefinition[] = columnInfo.map((col) => ({
+        id: `col_${col.cid}`,
+        name: col.name,
+        dataType: normalizeSQLiteType(col.type),
+        isNullable: col.notnull === 0,
+        isPrimaryKey: col.pk > 0,
+        isUnique: false, // TODO: detect from indexes
+        defaultValue: col.dflt_value ?? undefined
+      }))
+
+      // Get foreign keys
+      const foreignKeys = db.prepare(`PRAGMA foreign_key_list("${table}")`).all() as Array<{
+        id: number
+        seq: number
+        table: string
+        from: string
+        to: string
+        on_update: string
+        on_delete: string
+      }>
+
+      // Build constraint definitions
+      const constraints: ConstraintDefinition[] = []
+
+      // Add foreign key constraints
+      const fkGroups = new Map<number, typeof foreignKeys>()
+      for (const fk of foreignKeys) {
+        if (!fkGroups.has(fk.id)) {
+          fkGroups.set(fk.id, [])
+        }
+        fkGroups.get(fk.id)!.push(fk)
+      }
+
+      for (const [fkId, fkCols] of fkGroups) {
+        if (fkCols.length > 0) {
+          constraints.push({
+            id: `fk_${fkId}`,
+            name: `fk_${table}_${fkId}`,
+            type: 'foreign_key',
+            columns: fkCols.map((fk) => fk.from),
+            referencedSchema: 'main',
+            referencedTable: fkCols[0].table,
+            referencedColumns: fkCols.map((fk) => fk.to),
+            onUpdate: fkCols[0].on_update as any,
+            onDelete: fkCols[0].on_delete as any
+          })
+        }
+      }
+
+      // Get indexes
+      const indexList = db.prepare(`PRAGMA index_list("${table}")`).all() as Array<{
+        seq: number
+        name: string
+        unique: number
+        origin: string
+        partial: number
+      }>
+
+      const indexes: IndexDefinition[] = []
+
+      for (const idx of indexList) {
+        // Skip auto-created indexes for primary keys
+        if (idx.origin === 'pk') continue
+
+        const indexInfo = db.prepare(`PRAGMA index_info("${idx.name}")`).all() as Array<{
+          seqno: number
+          cid: number
+          name: string
+        }>
+
+        indexes.push({
+          id: `idx_${idx.seq}`,
+          name: idx.name,
+          columns: indexInfo.map((col) => ({ name: col.name })),
+          isUnique: idx.unique === 1,
+          method: 'btree' // SQLite only uses btree
+        })
+      }
+
+      return {
+        schema: 'main',
+        name: table,
+        columns,
+        constraints,
+        indexes
+      }
+    } finally {
+      db.close()
+    }
+  }
+
+  /**
+   * Get sequences
+   * SQLite doesn't have sequences - return empty array
+   */
+  async getSequences(_config: ConnectionConfig): Promise<SequenceInfo[]> {
+    return []
+  }
+
+  /**
+   * Get custom types (enums, composites, etc.)
+   * SQLite doesn't have custom types - return empty array
+   */
+  async getTypes(_config: ConnectionConfig): Promise<CustomTypeInfo[]> {
+    return []
+  }
+}

--- a/apps/desktop/src/main/db-adapter.ts
+++ b/apps/desktop/src/main/db-adapter.ts
@@ -70,12 +70,13 @@ export interface DatabaseAdapter {
 // Import adapters
 import { PostgresAdapter } from './adapters/postgres-adapter'
 import { MySQLAdapter } from './adapters/mysql-adapter'
+import { SQLiteAdapter } from './adapters/sqlite-adapter'
 
 // Adapter instances (singletons)
 const adapters: Record<DatabaseType, DatabaseAdapter> = {
   postgresql: new PostgresAdapter(),
   mysql: new MySQLAdapter(),
-  sqlite: new PostgresAdapter() // Placeholder - SQLite not implemented yet
+  sqlite: new SQLiteAdapter()
 }
 
 /**

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, shell, BrowserWindow, ipcMain } from 'electron'
+import { app, shell, BrowserWindow, ipcMain, dialog } from 'electron'
 import { join } from 'path'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import icon from '../../resources/icon.png?asset'
@@ -173,18 +173,14 @@ app.whenReady().then(async () => {
   ipcMain.handle(
     'db:query',
     async (_, { config, query }: { config: ConnectionConfig; query: string }) => {
-      console.log('[main:db:query] Received query request')
-      console.log('[main:db:query] Config:', { ...config, password: '***' })
-      console.log('[main:db:query] Query:', query)
+      console.error('[main:db:query] Received query request for', config.dbType)
 
       try {
         const adapter = getAdapter(config)
-        console.log('[main:db:query] Connecting...')
         const start = Date.now()
         const result = await adapter.query(config, query)
         const duration = Date.now() - start
-        console.log('[main:db:query] Query completed in', duration, 'ms')
-        console.log('[main:db:query] Rows:', result.rowCount)
+        console.error('[main:db:query] Completed in', duration, 'ms, rows:', result.rowCount)
 
         return {
           success: true,
@@ -277,9 +273,7 @@ app.whenReady().then(async () => {
   ipcMain.handle(
     'db:execute',
     async (_, { config, batch }: { config: ConnectionConfig; batch: EditBatch }) => {
-      console.log('[main:db:execute] Received edit batch')
-      console.log('[main:db:execute] Context:', batch.context)
-      console.log('[main:db:execute] Operations count:', batch.operations.length)
+      console.error('[main:db:execute] Received', batch.operations.length, 'operations')
 
       const adapter = getAdapter(config)
       const dbType = config.dbType || 'postgresql'
@@ -372,9 +366,7 @@ app.whenReady().then(async () => {
       _,
       { config, query, analyze }: { config: ConnectionConfig; query: string; analyze: boolean }
     ) => {
-      console.log('[main:db:explain] Received explain request')
-      console.log('[main:db:explain] Query:', query)
-      console.log('[main:db:explain] Analyze:', analyze)
+      console.error('[main:db:explain] Received explain request, analyze:', analyze)
 
       try {
         const adapter = getAdapter(config)
@@ -403,7 +395,7 @@ app.whenReady().then(async () => {
       _,
       { config, definition }: { config: ConnectionConfig; definition: TableDefinition }
     ) => {
-      console.log('[main:db:create-table] Creating table:', definition.schema, definition.name)
+      console.error('[main:db:create-table] Creating table:', definition.schema, definition.name)
 
       // Validate table definition
       const validation = validateTableDefinition(definition)
@@ -427,7 +419,7 @@ app.whenReady().then(async () => {
         const { sql } = buildCreateTable(definition, dbType)
         result.executedSql.push(sql)
 
-        console.log('[main:db:create-table] Executing:', sql)
+        console.error('[main:db:create-table] Executing DDL')
 
         // Execute each statement separately (CREATE TABLE, COMMENT, indexes)
         const statements = sql.split(/;\s*\n\n/).filter((s) => s.trim())
@@ -453,7 +445,7 @@ app.whenReady().then(async () => {
   ipcMain.handle(
     'db:alter-table',
     async (_, { config, batch }: { config: ConnectionConfig; batch: AlterTableBatch }) => {
-      console.log('[main:db:alter-table] Altering table:', batch.schema, batch.table)
+      console.error('[main:db:alter-table] Altering table:', batch.schema, batch.table)
 
       const adapter = getAdapter(config)
       const dbType = config.dbType || 'postgresql'
@@ -469,7 +461,7 @@ app.whenReady().then(async () => {
         const statements = queries.map((q) => ({ sql: q.sql, params: [] }))
         result.executedSql = queries.map((q) => q.sql)
 
-        console.log('[main:db:alter-table] Executing:', result.executedSql)
+        console.error('[main:db:alter-table] Executing', result.executedSql.length, 'statements')
 
         await adapter.executeTransaction(config, statements)
 
@@ -496,14 +488,14 @@ app.whenReady().then(async () => {
         cascade
       }: { config: ConnectionConfig; schema: string; table: string; cascade?: boolean }
     ) => {
-      console.log('[main:db:drop-table] Dropping table:', schema, table)
+      console.error('[main:db:drop-table] Dropping table:', schema, table)
 
       const adapter = getAdapter(config)
       const dbType = config.dbType || 'postgresql'
 
       try {
         const { sql } = buildDropTable(schema, table, cascade, dbType)
-        console.log('[main:db:drop-table] Executing:', sql)
+        console.error('[main:db:drop-table] Executing DROP')
 
         await adapter.executeTransaction(config, [{ sql, params: [] }])
 
@@ -526,7 +518,7 @@ app.whenReady().then(async () => {
       _,
       { config, schema, table }: { config: ConnectionConfig; schema: string; table: string }
     ) => {
-      console.log('[main:db:get-table-ddl] Getting DDL for:', schema, table)
+      console.error('[main:db:get-table-ddl] Getting DDL for:', schema, table)
 
       try {
         const adapter = getAdapter(config)
@@ -542,7 +534,7 @@ app.whenReady().then(async () => {
 
   // Get available sequences
   ipcMain.handle('db:get-sequences', async (_, config: ConnectionConfig) => {
-    console.log('[main:db:get-sequences] Fetching sequences')
+    console.error('[main:db:get-sequences] Fetching sequences')
 
     try {
       const adapter = getAdapter(config)
@@ -557,7 +549,7 @@ app.whenReady().then(async () => {
 
   // Get custom types (enums, composites, etc.)
   ipcMain.handle('db:get-types', async (_, config: ConnectionConfig) => {
-    console.log('[main:db:get-types] Fetching custom types')
+    console.error('[main:db:get-types] Fetching custom types')
 
     try {
       const adapter = getAdapter(config)
@@ -603,7 +595,7 @@ app.whenReady().then(async () => {
 
   // Activate a license
   ipcMain.handle('license:activate', async (_, request: LicenseActivationRequest) => {
-    console.log('[main:license:activate] Activating license for:', request.email)
+    console.error('[main:license:activate] Activating license')
     try {
       const result = await activateLicense(request.key, request.email)
       if (result.success) {
@@ -620,7 +612,7 @@ app.whenReady().then(async () => {
 
   // Deactivate the current license
   ipcMain.handle('license:deactivate', async () => {
-    console.log('[main:license:deactivate] Deactivating license')
+    console.error('[main:license:deactivate] Deactivating license')
     try {
       const result = await deactivateLicense()
       return { success: result.success, error: result.error }
@@ -643,7 +635,7 @@ app.whenReady().then(async () => {
         daysValid
       }: { key: string; email: string; type?: 'individual' | 'team'; daysValid?: number }
     ) => {
-      console.log('[main:license:activate-offline] Offline activation for:', email)
+      console.error('[main:license:activate-offline] Offline activation')
       try {
         activateLicenseOffline(key, email, type, daysValid)
         const status = await checkLicense()
@@ -653,6 +645,24 @@ app.whenReady().then(async () => {
         const errorMessage = error instanceof Error ? error.message : String(error)
         return { success: false, error: errorMessage }
       }
+    }
+  )
+
+  // ============================================
+  // File Dialog (for SQLite file picker)
+  // ============================================
+
+  ipcMain.handle(
+    'dialog:show-open',
+    async (
+      _,
+      options: {
+        properties?: Array<'openFile' | 'openDirectory' | 'multiSelections'>
+        filters?: Array<{ name: string; extensions: string[] }>
+      }
+    ) => {
+      const result = await dialog.showOpenDialog(options)
+      return result
     }
   )
 

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -80,6 +80,10 @@ interface DataPeekApi {
       daysValid?: number
     ) => Promise<IpcResponse<LicenseStatus>>
   }
+  showOpenDialog: (options: {
+    properties?: Array<'openFile' | 'openDirectory' | 'multiSelections'>
+    filters?: Array<{ name: string; extensions: string[] }>
+  }) => Promise<{ canceled: boolean; filePaths: string[] }>
   savedQueries: {
     list: () => Promise<IpcResponse<SavedQuery[]>>
     add: (query: SavedQuery) => Promise<IpcResponse<SavedQuery>>

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -128,6 +128,12 @@ const api = {
     ): Promise<IpcResponse<LicenseStatus>> =>
       ipcRenderer.invoke('license:activate-offline', { key, email, type, daysValid })
   },
+  // File dialog
+  showOpenDialog: (options: {
+    properties?: Array<'openFile' | 'openDirectory' | 'multiSelections'>
+    filters?: Array<{ name: string; extensions: string[] }>
+  }): Promise<{ canceled: boolean; filePaths: string[] }> =>
+    ipcRenderer.invoke('dialog:show-open', options),
   // Saved queries management
   savedQueries: {
     list: (): Promise<IpcResponse<SavedQuery[]>> => ipcRenderer.invoke('saved-queries:list'),

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -8,6 +8,8 @@ export interface ConnectionConfig {
   password?: string;
   ssl?: boolean;
   dbType: DatabaseType;
+  // SQLite-specific
+  filePath?: string;
 }
 
 /**


### PR DESCRIPTION
Adds SQLite as a third database option alongside PostgreSQL and MySQL, enabling users to work with local database files without a server.

**IMPORTANT: this feature 100% AI-coded, recommend testing with a few .sqlite files on your side @Rohithgilla12.**

**Key Changes**
- New SQLiteAdapter implementing DatabaseAdapter interface
- File picker dialog for selecting .sqlite, .db, and .db3 files
- Updated connection dialog with SQLite-specific fields
- dialog:show-open IPC handler for native file selection
- Extended ConnectionConfig to support file-based connections

**Technical Details**
- Uses better-sqlite3 for synchronous operations
- Schema metadata extraction matching PostgreSQL/MySQL patterns

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * SQLite database support now available with file-based connection configuration
  * File browser dialog added for selecting database files when setting up SQLite connections

* **Chores**
  * Electron binary configuration updated to use official GitHub releases

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->