### PR TITLE
fix: MSSQL stored procedure parameters UI overlap

### DIFF
--- a/apps/desktop/src/renderer/src/components/schema-explorer.tsx
+++ b/apps/desktop/src/renderer/src/components/schema-explorer.tsx
@@ -128,7 +128,10 @@ function VirtualizedSchemaItems({
       } else {
         const routineKey = `${schemaName}.${item.data.name}`
         const paramCount = item.data.parameters.length + (item.data.returnType ? 1 : 0)
-        return expandedRoutines.has(routineKey) ? 28 + paramCount * 24 : 28
+        // Account for "No parameters" message when there are no params and no return type
+        const hasNoParamsMessage = item.data.parameters.length === 0 && !item.data.returnType
+        const contentCount = paramCount === 0 && hasNoParamsMessage ? 1 : paramCount
+        return expandedRoutines.has(routineKey) ? 28 + contentCount * 24 : 28
       }
     },
     overscan: 5


### PR DESCRIPTION
## Summary

- Fixed UI bug where "No parameters" text was overlapping with the next procedure name in MSSQL schema explorer
- The issue was in the virtualized list height calculation - routines without parameters and no return type weren't accounting for the "No parameters" message height
- Added logic to include the message height (24px) when calculating expanded routine size

<img width="304" height="65" alt="image" src="https://github.com/user-attachments/assets/588f5044-720c-439c-9492-fb6f9bef93a9" />


Fixes #34

## Test plan

- [ ] Connect to MSSQL Server database
- [ ] Expand stored procedures in schema explorer
- [ ] Verify procedures without parameters properly show "No parameters" without overlapping next item
- [ ] Verify procedures with parameters still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced display accuracy in the schema explorer list with improved size calculations for items in virtualized views.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->