### PR TITLE
fix: MSSQL compatibility for LIMIT/TOP syntax and unnamed columns

### DIFF
--- a/apps/desktop/src/main/ai-service.ts
+++ b/apps/desktop/src/main/ai-service.ts
@@ -379,7 +379,7 @@ Use when user asks for data or wants to run a query.
 - Fill: message, sql, explanation
 - Optional: warning, requiresConfirmation (set true for UPDATE/DELETE/DROP/TRUNCATE)
 - Null: title, description, chartType, xKey, yKeys, label, format, tables
-- Include LIMIT 100 for SELECT queries unless specified
+- Limit results: ${dbType === 'mssql' ? 'Use SELECT TOP 100 for MSSQL' : 'Include LIMIT 100 at the end'} unless user specifies otherwise
 
 ### type: "chart"
 Use when user asks to visualize, chart, graph, or plot data.

--- a/apps/desktop/src/renderer/src/components/data-table.tsx
+++ b/apps/desktop/src/renderer/src/components/data-table.tsx
@@ -196,7 +196,11 @@ export function DataTable<TData extends Record<string, unknown>>({
   // Generate TanStack Table columns from column definitions
   const columns = React.useMemo<ColumnDef<TData>[]>(
     () =>
-      columnDefs.map((col) => {
+      columnDefs.map((col, index) => {
+        // Generate a stable id for columns - MSSQL can return empty names for aggregates like COUNT(*)
+        const columnId = col.name || `_col_${index}`
+        const displayName = col.name || `(column ${index + 1})`
+
         const lowerType = col.dataType.toLowerCase()
         const isNumeric =
           lowerType.includes('int') ||
@@ -208,6 +212,7 @@ export function DataTable<TData extends Record<string, unknown>>({
           lowerType.includes('money')
 
         return {
+          id: columnId,
           accessorKey: col.name,
           header: ({ column }) => {
             const isSorted = column.getIsSorted()
@@ -218,7 +223,7 @@ export function DataTable<TData extends Record<string, unknown>>({
                   className="h-auto py-1 px-2 -mx-2 font-medium hover:bg-accent/50"
                   onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
                 >
-                  <span>{col.name}</span>
+                  <span>{displayName}</span>
                   {col.foreignKey && <Link2 className="ml-1 size-3 text-blue-400" />}
                   <Badge
                     variant="outline"


### PR DESCRIPTION
## Summary

- Fix MSSQL queries using `LIMIT` instead of `TOP` syntax
- Fix `COUNT(*)`, `SUM()`, and other aggregate functions returning NULL values
- Fix "Columns require an id" errors in data tables for unnamed columns

## Changes

| File | Change |
|------|--------|
| `mssql-adapter.ts` | Generate fallback names (`column_1`, `column_2`) for unnamed columns and remap row data |
| `editable-data-table.tsx` | Use `TOP` for FK lookups on MSSQL, add explicit column IDs |
| `data-table.tsx` | Add explicit column IDs for unnamed columns |
| `tab-query-editor.tsx` | Handle both `TOP` and `LIMIT` when applying filters |
| `ai-service.ts` | Update AI prompt to use correct syntax per database type |

## Test plan

- [ ] Run `SELECT COUNT(*) FROM table` on MSSQL - should display the count value
- [ ] Run `SELECT SUM(col), AVG(col) FROM table` on MSSQL - should display values
- [ ] Apply filters to MSSQL queries with `TOP` clause
- [ ] Verify FK dropdowns work on MSSQL tables

Closes #52 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced MSSQL support by properly handling unnamed columns with generated fallback names.
  * Improved query limit handling for MSSQL with dynamic TOP clause syntax alongside standard LIMIT syntax for other databases.
  * Fixed column identification in data tables to display stable identifiers and readable names when column names are missing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->