### PR TITLE
UI: Refine titlebar label and adjust header margin on sidebar collapse

### DIFF
--- a/apps/desktop/src/renderer/src/assets/global.css
+++ b/apps/desktop/src/renderer/src/assets/global.css
@@ -249,6 +249,15 @@
     background: oklch(0.6 0 0 / 0.5);
   }
 
+  /* Scrollbar corner */
+  ::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+
+  .dark ::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+
   /* Selection colors */
   ::selection {
     background: oklch(0.45 0.15 250 / 0.3);

--- a/apps/desktop/src/renderer/src/components/ui/sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/sidebar.tsx
@@ -404,7 +404,7 @@ function SidebarInset({ className, ...props }: React.ComponentProps<'main'>) {
         'bg-background relative flex w-full flex-1 flex-col',
         'md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2',
         // On Mac, when sidebar is collapsed, add left padding for window controls (traffic lights)
-        'peer-data-[state=collapsed]:pl-[72px]',
+        // 'peer-data-[state=collapsed]:pl-[72px]',
         className
       )}
       {...props}

--- a/apps/desktop/src/renderer/src/router.tsx
+++ b/apps/desktop/src/renderer/src/router.tsx
@@ -16,7 +16,7 @@ import { DatabaseIcon } from '@/components/database-icons'
 import { AppSidebar } from '@/components/app-sidebar'
 import { NavActions } from '@/components/nav-actions'
 import { Separator } from '@/components/ui/separator'
-import { SidebarInset, SidebarProvider, SidebarTrigger } from '@/components/ui/sidebar'
+import { SidebarInset, SidebarProvider, SidebarTrigger, useSidebar } from '@/components/ui/sidebar'
 import { TabContainer } from '@/components/tab-container'
 import { DashboardView } from '@/components/dashboard'
 import { ConnectionPicker } from '@/components/connection-picker'
@@ -42,6 +42,7 @@ type CommandPalettePage = 'home' | 'connections' | 'connections:switch' | 'saved
 
 // Inner layout component that has access to sidebar context
 function LayoutContent() {
+  const { state: sidebarState } = useSidebar()
   const activeConnection = useConnectionStore((s) => s.getActiveConnection())
   const connections = useConnectionStore((s) => s.connections)
   const setActiveConnection = useConnectionStore((s) => s.setActiveConnection)
@@ -189,11 +190,16 @@ function LayoutContent() {
     <>
       <AppSidebar />
       <SidebarInset>
-        <header className="titlebar-drag-region flex h-14 shrink-0 items-center gap-2 border-b border-border/40 bg-background/80 backdrop-blur-xl">
+        <header
+          className={cn(
+            'titlebar-drag-region flex h-14 shrink-0 items-center gap-2 border-b border-border/40 bg-background/80 backdrop-blur-xl transition-[margin] duration-200 ease-linear',
+            sidebarState === 'collapsed' && 'mx-[72px]'
+          )}
+        >
           <div className="flex flex-1 items-center gap-2 px-3">
             <SidebarTrigger className="titlebar-no-drag" />
             <Separator orientation="vertical" className="mr-2 data-[orientation=vertical]:h-4" />
-            <span className="text-sm font-medium text-muted-foreground">data-peek</span>
+            <span className="text-sm font-medium text-muted-foreground">Data Peek</span>
             {activeConnection && (
               <>
                 <Separator


### PR DESCRIPTION
## Summary

Improves the top bar UI by refining the title presentation and adjusting header spacing when the sidebar is collapsed, resulting in a more polished appearance and smoother layout behavior.

## Changes

- Updated top bar title formatting for a more professional and consistent look
- Added conditional mx-[72px] margin to the header when the sidebar is collapsed
- Applied a 200ms transition for smooth spacing adjustment and to remove the gap between the add icon and the screen edge

## Related Issues

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have tested my changes
- [ ] I have updated documentation if needed

## Screenshots 
<img width="795" height="403" alt="image" src="https://github.com/user-attachments/assets/be28fba6-ae81-4784-ad24-af59d0af395a" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved scrollbar corner styling for visual consistency
  * Adjusted sidebar layout padding when collapsed
  * Enhanced header styling responsiveness

* **UI Updates**
  * Updated label text for improved clarity

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->