### PR TITLE
feat: add configurable query timeout setting

### DIFF
--- a/apps/desktop/src/main/adapters/mssql-adapter.ts
+++ b/apps/desktop/src/main/adapters/mssql-adapter.ts
@@ -151,10 +151,9 @@ function toMSSQLConfig(config: ConnectionConfig): sql.config {
     options.connectTimeout = mssqlOptions.connectionTimeout
   }
 
-  // Add request timeout if specified
-  if (mssqlOptions.requestTimeout !== undefined) {
-    options.requestTimeout = mssqlOptions.requestTimeout
-  }
+  // Set request timeout (default to 0 = no timeout to allow long-running queries)
+  // The mssql library defaults to 15000ms which is too short for complex queries
+  options.requestTimeout = mssqlOptions.requestTimeout ?? 0
 
   // Build base config
   const sqlConfig: sql.config = {
@@ -343,6 +342,12 @@ export class MSSQLAdapter implements DatabaseAdapter {
 
         try {
           const request = pool.request()
+
+          // Set per-request timeout if specified (overrides connection-level timeout)
+          const queryTimeoutMs = options?.queryTimeoutMs
+          if (queryTimeoutMs !== undefined) {
+            request.timeout = queryTimeoutMs
+          }
 
           // Register the current request for cancellation support
           if (options?.executionId) {

--- a/apps/desktop/src/main/adapters/mssql-adapter.ts
+++ b/apps/desktop/src/main/adapters/mssql-adapter.ts
@@ -345,8 +345,16 @@ export class MSSQLAdapter implements DatabaseAdapter {
 
           // Set per-request timeout if specified (overrides connection-level timeout)
           const queryTimeoutMs = options?.queryTimeoutMs
-          if (queryTimeoutMs !== undefined) {
-            request.timeout = queryTimeoutMs
+          if (
+            queryTimeoutMs !== undefined &&
+            typeof queryTimeoutMs === 'number' &&
+            Number.isFinite(queryTimeoutMs)
+          ) {
+            // The mssql library supports request.timeout at runtime but types don't expose it
+            ;(request as unknown as { timeout: number }).timeout = Math.max(
+              0,
+              Math.floor(queryTimeoutMs)
+            )
           }
 
           // Register the current request for cancellation support

--- a/apps/desktop/src/main/adapters/mysql-adapter.ts
+++ b/apps/desktop/src/main/adapters/mysql-adapter.ts
@@ -189,6 +189,13 @@ export class MySQLAdapter implements DatabaseAdapter {
       telemetryCollector.endPhase(executionId, TELEMETRY_PHASES.DB_HANDSHAKE)
     }
 
+    // Set query timeout if specified (0 = no timeout)
+    // Note: max_execution_time only affects SELECT statements in MySQL 5.7.8+
+    const queryTimeoutMs = options?.queryTimeoutMs
+    if (queryTimeoutMs !== undefined && queryTimeoutMs > 0) {
+      await connection.query(`SET SESSION max_execution_time = ${queryTimeoutMs}`)
+    }
+
     // Register for cancellation support
     if (options?.executionId) {
       registerQuery(options.executionId, { type: 'mysql', connection })

--- a/apps/desktop/src/main/adapters/mysql-adapter.ts
+++ b/apps/desktop/src/main/adapters/mysql-adapter.ts
@@ -192,8 +192,13 @@ export class MySQLAdapter implements DatabaseAdapter {
     // Set query timeout if specified (0 = no timeout)
     // Note: max_execution_time only affects SELECT statements in MySQL 5.7.8+
     const queryTimeoutMs = options?.queryTimeoutMs
-    if (queryTimeoutMs !== undefined && queryTimeoutMs > 0) {
-      await connection.query(`SET SESSION max_execution_time = ${queryTimeoutMs}`)
+    if (
+      typeof queryTimeoutMs === 'number' &&
+      Number.isFinite(queryTimeoutMs) &&
+      queryTimeoutMs > 0
+    ) {
+      const safeTimeout = Math.floor(queryTimeoutMs)
+      await connection.query(`SET SESSION max_execution_time = ${safeTimeout}`)
     }
 
     // Register for cancellation support

--- a/apps/desktop/src/main/adapters/postgres-adapter.ts
+++ b/apps/desktop/src/main/adapters/postgres-adapter.ts
@@ -132,6 +132,12 @@ export class PostgresAdapter implements DatabaseAdapter {
       telemetryCollector.endPhase(executionId, TELEMETRY_PHASES.DB_HANDSHAKE)
     }
 
+    // Set query timeout if specified (0 = no timeout)
+    const queryTimeoutMs = options?.queryTimeoutMs
+    if (queryTimeoutMs !== undefined && queryTimeoutMs > 0) {
+      await client.query(`SET statement_timeout = ${queryTimeoutMs}`)
+    }
+
     // Register for cancellation support
     if (options?.executionId) {
       registerQuery(options.executionId, { type: 'postgresql', client })

--- a/apps/desktop/src/main/adapters/postgres-adapter.ts
+++ b/apps/desktop/src/main/adapters/postgres-adapter.ts
@@ -134,8 +134,15 @@ export class PostgresAdapter implements DatabaseAdapter {
 
     // Set query timeout if specified (0 = no timeout)
     const queryTimeoutMs = options?.queryTimeoutMs
-    if (queryTimeoutMs !== undefined && queryTimeoutMs > 0) {
-      await client.query(`SET statement_timeout = ${queryTimeoutMs}`)
+    if (
+      typeof queryTimeoutMs === 'number' &&
+      Number.isFinite(queryTimeoutMs) &&
+      queryTimeoutMs > 0
+    ) {
+      await client.query('SELECT set_config($1, $2, false)', [
+        'statement_timeout',
+        `${Math.floor(queryTimeoutMs)}ms`
+      ])
     }
 
     // Register for cancellation support

--- a/apps/desktop/src/main/db-adapter.ts
+++ b/apps/desktop/src/main/db-adapter.ts
@@ -37,6 +37,8 @@ export interface QueryOptions {
   executionId?: string
   /** Whether to collect detailed telemetry data */
   collectTelemetry?: boolean
+  /** Query timeout in milliseconds (0 = no timeout) */
+  queryTimeoutMs?: number
 }
 
 /**

--- a/apps/desktop/src/main/ipc/query-handlers.ts
+++ b/apps/desktop/src/main/ipc/query-handlers.ts
@@ -45,20 +45,25 @@ export function registerQueryHandlers(): void {
       {
         config,
         query,
-        executionId
-      }: { config: ConnectionConfig; query: string; executionId?: string }
+        executionId,
+        queryTimeoutMs
+      }: { config: ConnectionConfig; query: string; executionId?: string; queryTimeoutMs?: number }
     ) => {
       log.debug('Received query request', { ...config, password: '***' })
       log.debug('Query:', query)
       log.debug('Execution ID:', executionId)
+      log.debug('Query timeout:', queryTimeoutMs)
 
       try {
         const adapter = getAdapter(config)
         log.debug('Connecting...')
 
         // Use queryMultiple to support multiple statements
-        // Pass executionId for cancellation support
-        const multiResult = await adapter.queryMultiple(config, query, { executionId })
+        // Pass executionId for cancellation support and queryTimeoutMs for timeout
+        const multiResult = await adapter.queryMultiple(config, query, {
+          executionId,
+          queryTimeoutMs
+        })
 
         log.debug('Query completed in', multiResult.totalDurationMs, 'ms')
         log.debug('Statement count:', multiResult.results.length)
@@ -329,12 +334,14 @@ export function registerQueryHandlers(): void {
       {
         config,
         query,
-        executionId
-      }: { config: ConnectionConfig; query: string; executionId?: string }
+        executionId,
+        queryTimeoutMs
+      }: { config: ConnectionConfig; query: string; executionId?: string; queryTimeoutMs?: number }
     ) => {
       log.debug('Received query with telemetry request', { ...config, password: '***' })
       log.debug('Query:', query)
       log.debug('Execution ID:', executionId)
+      log.debug('Query timeout:', queryTimeoutMs)
 
       try {
         const adapter = getAdapter(config)
@@ -343,7 +350,8 @@ export function registerQueryHandlers(): void {
         // Use queryMultiple with telemetry enabled
         const multiResult = await adapter.queryMultiple(config, query, {
           executionId,
-          collectTelemetry: true
+          collectTelemetry: true,
+          queryTimeoutMs
         })
 
         log.debug('Query completed in', multiResult.totalDurationMs, 'ms')

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -140,7 +140,8 @@ interface DataPeekApi {
     query: (
       config: ConnectionConfig,
       query: string,
-      executionId?: string
+      executionId?: string,
+      queryTimeoutMs?: number
     ) => Promise<IpcResponse<unknown>>
     cancelQuery: (executionId: string) => Promise<IpcResponse<{ cancelled: boolean }>>
     schemas: (
@@ -160,7 +161,8 @@ interface DataPeekApi {
     queryWithTelemetry: (
       config: ConnectionConfig,
       query: string,
-      executionId?: string
+      executionId?: string,
+      queryTimeoutMs?: number
     ) => Promise<IpcResponse<MultiStatementResultWithTelemetry & { results: unknown[] }>>
     benchmark: (
       config: ConnectionConfig,

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -58,9 +58,10 @@ const api = {
     query: (
       config: ConnectionConfig,
       query: string,
-      executionId?: string
+      executionId?: string,
+      queryTimeoutMs?: number
     ): Promise<IpcResponse<unknown>> =>
-      ipcRenderer.invoke('db:query', { config, query, executionId }),
+      ipcRenderer.invoke('db:query', { config, query, executionId, queryTimeoutMs }),
     cancelQuery: (executionId: string): Promise<IpcResponse<{ cancelled: boolean }>> =>
       ipcRenderer.invoke('db:cancel-query', executionId),
     schemas: (
@@ -86,9 +87,10 @@ const api = {
     queryWithTelemetry: (
       config: ConnectionConfig,
       query: string,
-      executionId?: string
+      executionId?: string,
+      queryTimeoutMs?: number
     ): Promise<IpcResponse<MultiStatementResultWithTelemetry & { results: unknown[] }>> =>
-      ipcRenderer.invoke('db:query-with-telemetry', { config, query, executionId }),
+      ipcRenderer.invoke('db:query-with-telemetry', { config, query, executionId, queryTimeoutMs }),
     // Benchmark query with multiple runs
     benchmark: (
       config: ConnectionConfig,

--- a/apps/desktop/src/renderer/src/components/add-connection-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/add-connection-dialog.tsx
@@ -1,7 +1,16 @@
 'use client'
 
 import { useState, useEffect, useRef } from 'react'
-import { Loader2, Database, CheckCircle2, XCircle, Link, Settings2, FolderOpen } from 'lucide-react'
+import {
+  Loader2,
+  Database,
+  CheckCircle2,
+  XCircle,
+  Link,
+  Settings2,
+  FolderOpen,
+  ChevronDown
+} from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import {
@@ -14,6 +23,7 @@ import {
 } from '@/components/ui/sheet'
 import { useConnectionStore, type Connection } from '@/stores'
 import { PostgreSQLIcon, MySQLIcon, MSSQLIcon, SQLiteIcon } from './database-icons'
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
 import { SSHConfigSection } from './ssh-config-section'
 import type { SSHConfig } from '@shared/index'
 import type { DatabaseType } from '@shared/index'
@@ -289,6 +299,7 @@ export function AddConnectionDialog({
   const [mssqlOptions, setMssqlOptions] = useState<
     import('@shared/index').MSSQLConnectionOptions | undefined
   >(undefined)
+  const [mssqlAdvancedOpen, setMssqlAdvancedOpen] = useState(false)
 
   const [isTesting, setIsTesting] = useState(false)
   const [isSaving, setIsSaving] = useState(false)
@@ -893,6 +904,64 @@ export function AddConnectionDialog({
                   </label>
                 </div>
               </div>
+
+              {/* MSSQL Advanced Options */}
+              {dbType === 'mssql' && (
+                <Collapsible open={mssqlAdvancedOpen} onOpenChange={setMssqlAdvancedOpen}>
+                  <CollapsibleTrigger asChild>
+                    <button
+                      type="button"
+                      className="flex w-full items-center justify-between rounded-md border bg-muted/50 px-3 py-2 text-sm font-medium hover:bg-muted transition-colors"
+                    >
+                      <span>Advanced Options</span>
+                      <ChevronDown
+                        className={`size-4 transition-transform ${mssqlAdvancedOpen ? 'rotate-180' : ''}`}
+                      />
+                    </button>
+                  </CollapsibleTrigger>
+                  <CollapsibleContent className="pt-3 space-y-4">
+                    <div className="flex items-center gap-2">
+                      <input
+                        id="encrypt"
+                        type="checkbox"
+                        checked={mssqlOptions?.encrypt ?? false}
+                        onChange={(e) =>
+                          setMssqlOptions((prev) => ({
+                            ...prev,
+                            encrypt: e.target.checked
+                          }))
+                        }
+                        className="size-4 rounded border-input"
+                      />
+                      <label htmlFor="encrypt" className="text-sm font-medium">
+                        Encrypt Connection
+                      </label>
+                    </div>
+
+                    <div className="flex items-center gap-2">
+                      <input
+                        id="trustServerCertificate"
+                        type="checkbox"
+                        checked={mssqlOptions?.trustServerCertificate ?? true}
+                        onChange={(e) =>
+                          setMssqlOptions((prev) => ({
+                            ...prev,
+                            trustServerCertificate: e.target.checked
+                          }))
+                        }
+                        className="size-4 rounded border-input"
+                      />
+                      <label htmlFor="trustServerCertificate" className="text-sm font-medium">
+                        Trust Server Certificate
+                      </label>
+                    </div>
+
+                    <p className="text-xs text-muted-foreground">
+                      Query timeout can be configured in Settings → Database.
+                    </p>
+                  </CollapsibleContent>
+                </Collapsible>
+              )}
             </>
           )}
 

--- a/apps/desktop/src/renderer/src/components/command-palette.tsx
+++ b/apps/desktop/src/renderer/src/components/command-palette.tsx
@@ -111,7 +111,12 @@ function calculateFuzzyScore(text: string, search: string): number {
       }
 
       // Bonus for matching at word boundaries (start of word)
-      if (textIndex === 0 || text[textIndex - 1] === ' ' || text[textIndex - 1] === '-' || text[textIndex - 1] === '_') {
+      if (
+        textIndex === 0 ||
+        text[textIndex - 1] === ' ' ||
+        text[textIndex - 1] === '-' ||
+        text[textIndex - 1] === '_'
+      ) {
         score += 0.03
       }
 
@@ -131,9 +136,8 @@ function calculateFuzzyScore(text: string, search: string): number {
   const lengthBonus = Math.max(0, 0.1 - (text.length - search.length) * 0.005)
 
   // Bonus for matches being close together
-  const spread = matchPositions.length > 1
-    ? matchPositions[matchPositions.length - 1] - matchPositions[0]
-    : 0
+  const spread =
+    matchPositions.length > 1 ? matchPositions[matchPositions.length - 1] - matchPositions[0] : 0
   const compactnessBonus = Math.max(0, 0.1 - spread * 0.01)
 
   return Math.min(0.7, baseScore + consecutiveBonus + lengthBonus + compactnessBonus + score)

--- a/apps/desktop/src/renderer/src/components/settings-modal.tsx
+++ b/apps/desktop/src/renderer/src/components/settings-modal.tsx
@@ -125,7 +125,8 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
                   value={queryTimeoutMs === 0 ? '' : queryTimeoutMs / 1000}
                   placeholder="0"
                   onChange={(e) => {
-                    const seconds = e.target.value ? parseFloat(e.target.value) : 0
+                    const parsed = e.target.value ? parseFloat(e.target.value) : 0
+                    const seconds = isNaN(parsed) || parsed < 0 ? 0 : parsed
                     setQueryTimeoutMs(Math.round(seconds * 1000))
                   }}
                 />

--- a/apps/desktop/src/renderer/src/components/settings-modal.tsx
+++ b/apps/desktop/src/renderer/src/components/settings-modal.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/components/ui/dialog'
 import { Switch } from '@/components/ui/switch'
 import { Label } from '@/components/ui/label'
+import { Input } from '@/components/ui/input'
 import { useSettingsStore } from '@/stores/settings-store'
 
 interface SettingsModalProps {
@@ -23,9 +24,11 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
     hideQueryEditorByDefault,
     expandJsonByDefault,
     hideQuickQueryPanel,
+    queryTimeoutMs,
     setHideQueryEditorByDefault,
     setExpandJsonByDefault,
     setHideQuickQueryPanel,
+    setQueryTimeoutMs,
     resetSettings
   } = useSettingsStore()
 
@@ -98,6 +101,35 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
                 checked={expandJsonByDefault}
                 onCheckedChange={setExpandJsonByDefault}
               />
+            </div>
+          </div>
+
+          {/* Database Section */}
+          <div className="space-y-4">
+            <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">
+              Database
+            </h3>
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <div className="space-y-0.5">
+                  <Label htmlFor="query-timeout">Query timeout (seconds)</Label>
+                  <p className="text-xs text-muted-foreground">
+                    Maximum time to wait for a query to complete. Set to 0 for no timeout.
+                  </p>
+                </div>
+                <Input
+                  id="query-timeout"
+                  type="number"
+                  min={0}
+                  className="w-24"
+                  value={queryTimeoutMs === 0 ? '' : queryTimeoutMs / 1000}
+                  placeholder="0"
+                  onChange={(e) => {
+                    const seconds = e.target.value ? parseFloat(e.target.value) : 0
+                    setQueryTimeoutMs(Math.round(seconds * 1000))
+                  }}
+                />
+              </div>
             </div>
           </div>
         </div>

--- a/apps/desktop/src/renderer/src/components/tab-query-editor.tsx
+++ b/apps/desktop/src/renderer/src/components/tab-query-editor.tsx
@@ -86,6 +86,7 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
   const getEnumValues = useConnectionStore((s) => s.getEnumValues)
   const addToHistory = useQueryStore((s) => s.addToHistory)
   const hideQueryEditorByDefault = useSettingsStore((s) => s.hideQueryEditorByDefault)
+  const queryTimeoutMs = useSettingsStore((s) => s.queryTimeoutMs)
 
   // Telemetry state
   const {
@@ -190,8 +191,13 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
     setBenchmark(null)
 
     try {
-      // Use telemetry-enabled query API
-      const response = await window.api.db.queryWithTelemetry(tabConnection, tab.query, executionId)
+      // Use telemetry-enabled query API with timeout from settings
+      const response = await window.api.db.queryWithTelemetry(
+        tabConnection,
+        tab.query,
+        executionId,
+        queryTimeoutMs
+      )
 
       if (response.success && response.data) {
         const data = response.data as {
@@ -284,7 +290,8 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
     markTabSaved,
     addToHistory,
     setTelemetry,
-    setBenchmark
+    setBenchmark,
+    queryTimeoutMs
   ])
 
   const handleCancelQuery = useCallback(async () => {

--- a/apps/desktop/src/renderer/src/router.tsx
+++ b/apps/desktop/src/renderer/src/router.tsx
@@ -28,6 +28,7 @@ import { Notifications } from '@/components/notifications'
 import { useAIStore } from '@/stores/ai-store'
 import { Switch } from '@/components/ui/switch'
 import { Label } from '@/components/ui/label'
+import { Input } from '@/components/ui/input'
 import { useConnectionStore, useLicenseStore, useSettingsStore, useTabStore } from '@/stores'
 import { cn, keys } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
@@ -396,7 +397,9 @@ function SettingsPage() {
     setHideQueryEditorByDefault,
     setExpandJsonByDefault,
     hideQuickQueryPanel,
-    setHideQuickQueryPanel
+    setHideQuickQueryPanel,
+    queryTimeoutMs,
+    setQueryTimeoutMs
   } = useSettingsStore()
 
   return (
@@ -615,6 +618,32 @@ function SettingsPage() {
               id="expand-json"
               checked={expandJsonByDefault}
               onCheckedChange={setExpandJsonByDefault}
+            />
+          </div>
+        </div>
+
+        {/* Database */}
+        <div className="rounded-lg border border-border/50 bg-card p-4">
+          <h2 className="text-lg font-medium mb-2">Database</h2>
+          <p className="text-sm text-muted-foreground mb-4">Configure database query behavior.</p>
+          <div className="flex items-center justify-between">
+            <div className="space-y-0.5">
+              <Label htmlFor="query-timeout">Query timeout (seconds)</Label>
+              <p className="text-xs text-muted-foreground">
+                Maximum time to wait for a query to complete. Set to 0 for no timeout.
+              </p>
+            </div>
+            <Input
+              id="query-timeout"
+              type="number"
+              min={0}
+              className="w-24"
+              value={queryTimeoutMs === 0 ? '' : queryTimeoutMs / 1000}
+              placeholder="0"
+              onChange={(e) => {
+                const seconds = e.target.value ? parseFloat(e.target.value) : 0
+                setQueryTimeoutMs(Math.round(seconds * 1000))
+              }}
             />
           </div>
         </div>

--- a/apps/desktop/src/renderer/src/stores/settings-store.ts
+++ b/apps/desktop/src/renderer/src/stores/settings-store.ts
@@ -8,6 +8,9 @@ export interface AppSettings {
   expandJsonByDefault: boolean
   hideQuickQueryPanel: boolean
   jsonExpandDepth: number
+  // Database settings
+  /** Query timeout in milliseconds (0 = no timeout) */
+  queryTimeoutMs: number
 }
 
 interface SettingsState extends AppSettings {
@@ -15,6 +18,7 @@ interface SettingsState extends AppSettings {
   setHideQueryEditorByDefault: (value: boolean) => void
   setExpandJsonByDefault: (value: boolean) => void
   setJsonExpandDepth: (depth: number) => void
+  setQueryTimeoutMs: (value: number) => void
   resetSettings: () => void
   setHideQuickQueryPanel: (value: boolean) => void
 }
@@ -23,7 +27,8 @@ const defaultSettings: AppSettings = {
   hideQueryEditorByDefault: false,
   expandJsonByDefault: false,
   jsonExpandDepth: 2,
-  hideQuickQueryPanel: true
+  hideQuickQueryPanel: true,
+  queryTimeoutMs: 0 // 0 = no timeout
 }
 
 export const useSettingsStore = create<SettingsState>()(
@@ -33,6 +38,7 @@ export const useSettingsStore = create<SettingsState>()(
       setHideQueryEditorByDefault: (value) => set({ hideQueryEditorByDefault: value }),
       setExpandJsonByDefault: (value) => set({ expandJsonByDefault: value }),
       setJsonExpandDepth: (depth) => set({ jsonExpandDepth: depth }),
+      setQueryTimeoutMs: (value) => set({ queryTimeoutMs: value }),
       setHideQuickQueryPanel: (value) => set({ hideQuickQueryPanel: value }),
       resetSettings: () => set(defaultSettings)
     }),


### PR DESCRIPTION
## Summary
- Add global query timeout setting in **Settings → Database**
- Applies to all database types: PostgreSQL, MySQL, MSSQL
- Default: 0 (no timeout) to allow long-running queries

## Changes
- PostgreSQL: uses `SET statement_timeout`
- MySQL: uses `SET SESSION max_execution_time`
- MSSQL: uses per-request timeout on request object
- Removed per-connection timeout from MSSQL advanced options (now global)

## Test plan
- [ ] Open Settings page and verify Database section appears
- [ ] Set a timeout value (e.g., 5 seconds) and run a long query
- [ ] Verify query times out with appropriate error
- [ ] Set timeout to 0 and verify long queries complete without timeout
- [ ] Test with PostgreSQL, MySQL, and MSSQL connections

Closes #58

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a global "Query timeout" setting (seconds) in Database settings.
  * Added MSSQL Advanced Options section in the Add Connection dialog (encrypt & trust toggles).
  * Implemented per-query timeout support for MSSQL, MySQL, and PostgreSQL; timeout can be passed with query calls and is honored per-request.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->