### PR TITLE
fix: respect connection overhead toggle in benchmark stats

### DIFF
--- a/apps/desktop/src/main/telemetry-collector.ts
+++ b/apps/desktop/src/main/telemetry-collector.ts
@@ -1,9 +1,11 @@
-import type {
-  QueryTelemetry,
-  TimingPhase,
-  BenchmarkResult,
-  TelemetryStats,
-  PhaseStats
+import {
+  calcPercentile,
+  calcStdDev,
+  type QueryTelemetry,
+  type TimingPhase,
+  type BenchmarkResult,
+  type TelemetryStats,
+  type PhaseStats
 } from '@shared/index'
 import { performance } from 'perf_hooks'
 
@@ -151,25 +153,6 @@ class TelemetryCollector {
   }
 
   /**
-   * Calculate percentile from a sorted array
-   */
-  private percentile(sorted: number[], p: number): number {
-    if (sorted.length === 0) return 0
-    if (sorted.length === 1) return sorted[0]
-    const idx = Math.ceil((p / 100) * sorted.length) - 1
-    return sorted[Math.max(0, Math.min(idx, sorted.length - 1))]
-  }
-
-  /**
-   * Calculate standard deviation
-   */
-  private stdDev(values: number[], mean: number): number {
-    if (values.length === 0) return 0
-    const variance = values.reduce((acc, val) => acc + Math.pow(val - mean, 2), 0) / values.length
-    return Math.sqrt(variance)
-  }
-
-  /**
    * Aggregate multiple telemetry runs into benchmark results
    */
   aggregateBenchmark(runs: QueryTelemetry[]): BenchmarkResult {
@@ -186,10 +169,10 @@ class TelemetryCollector {
       avg,
       min: durations[0],
       max: durations[durations.length - 1],
-      p90: this.percentile(durations, 90),
-      p95: this.percentile(durations, 95),
-      p99: this.percentile(durations, 99),
-      stdDev: this.stdDev(durations, avg)
+      p90: calcPercentile(durations, 90),
+      p95: calcPercentile(durations, 95),
+      p99: calcPercentile(durations, 99),
+      stdDev: calcStdDev(durations, avg)
     }
 
     // Calculate per-phase statistics
@@ -206,9 +189,9 @@ class TelemetryCollector {
         const phaseAvg = phaseDurations.reduce((a, b) => a + b, 0) / phaseDurations.length
         phaseStats[name] = {
           avg: phaseAvg,
-          p90: this.percentile(phaseDurations, 90),
-          p95: this.percentile(phaseDurations, 95),
-          p99: this.percentile(phaseDurations, 99)
+          p90: calcPercentile(phaseDurations, 90),
+          p95: calcPercentile(phaseDurations, 95),
+          p99: calcPercentile(phaseDurations, 99)
         }
       }
     }

--- a/apps/desktop/src/renderer/src/components/telemetry-panel.tsx
+++ b/apps/desktop/src/renderer/src/components/telemetry-panel.tsx
@@ -332,13 +332,24 @@ export function TelemetryPanel({
     return 0
   }
 
+  const getConnectionOverheadMs = (): number => {
+    if (showConnectionOverhead) return 0
+    return phases
+      .filter((p) => PHASE_CONFIG[p.name]?.isConnectionPhase)
+      .reduce((sum, p) => sum + p.durationMs, 0)
+  }
+
+  const connectionOverheadMs = getConnectionOverheadMs()
+
   const getPhaseForTimeline = (phase: TimingPhase): { start: number; duration: number } => {
+    const adjustedStart = Math.max(0, phase.startOffset - connectionOverheadMs)
+
     // For benchmark mode, we don't have per-run startOffset, so estimate based on phase order
     if (benchmark) {
       const duration = benchmark.phaseStats[phase.name]?.[selectedPercentile] ?? phase.durationMs
-      return { start: phase.startOffset, duration }
+      return { start: adjustedStart, duration }
     }
-    return { start: phase.startOffset, duration: phase.durationMs }
+    return { start: adjustedStart, duration: phase.durationMs }
   }
 
   const totalDuration = getTotalDuration()

--- a/apps/desktop/src/renderer/src/components/telemetry-panel.tsx
+++ b/apps/desktop/src/renderer/src/components/telemetry-panel.tsx
@@ -1,5 +1,11 @@
 import { cn } from '@/lib/utils'
-import type { QueryTelemetry, BenchmarkResult, TimingPhase } from '@data-peek/shared'
+import {
+  calcPercentile,
+  calcStdDev,
+  type QueryTelemetry,
+  type BenchmarkResult,
+  type TimingPhase
+} from '@data-peek/shared'
 import {
   X,
   Activity,
@@ -124,25 +130,6 @@ function formatDuration(ms: number): string {
 }
 
 /**
- * Calculate percentile from a sorted array
- */
-function percentile(sorted: number[], p: number): number {
-  if (sorted.length === 0) return 0
-  if (sorted.length === 1) return sorted[0]
-  const idx = Math.ceil((p / 100) * sorted.length) - 1
-  return sorted[Math.max(0, Math.min(idx, sorted.length - 1))]
-}
-
-/**
- * Calculate standard deviation
- */
-function stdDev(values: number[], mean: number): number {
-  if (values.length === 0) return 0
-  const variance = values.reduce((acc, val) => acc + Math.pow(val - mean, 2), 0) / values.length
-  return Math.sqrt(variance)
-}
-
-/**
  * Calculate adjusted stats excluding connection overhead
  */
 function calculateAdjustedStats(
@@ -171,10 +158,10 @@ function calculateAdjustedStats(
     avg,
     min: adjustedDurations[0],
     max: adjustedDurations[adjustedDurations.length - 1],
-    p90: percentile(adjustedDurations, 90),
-    p95: percentile(adjustedDurations, 95),
-    p99: percentile(adjustedDurations, 99),
-    stdDev: stdDev(adjustedDurations, avg)
+    p90: calcPercentile(adjustedDurations, 90),
+    p95: calcPercentile(adjustedDurations, 95),
+    p99: calcPercentile(adjustedDurations, 99),
+    stdDev: calcStdDev(adjustedDurations, avg)
   }
 }
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1256,6 +1256,31 @@ export interface TelemetryStats {
 }
 
 /**
+ * Calculate percentile from a sorted array of numbers
+ * @param sorted - Array of numbers sorted in ascending order
+ * @param p - Percentile to calculate (0-100)
+ */
+export function calcPercentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  if (sorted.length === 1) return sorted[0];
+  const idx = Math.ceil((p / 100) * sorted.length) - 1;
+  return sorted[Math.max(0, Math.min(idx, sorted.length - 1))];
+}
+
+/**
+ * Calculate standard deviation of an array of numbers
+ * @param values - Array of numbers
+ * @param mean - Pre-calculated mean of the values
+ */
+export function calcStdDev(values: number[], mean: number): number {
+  if (values.length === 0) return 0;
+  const variance =
+    values.reduce((acc, val) => acc + Math.pow(val - mean, 2), 0) /
+    values.length;
+  return Math.sqrt(variance);
+}
+
+/**
  * Per-phase statistics for benchmark analysis
  */
 export interface PhaseStats {


### PR DESCRIPTION
## Summary

Fixed benchmark stats (MIN/MAX/AVG/P90/P95/P99/σ) not updating when the "Conn. overhead" toggle is toggled. Stats now correctly recalculate by excluding TCP and DB handshake phases when the toggle is off.

## Changes

- Added `calculateAdjustedStats()` function to recalculate stats without connection overhead
- Updated footer stats display to use adjusted values based on toggle state
- Updated total duration display in header to respect the toggle

## Related Issues

Fixes #100

## Type of Change

- [x] Bug fix

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] TypeScript and linting checks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Benchmark statistics can be adjusted to exclude connection overhead for more accurate results.
  * Additional statistical metrics (p90, p95, p99 and standard deviation) are computed and displayed using adjusted values.
  * Timelines, phase bars, and header/footer summaries show adjusted benchmark values when available.

* **Bug Fixes**
  * Improved consistency of timeline positioning and duration calculations when connection overhead is hidden.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->