### PR TITLE
Fix: sync query tab connection when active connection changes

### DIFF
--- a/apps/desktop/src/renderer/src/components/edit-toolbar.tsx
+++ b/apps/desktop/src/renderer/src/components/edit-toolbar.tsx
@@ -286,7 +286,9 @@ export function EditToolbar({
                 </Button>
               </TooltipTrigger>
               <TooltipContent side="bottom">
-                <p className="text-xs">Discard all pending changes ({keys.mod}+{keys.shift}+Z)</p>
+                <p className="text-xs">
+                  Discard all pending changes ({keys.mod}+{keys.shift}+Z)
+                </p>
               </TooltipContent>
             </Tooltip>
 

--- a/apps/desktop/src/renderer/src/router.tsx
+++ b/apps/desktop/src/renderer/src/router.tsx
@@ -90,6 +90,10 @@ function LayoutContent() {
   // Tab store for opening SQL in new tab
   const createQueryTab = useTabStore((s) => s.createQueryTab)
   const setActiveTab = useTabStore((s) => s.setActiveTab)
+  const syncActiveTabWithConnection = useTabStore((s) => s.syncActiveTabWithConnection)
+
+  // Track active connection ID for sync effect
+  const activeConnectionId = useConnectionStore((s) => s.activeConnectionId)
 
   const platform = window.electron.process.platform
 
@@ -114,6 +118,13 @@ function LayoutContent() {
     })
     return cleanup
   }, [])
+
+  // Sync active query tab's connection when the active connection changes
+  useEffect(() => {
+    if (activeConnectionId) {
+      syncActiveTabWithConnection(activeConnectionId)
+    }
+  }, [activeConnectionId, syncActiveTabWithConnection])
 
   // Handle connection switching (used by keyboard shortcuts)
   const handleSelectConnection = useCallback(

--- a/apps/desktop/src/renderer/src/stores/tab-store.ts
+++ b/apps/desktop/src/renderer/src/stores/tab-store.ts
@@ -148,6 +148,10 @@ interface TabState {
   // Tab title
   renameTab: (tabId: string, title: string) => void
 
+  // Connection sync
+  updateTabConnectionId: (tabId: string, connectionId: string | null) => void
+  syncActiveTabWithConnection: (connectionId: string | null) => void
+
   // Computed helpers
   getTab: (tabId: string) => Tab | undefined
   getActiveTab: () => Tab | undefined
@@ -624,6 +628,26 @@ export const useTabStore = create<TabState>()(
       renameTab: (tabId, title) => {
         set((state) => ({
           tabs: state.tabs.map((t) => (t.id === tabId ? { ...t, title } : t))
+        }))
+      },
+
+      updateTabConnectionId: (tabId, connectionId) => {
+        set((state) => ({
+          tabs: state.tabs.map((t) => (t.id === tabId ? { ...t, connectionId } : t))
+        }))
+      },
+
+      syncActiveTabWithConnection: (connectionId) => {
+        const activeTab = get().getActiveTab()
+        if (!activeTab) return
+
+        // Only sync query tabs (not table-preview, erd, or table-designer)
+        // Table previews are tied to specific tables in specific databases
+        // ERD and table designer are also database-specific
+        if (activeTab.type !== 'query') return
+
+        set((state) => ({
+          tabs: state.tabs.map((t) => (t.id === activeTab.id ? { ...t, connectionId } : t))
         }))
       },
 

--- a/apps/desktop/src/renderer/src/stores/tab-store.ts
+++ b/apps/desktop/src/renderer/src/stores/tab-store.ts
@@ -149,7 +149,6 @@ interface TabState {
   renameTab: (tabId: string, title: string) => void
 
   // Connection sync
-  updateTabConnectionId: (tabId: string, connectionId: string | null) => void
   syncActiveTabWithConnection: (connectionId: string | null) => void
 
   // Computed helpers
@@ -628,12 +627,6 @@ export const useTabStore = create<TabState>()(
       renameTab: (tabId, title) => {
         set((state) => ({
           tabs: state.tabs.map((t) => (t.id === tabId ? { ...t, title } : t))
-        }))
-      },
-
-      updateTabConnectionId: (tabId, connectionId) => {
-        set((state) => ({
-          tabs: state.tabs.map((t) => (t.id === tabId ? { ...t, connectionId } : t))
         }))
       },
 


### PR DESCRIPTION
## Summary

When switching database connections, query tabs now automatically update their connection reference to execute against the newly selected connection instead of the previously stored one.

## Changes

- Added `syncActiveTabWithConnection()` action to tab store to update active query tab's connection
- Added `updateTabConnectionId()` action for direct connection ID updates on tabs
- Added effect in router to sync active query tab when connection changes
- Query tabs now refresh their execution context when connection is switched
- Table preview, ERD, and table designer tabs remain bound to original connection (as they're tied to specific database objects)

## Related Issues

Fixes #93

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have tested my changes (TypeScript check, linting)
- [ ] I have updated documentation if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Active SQL query tabs now automatically synchronize with the currently selected database connection, keeping your active tab aligned when switching connections.

* **Style**
  * Improved tooltip formatting for the Discard button to enhance readability and presentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->