### PR TITLE
fix: Add SSL certificate verification options for cloud databases

### DIFF
--- a/apps/desktop/src/main/adapters/mysql-adapter.ts
+++ b/apps/desktop/src/main/adapters/mysql-adapter.ts
@@ -100,13 +100,16 @@ function toMySQLConfig(config: ConnectionConfig): mysql.ConnectionOptions {
           rejectUnauthorized: true,
           ca: readFileSync(sslOptions.ca, 'utf-8')
         }
-      } catch {
-        mysqlConfig.ssl = {
-          rejectUnauthorized: true
-        }
+      } catch (err) {
+        console.error(`Failed to read CA certificate from ${sslOptions.ca}:`, err)
+        throw new Error(
+          `Failed to read CA certificate file: ${sslOptions.ca}. Please verify the file exists and is readable.`
+        )
       }
     } else {
-      mysqlConfig.ssl = {}
+      mysqlConfig.ssl = {
+        rejectUnauthorized: true
+      }
     }
   }
 

--- a/apps/desktop/src/main/adapters/postgres-adapter.ts
+++ b/apps/desktop/src/main/adapters/postgres-adapter.ts
@@ -59,10 +59,11 @@ function buildClientConfig(config: ConnectionConfig): ClientConfig {
           rejectUnauthorized: true,
           ca: readFileSync(sslOptions.ca, 'utf-8')
         }
