### PR TITLE
fix: quote table names in quick select (PascalCase-safe)

### DIFF
--- a/apps/desktop/src/renderer/src/components/schema-explorer.tsx
+++ b/apps/desktop/src/renderer/src/components/schema-explorer.tsx
@@ -57,6 +57,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { useConnectionStore, useTabStore, notify } from '@/stores'
 import type { TableInfo, RoutineInfo, QueryResult as IpcQueryResult } from '@shared/index'
 import { downloadCSV, downloadJSON, downloadSQL, generateExportFilename } from '@/lib/export'
+import { buildFullyQualifiedTableRef } from '@/lib/sql-helpers'
 
 // Threshold for enabling virtualization
 const VIRTUALIZATION_THRESHOLD = 50
@@ -634,13 +635,7 @@ export function SchemaExplorer() {
 
     try {
       // Query all data from the table
-      const qualifiedName =
-        connection.dbType === 'mssql'
-          ? `[${schemaName}].[${tableName}]`
-          : connection.dbType === 'mysql'
-            ? `\`${schemaName}\`.\`${tableName}\``
-            : `"${schemaName}"."${tableName}"`
-
+      const qualifiedName = buildFullyQualifiedTableRef(schemaName, tableName, connection.dbType)
       const result = await window.api.db.query(connection, `SELECT * FROM ${qualifiedName}`)
 
       if (!result.success || !result.data) {

--- a/apps/desktop/src/renderer/src/stores/query-store.ts
+++ b/apps/desktop/src/renderer/src/stores/query-store.ts
@@ -1,4 +1,4 @@
-import { buildSelectQuery } from '@/lib/sql-helpers'
+import { buildQualifiedTableRef, buildSelectQuery } from '@/lib/sql-helpers'
 import { resolvePostgresType, type QueryResult as IpcQueryResult } from '@data-peek/shared'
 import { create } from 'zustand'
 import type { Connection, Table } from './connection-store'
@@ -79,10 +79,8 @@ export const useQueryStore = create<QueryState>((set, get) => ({
   setError: (error) => set({ error, result: null }),
 
   loadTableData: (schemaName, table, connection) => {
-    // Build table reference (handle MSSQL's dbo schema)
-    const defaultSchema = connection.dbType === 'mssql' ? 'dbo' : 'public'
-    const tableRef = schemaName === defaultSchema ? table.name : `${schemaName}.${table.name}`
-    const query = buildSelectQuery(tableRef, connection.dbType, { limit: 100 })
+    const sqlTableRef = buildQualifiedTableRef(schemaName, table.name, connection.dbType)
+    const query = buildSelectQuery(sqlTableRef, connection.dbType, { limit: 100 })
 
     set({ currentQuery: query })
 


### PR DESCRIPTION
### Summary
- Quote table/schema identifiers when generating table preview SQL (sidebar quick select), so PostgreSQL PascalCase tables (e.g. Prisma) work correctly.
- Centralizes db-specific identifier quoting for Postgres/SQLite ("name"), MySQL (`name`), and MSSQL ([name]).

### Why
PostgreSQL folds unquoted identifiers to lowercase, so SELECT * FROM TableName fails when the actual table is "TableName".

Fixes #8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated database-specific table reference construction logic across the application, replacing manual handling with centralized helper functions that support MySQL, MSSQL, PostgreSQL, and SQLite. This improves code maintainability while preserving existing functionality and behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->