### PR TITLE
fix(ai): display SQL query even when explanation is missing

### DIFF
--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -93,7 +93,7 @@ interface AIChatResponse {
 interface StoredQueryData {
   type: 'query'
   sql: string
-  explanation: string
+  explanation?: string
   warning?: string
 }
 

--- a/apps/desktop/src/renderer/src/components/ai/ai-chat-panel.tsx
+++ b/apps/desktop/src/renderer/src/components/ai/ai-chat-panel.tsx
@@ -57,7 +57,7 @@ export type AIResponseType = 'message' | 'query' | 'chart' | 'metric' | 'schema'
 export interface AIQueryData {
   type: 'query'
   sql: string
-  explanation: string
+  explanation?: string
   warning?: string
   /** If true, query should NOT be auto-executed (UPDATE/DELETE operations) */
   requiresConfirmation?: boolean
@@ -267,11 +267,11 @@ export function AIChatPanel({
         // Extract response data based on type
         // Note: Backend uses flat schema with nullable fields for AI provider compatibility
         let responseData: AIResponseData = null
-        if (data.type === 'query' && data.sql && data.explanation) {
+        if (data.type === 'query' && data.sql) {
           responseData = {
             type: 'query',
             sql: data.sql,
-            explanation: data.explanation,
+            explanation: data.explanation ?? undefined,
             warning: data.warning ?? undefined,
             requiresConfirmation: data.requiresConfirmation ?? undefined
           }


### PR DESCRIPTION
## Summary
- Fixed bug where AI-generated SQL queries were not displayed when the explanation field was missing
- Made `explanation` field optional in both `AIQueryData` and `StoredQueryData` interfaces
- Updated the response condition to only require `sql` field, not `explanation`

## Root Cause
The backend Zod schema uses `.nullish()` for explanation, but the frontend required it to be truthy. When AI returned a query without explanation, the SQL preview silently disappeared.

## Changes
- `src/preload/index.d.ts`: Made `explanation` optional in `StoredQueryData`
- `src/renderer/src/components/ai/ai-chat-panel.tsx`: Made `explanation` optional in `AIQueryData` and removed the `&& data.explanation` check

## Test Plan
- [ ] Ask AI to generate an INSERT query and verify SQL preview appears
- [ ] Verify existing queries with explanations still work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * AI chat panel now handles queries without explanations, improving robustness and preventing errors when explanations are unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->