-      } catch {
-        clientConfig.ssl = {
-          rejectUnauthorized: true
-        }
+      } catch (err) {
+        console.error(`Failed to read CA certificate from ${sslOptions.ca}:`, err)
+        throw new Error(
+          `Failed to read CA certificate file: ${sslOptions.ca}. Please verify the file exists and is readable.`
+        )
       }
     } else {
       clientConfig.ssl = true

--- a/apps/desktop/src/renderer/src/components/add-connection-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/add-connection-dialog.tsx
@@ -26,7 +26,7 @@ import { DB_DEFAULTS, parseConnectionString } from '@/lib/connection-string-pars
 import { PostgreSQLIcon, MySQLIcon, MSSQLIcon, SQLiteIcon } from './database-icons'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
 import { SSHConfigSection } from './ssh-config-section'
-import type { SSHConfig } from '@shared/index'
+import type { SSHConfig, SSLConnectionOptions } from '@shared/index'
 import type { DatabaseType } from '@shared/index'
 
 interface AddConnectionDialogProps {
@@ -77,6 +77,10 @@ export function AddConnectionDialog({
     passphrase: ''
   })
 
+  const [sslOptions, setSslOptions] = useState<SSLConnectionOptions>({
+    rejectUnauthorized: true
+  })
+
   const [mssqlOptions, setMssqlOptions] = useState<
     import('@shared/index').MSSQLConnectionOptions | undefined
   >(undefined)
@@ -99,6 +103,7 @@ export function AddConnectionDialog({
       setUser(editConnection.user || '')
       setPassword(editConnection.password || '')
       setSsl(editConnection.ssl || false)
+      setSslOptions(editConnection.sslOptions || { rejectUnauthorized: true })
       setSsh(editConnection.ssh || false)
       setMssqlOptions(editConnection.mssqlOptions)
 
@@ -212,6 +217,7 @@ export function AddConnectionDialog({
     setUser('postgres')
     setPassword('')
     setSsl(false)
+    setSslOptions({ rejectUnauthorized: true })
     setSsh(false)
     setSshConfig({
       host: '',
@@ -262,6 +268,7 @@ export function AddConnectionDialog({
       ssh,
       dstPort: parseInt(port, 10) || 0,
       sshConfig: sshConfigForConnection,
+      ...(ssl && { sslOptions }),
       ...(dbType === 'mssql' && mssqlOptions && { mssqlOptions })
     }
   }
@@ -671,31 +678,59 @@ export function AddConnectionDialog({
                 </div>
               </div>
 
-              <div className="flex space-x-4">
-                <div className="flex items-center gap-2">
-                  <input
-                    id="ssl"
-                    type="checkbox"
-                    checked={ssl}
-                    onChange={(e) => setSsl(e.target.checked)}
-                    className="size-4 rounded border-input"
-                  />
-                  <label htmlFor="ssl" className="text-sm font-medium">
-                    Use SSL
-                  </label>
+              <div className="flex flex-col gap-3">
+                <div className="flex space-x-4">
+                  <div className="flex items-center gap-2">
+                    <input
+                      id="ssl"
+                      type="checkbox"
+                      checked={ssl}
+                      onChange={(e) => setSsl(e.target.checked)}
+                      className="size-4 rounded border-input"
+                    />
+                    <label htmlFor="ssl" className="text-sm font-medium">
+                      Use SSL
+                    </label>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <input
+                      id="ssh"
+                      type="checkbox"
+                      checked={ssh}
+                      onChange={() => setSsh(!ssh)}
+                      className="size-4 rounded border-input"
+                    />
+                    <label htmlFor="ssh" className="text-sm font-medium">
+                      Use SSH
+                    </label>
+                  </div>
                 </div>
-                <div className="flex items-center gap-2">
-                  <input
-                    id="ssh"
-                    type="checkbox"
-                    checked={ssh}
-                    onChange={() => setSsh(!ssh)}
-                    className="size-4 rounded border-input"
-                  />
-                  <label htmlFor="ssh" className="text-sm font-medium">
-                    Use SSH
-                  </label>
-                </div>
+
+                {ssl && dbType !== 'mssql' && (
+                  <div className="ml-6 flex flex-col gap-2 rounded-md border bg-muted/30 p-3">
+                    <div className="flex items-center gap-2">
+                      <input
+                        id="sslRejectUnauthorized"
+                        type="checkbox"
+                        checked={sslOptions.rejectUnauthorized !== false}
+                        onChange={(e) =>
+                          setSslOptions((prev) => ({
+                            ...prev,
+                            rejectUnauthorized: e.target.checked
+                          }))
+                        }
+                        className="size-4 rounded border-input"
+                      />
+                      <label htmlFor="sslRejectUnauthorized" className="text-sm font-medium">
+                        Verify server certificate
+                      </label>
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      Disable this for AWS RDS, Azure, or other cloud databases where certificate
+                      verification fails. Required when connecting through VPN.
+                    </p>
+                  </div>
+                )}
               </div>
 
               {/* MSSQL Advanced Options */}

--- a/apps/desktop/src/renderer/src/components/add-connection-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/add-connection-dialog.tsx
@@ -707,28 +707,52 @@ export function AddConnectionDialog({
                 </div>
 
                 {ssl && dbType !== 'mssql' && (
-                  <div className="ml-6 flex flex-col gap-2 rounded-md border bg-muted/30 p-3">
-                    <div className="flex items-center gap-2">
-                      <input
-                        id="sslRejectUnauthorized"
-                        type="checkbox"
-                        checked={sslOptions.rejectUnauthorized !== false}
+                  <div className="ml-6 flex flex-col gap-3 rounded-md border bg-muted/30 p-3">
+                    <div>
+                      <div className="flex items-center gap-2">
+                        <input
+                          id="sslRejectUnauthorized"
+                          type="checkbox"
+                          checked={sslOptions.rejectUnauthorized !== false}
+                          onChange={(e) =>
+                            setSslOptions((prev) => ({
+                              ...prev,
+                              rejectUnauthorized: e.target.checked
+                            }))
+                          }
+                          className="size-4 rounded border-input"
+                        />
+                        <label htmlFor="sslRejectUnauthorized" className="text-sm font-medium">
+                          Verify server certificate
+                        </label>
+                      </div>
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        Disable this for AWS RDS, Azure, or other cloud databases where certificate
+                        verification fails.
+                      </p>
+                    </div>
+
+                    <div>
+                      <label htmlFor="sslCaPath" className="text-sm font-medium">
+                        CA Certificate Path (optional)
+                      </label>
+                      <Input
+                        id="sslCaPath"
+                        type="text"
+                        value={sslOptions.ca || ''}
                         onChange={(e) =>
                           setSslOptions((prev) => ({
                             ...prev,
-                            rejectUnauthorized: e.target.checked
+                            ca: e.target.value || undefined
                           }))
                         }
-                        className="size-4 rounded border-input"
+                        placeholder="/path/to/ca-certificate.pem"
+                        className="mt-1"
                       />
-                      <label htmlFor="sslRejectUnauthorized" className="text-sm font-medium">
-                        Verify server certificate
-                      </label>
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        Path to a CA certificate file for servers with private CA certificates.
+                      </p>
                     </div>
-                    <p className="text-xs text-muted-foreground">
-                      Disable this for AWS RDS, Azure, or other cloud databases where certificate
-                      verification fails. Required when connecting through VPN.
-                    </p>
                   </div>
                 )}
               </div>

--- a/apps/desktop/src/renderer/src/stores/connection-store.ts
+++ b/apps/desktop/src/renderer/src/stores/connection-store.ts
@@ -8,7 +8,8 @@ import {
   CustomTypeInfo,
   MSSQLConnectionOptions,
   SSHConfig,
-  SQLiteConnectionOptions
+  SQLiteConnectionOptions,
+  SSLConnectionOptions
 } from '@shared/index'
 import { notify } from './notification-store'
 
@@ -36,6 +37,7 @@ export interface Connection {
   sshConfig?: SSHConfig
   group?: string
   dbType: DatabaseType
+  sslOptions?: SSLConnectionOptions
   mssqlOptions?: MSSQLConnectionOptions
   sqliteOptions?: SQLiteConnectionOptions
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -389,6 +389,25 @@ export interface SQLiteConnectionOptions {
 }
 
 /**
+ * SSL/TLS connection options for PostgreSQL and MySQL
+ * Allows configuration of certificate verification behavior
+ */
+export interface SSLConnectionOptions {
+  /**
+   * If true, the server certificate is verified against the list of supplied CAs.
+   * Set to false to allow connections to servers with self-signed certificates
+   * or when connecting through VPN to cloud databases (like AWS RDS).
+   * Default: true
+   */
+  rejectUnauthorized?: boolean;
+  /**
+   * Optional path to CA certificate file (PEM format)
+   * Use this when connecting to a server with a certificate signed by a private CA
+   */
+  ca?: string;
+}
+
+/**
  * MSSQL-specific connection options
  */
 export interface MSSQLConnectionOptions {
@@ -423,6 +442,8 @@ export interface ConnectionConfig {
   dbType: DatabaseType;
   dstPort: number;
   sshConfig?: SSHConfig;
+  /** SSL/TLS options for PostgreSQL and MySQL (only used when ssl is true) */
+  sslOptions?: SSLConnectionOptions;
   /** MSSQL-specific connection options (only used when dbType is 'mssql') */
   mssqlOptions?: MSSQLConnectionOptions;
   /** SQLite-specific connection options (only used when dbType is 'sqlite') */


### PR DESCRIPTION
## Summary

Add support for disabling SSL certificate verification when connecting to cloud databases like AWS RDS that use certificates not in the system trust store. Users can now configure SSL options per connection.

## Changes

- Add SSLConnectionOptions interface with `rejectUnauthorized` and `ca` options
- Update PostgresAdapter and MySQLAdapter to properly handle SSL configuration
- Add UI toggle in connection dialog to enable/disable server certificate verification
- Include helpful tooltip explaining when to disable verification (AWS RDS, Azure, VPN connections)

## Related Issues

Fixes #94

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] Code passes typecheck and linter
- [x] Changes work with PostgreSQL and MySQL adapters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SSL/TLS support for MySQL and PostgreSQL connections.
  * Added options to toggle certificate verification and specify a CA certificate file.
  * UI now shows SSL settings when enabling SSL for a connection (except unsupported DB types).
  * Connection records now persist SSL options so settings are retained across sessions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->