### PR TITLE
fix: SSH tunnel connection timeout when using jump servers

### DIFF
--- a/apps/desktop/src/main/ssh-tunnel-service.ts
+++ b/apps/desktop/src/main/ssh-tunnel-service.ts
@@ -13,6 +13,10 @@ export async function createTunnel(config: ConnectionConfig): Promise<TunnelSess
   if (!sshConfig) {
     throw new Error('SSH config is missing for SSH-enabled connection')
   }
+
+  const dstHost = config.host
+  const dstPort = config.dstPort || config.port
+
   let privateKey: string | undefined
   if (sshConfig.authMethod === 'Public Key') {
     try {
@@ -28,24 +32,22 @@ export async function createTunnel(config: ConnectionConfig): Promise<TunnelSess
     try {
       ssh = new SSHClient()
       ssh.once('ready', () => {
-        console.log('SSH connected, starting TCP proxy...')
-
         server = net.createServer((socket) => {
-          ssh!.forwardOut('127.0.0.1', 0, '127.0.0.1', config.dstPort, (err, stream) => {
+          ssh!.forwardOut('127.0.0.1', 0, dstHost, dstPort, (err, stream) => {
             if (err) {
-              console.error('Forward error:', err)
+              console.error('SSH tunnel forward error:', err)
               socket.destroy()
               return
             }
 
             stream.on('error', (err: Error) => {
-              console.error('Stream error:', err)
+              console.error('SSH tunnel stream error:', err)
               stream.end()
               socket.destroy()
             })
 
             socket.on('error', (err) => {
-              console.error('Socket error:', err)
+              console.error('SSH tunnel socket error:', err)
               stream.destroy()
               socket.destroy()
             })
@@ -54,27 +56,27 @@ export async function createTunnel(config: ConnectionConfig): Promise<TunnelSess
         })
 
         server.on('error', (error) => {
-          console.error('Server error', error)
+          console.error('SSH tunnel server error:', error)
           closeTunnel({ ssh, server })
           reject(error)
         })
 
         server.listen(0, '127.0.0.1', () => {
           const proxyPort = (server!.address() as net.AddressInfo).port
+          config.host = '127.0.0.1'
           config.port = proxyPort
-          console.log(`Tunnel: localhost:${proxyPort} → ${sshConfig.host}:${config.dstPort}`)
+          console.log(`SSH tunnel ready: localhost:${proxyPort} → ${dstHost}:${dstPort}`)
           resolve({ ssh, server })
         })
       })
 
       ssh.once('error', (error) => {
-        console.error('SSH error', error)
+        console.error('SSH connection error:', error)
         closeTunnel({ ssh, server })
         reject(error)
       })
 
       ssh.on('close', () => {
-        console.log('SSH closed')
         closeTunnel({ ssh, server })
       })
 
@@ -88,7 +90,7 @@ export async function createTunnel(config: ConnectionConfig): Promise<TunnelSess
         readyTimeout: 60000
       })
     } catch (err) {
-      console.error('Something went wrong while creating a tunnel', err)
+      console.error('Failed to create SSH tunnel:', err)
       closeTunnel({ ssh, server })
       reject(err)
     }
@@ -99,7 +101,6 @@ export function closeTunnel(tunnelSession: TunnelSession | null) {
   if (!tunnelSession) return
   closeServer(tunnelSession.server)
   closeSSHSession(tunnelSession.ssh)
-  console.log('SSH tunnel closed')
 }
 
 function closeSSHSession(ssh: SSHClient | null) {
@@ -112,7 +113,7 @@ function closeServer(server: net.Server | null) {
   if (server) {
     server.close((err) => {
       if (err) {
-        console.error('Error closing TCP server:', err)
+        console.error('Error closing SSH tunnel server:', err)
       }
     })
   }


### PR DESCRIPTION
## Summary
- Fixed SSH tunnel using hardcoded `127.0.0.1` instead of the actual database host in `forwardOut`
- Now properly forwards traffic to the configured database host through the SSH jump server
- Updated `config.host` to point to the local tunnel endpoint so database clients connect correctly

## Root Cause
The `forwardOut` call in `ssh-tunnel-service.ts` was hardcoding `'127.0.0.1'` as the destination host instead of using the actual database host from the config. This meant traffic was being forwarded to localhost on the SSH server rather than to the remote database server.

<img width="604" height="1170" alt="image" src="https://github.com/user-attachments/assets/12c6484c-8e9b-404c-8610-dd6834242e90" />


## Test plan
- [x] Test SSH tunnel connection with database on same machine as SSH server (127.0.0.1)
- [x] Test SSH tunnel connection with database on different machine (jump server scenario)
- [x] Verify connection timeout no longer occurs

Closes #77

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected tunnel forwarding to use the actual destination host and port instead of defaulting to localhost.
  * Dynamically allocate proxy ports and update connection settings when the server starts.
  * Improved and clarified tunnel-related logging; reduced noisy/informational messages and renamed error logs for specificity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->