### PR TITLE
UI: Refine titlebar label and adjust header margin on sidebar collapse

### DIFF
--- a/apps/desktop/src/renderer/src/assets/global.css
+++ b/apps/desktop/src/renderer/src/assets/global.css
@@ -254,10 +254,6 @@
     background: transparent;
   }
 
-  .dark ::-webkit-scrollbar-corner {
-    background: transparent;
-  }
-
   /* Selection colors */
   ::selection {
     background: oklch(0.45 0.15 250 / 0.3);

--- a/apps/desktop/src/renderer/src/components/ui/sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/sidebar.tsx
@@ -403,8 +403,6 @@ function SidebarInset({ className, ...props }: React.ComponentProps<'main'>) {
       className={cn(
         'bg-background relative flex w-full flex-1 flex-col',
         'md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2',
-        // On Mac, when sidebar is collapsed, add left padding for window controls (traffic lights)
-        // 'peer-data-[state=collapsed]:pl-[72px]',
         className
       )}
       {...props}

--- a/apps/desktop/src/renderer/src/router.tsx
+++ b/apps/desktop/src/renderer/src/router.tsx
@@ -193,7 +193,7 @@ function LayoutContent() {
         <header
           className={cn(
             'titlebar-drag-region flex h-14 shrink-0 items-center gap-2 border-b border-border/40 bg-background/80 backdrop-blur-xl transition-[margin] duration-200 ease-linear',
-            sidebarState === 'collapsed' && 'ml-[72px]'
+            sidebarState === 'collapsed' && platform === 'darwin' && 'ml-[72px]'
           )}
         >
           <div className="flex flex-1 items-center gap-2 px-3">


### PR DESCRIPTION
## Summary

Improves the top bar UI by refining the title presentation and adjusting header spacing when the sidebar is collapsed, resulting in a more polished appearance and smoother layout behavior.

## Changes

- Updated top bar title formatting for a more professional and consistent look
- Added conditional mx-[72px] margin to the header when the sidebar is collapsed
- Applied a 200ms transition for smooth spacing adjustment and to remove the gap between the add icon and the screen edge

## Related Issues

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have tested my changes
- [ ] I have updated documentation if needed

## Screenshots 

<img width="795" height="403" alt="2026-01-24_17-14-05" src="https://github.com/user-attachments/assets/355361a9-47e8-4c3d-8cf2-c0d55c8137ef" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced scrollbar appearance with transparent corner styling for improved visual consistency
  * Refined sidebar collapse behavior with dynamic header layout adjustments on macOS
  * Updated the "data-peek" label to "Data Peek" for improved clarity

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->