### PR TITLE
fix: Windows window resize and dock functionality

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -106,21 +106,24 @@ async function createWindow(): Promise<void> {
     minHeight: 600,
     show: false,
     autoHideMenuBar: false, // Show menu bar for native shortcuts
-    // macOS-style window
-    titleBarStyle: 'hiddenInset',
-    trafficLightPosition: { x: 16, y: 18 },
-    vibrancy: 'sidebar',
-    visualEffectState: 'active',
-    transparent: true,
-    backgroundColor: '#00000000',
-    // Windows titlebar overlay
+    // macOS-style window with vibrancy
+    ...(process.platform === 'darwin' && {
+      titleBarStyle: 'hiddenInset',
+      trafficLightPosition: { x: 16, y: 18 },
+      vibrancy: 'sidebar',
+      visualEffectState: 'active',
+      transparent: true,
+      backgroundColor: '#00000000'
+    }),
+    // Windows titlebar overlay - keep window resizable and dockable
     ...(process.platform === 'win32' && {
       titleBarStyle: 'hidden',
       titleBarOverlay: {
         color: '#1e1e1e',
         symbolColor: '#ffffff',
         height: 40
-      }
+      },
+      backgroundColor: '#1e1e1e'
     }),
     ...(process.platform === 'linux' ? { icon } : {}),
     webPreferences: {


### PR DESCRIPTION
## Summary

- Fixed Windows window not being resizable or dockable
- Moved macOS-specific visual settings (`vibrancy`, `transparent`, `visualEffectState`) to be conditional on darwin platform
- Windows was affected because transparent windows don't have proper window decorations for resize/dock operations

Fixes #37

## Test plan

- [ ] Test on Windows 11: verify window can be resized
- [ ] Test on Windows 11: verify window can be maximized/restored
- [ ] Test on Windows 11: verify window can be docked (snap to sides)
- [ ] Test on macOS: verify vibrancy and transparency still work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined window appearance settings for macOS and Windows to provide platform-appropriate visual presentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->