### PR TITLE
feat(data-table): Smart Sort Bar with multi-column chips

### DIFF
--- a/apps/desktop/src/renderer/src/components/__tests__/smart-sort-bar.test.ts
+++ b/apps/desktop/src/renderer/src/components/__tests__/smart-sort-bar.test.ts
@@ -1,0 +1,399 @@
+import { describe, it, expect } from 'vitest'
+import {
+  applySorts,
+  toggleColumnSort,
+  type SortChip,
+  type SortColumn
+} from '@/components/smart-sort-bar'
+
+type ChipInit = {
+  id?: string
+  column: string
+  direction?: 'asc' | 'desc'
+  mode?: SortChip['mode']
+  nullsPosition?: 'first' | 'last'
+  seed?: number
+}
+
+function chip(partial: ChipInit): SortChip {
+  const base = {
+    id: partial.id ?? 'id',
+    column: partial.column,
+    direction: partial.direction ?? 'asc',
+    nullsPosition: partial.nullsPosition ?? 'last'
+  }
+  if (partial.mode === 'random') {
+    return { ...base, mode: 'random', seed: partial.seed ?? 1 }
+  }
+  return { ...base, mode: partial.mode ?? 'default' }
+}
+
+const COL_N: SortColumn[] = [{ name: 'n', dataType: 'integer' }]
+const COL_S: SortColumn[] = [{ name: 's', dataType: 'varchar' }]
+const COL_D: SortColumn[] = [{ name: 'd', dataType: 'timestamp' }]
+const COL_B: SortColumn[] = [{ name: 'b', dataType: 'boolean' }]
+
+describe('applySorts', () => {
+  it('returns original array when no chips', () => {
+    const rows = [{ a: 1 }, { a: 2 }]
+    expect(applySorts(rows, [])).toBe(rows)
+  })
+
+  it('sorts numerically ascending in default mode', () => {
+    const rows = [{ n: 10 }, { n: 2 }, { n: 30 }]
+    const sorted = applySorts(rows, [chip({ column: 'n', direction: 'asc' })], COL_N)
+    expect(sorted.map((r) => r.n)).toEqual([2, 10, 30])
+  })
+
+  it('sorts numerically descending', () => {
+    const rows = [{ n: 10 }, { n: 2 }, { n: 30 }]
+    const sorted = applySorts(rows, [chip({ column: 'n', direction: 'desc' })], COL_N)
+    expect(sorted.map((r) => r.n)).toEqual([30, 10, 2])
+  })
+
+  it('sorts strings lexically by default (no numeric sniffing)', () => {
+    const rows = [{ s: 'item10' }, { s: 'item2' }, { s: 'item1' }]
+    const sorted = applySorts(rows, [chip({ column: 's', direction: 'asc' })], COL_S)
+    expect(sorted.map((r) => r.s)).toEqual(['item1', 'item10', 'item2'])
+  })
+
+  it('does not coerce numeric-looking strings to numbers in string column', () => {
+    const rows = [{ s: '7' }, { s: '42' }, { s: '01234' }]
+    const sorted = applySorts(rows, [chip({ column: 's', direction: 'asc' })], COL_S)
+    expect(sorted.map((r) => r.s)).toEqual(['01234', '42', '7'])
+  })
+
+  it('sorts strings naturally when mode is natural', () => {
+    const rows = [{ s: 'item10' }, { s: 'item2' }, { s: 'item1' }]
+    const sorted = applySorts(
+      rows,
+      [chip({ column: 's', direction: 'asc', mode: 'natural' })],
+      COL_S
+    )
+    expect(sorted.map((r) => r.s)).toEqual(['item1', 'item2', 'item10'])
+  })
+
+  it('sorts by string length', () => {
+    const rows = [{ s: 'aaa' }, { s: 'a' }, { s: 'aa' }]
+    const sorted = applySorts(
+      rows,
+      [chip({ column: 's', direction: 'asc', mode: 'length' })],
+      COL_S
+    )
+    expect(sorted.map((r) => r.s)).toEqual(['a', 'aa', 'aaa'])
+  })
+
+  it('sorts numerics by absolute value', () => {
+    const rows = [{ n: -5 }, { n: 2 }, { n: -1 }, { n: 3 }]
+    const sorted = applySorts(
+      rows,
+      [chip({ column: 'n', direction: 'asc', mode: 'absolute' })],
+      COL_N
+    )
+    expect(sorted.map((r) => r.n)).toEqual([-1, 2, 3, -5])
+  })
+
+  it('applies multi-column sort with priority ordering', () => {
+    const rows = [
+      { g: 'a', n: 2 },
+      { g: 'b', n: 1 },
+      { g: 'a', n: 1 },
+      { g: 'b', n: 2 }
+    ]
+    const cols: SortColumn[] = [
+      { name: 'g', dataType: 'varchar' },
+      { name: 'n', dataType: 'integer' }
+    ]
+    const sorted = applySorts(
+      rows,
+      [
+        chip({ column: 'g', direction: 'asc', id: '1' }),
+        chip({ column: 'n', direction: 'desc', id: '2' })
+      ],
+      cols
+    )
+    expect(sorted).toEqual([
+      { g: 'a', n: 2 },
+      { g: 'a', n: 1 },
+      { g: 'b', n: 2 },
+      { g: 'b', n: 1 }
+    ])
+  })
+
+  it('places nulls last by default', () => {
+    const rows = [{ n: 1 }, { n: null }, { n: 2 }]
+    const sorted = applySorts(rows, [chip({ column: 'n', direction: 'asc' })], COL_N)
+    expect(sorted.map((r) => r.n)).toEqual([1, 2, null])
+  })
+
+  it('places nulls first when configured', () => {
+    const rows = [{ n: 1 }, { n: null }, { n: 2 }]
+    const sorted = applySorts(
+      rows,
+      [chip({ column: 'n', direction: 'asc', nullsPosition: 'first' })],
+      COL_N
+    )
+    expect(sorted.map((r) => r.n)).toEqual([null, 1, 2])
+  })
+
+  it('treats empty string as null', () => {
+    const rows = [{ s: 'b' }, { s: '' }, { s: 'a' }]
+    const sorted = applySorts(rows, [chip({ column: 's', direction: 'asc' })], COL_S)
+    expect(sorted.map((r) => r.s)).toEqual(['a', 'b', ''])
+  })
+
+  it('respects per-chip nullsPosition independently in multi-column sort', () => {
+    const rows = [
+      { g: 'a', n: 1 },
+      { g: 'a', n: null },
+      { g: null, n: 99 },
+      { g: 'b', n: 2 }
+    ]
+    const cols: SortColumn[] = [
+      { name: 'g', dataType: 'varchar' },
+      { name: 'n', dataType: 'integer' }
+    ]
+    const sorted = applySorts(
+      rows,
+      [
+        chip({ column: 'g', direction: 'asc', id: '1', nullsPosition: 'first' }),
+        chip({ column: 'n', direction: 'asc', id: '2', nullsPosition: 'last' })
+      ],
+      cols
+    )
+    expect(sorted).toEqual([
+      { g: null, n: 99 },
+      { g: 'a', n: 1 },
+      { g: 'a', n: null },
+      { g: 'b', n: 2 }
+    ])
+  })
+
+  it('shuffles deterministically with same seed', () => {
+    const rows = Array.from({ length: 50 }, (_, i) => ({ i }))
+    const cols: SortColumn[] = [{ name: 'i', dataType: 'integer' }]
+    const a = applySorts(rows, [chip({ column: 'i', mode: 'random', seed: 42 })], cols)
+    const b = applySorts(rows, [chip({ column: 'i', mode: 'random', seed: 42 })], cols)
+    expect(a.map((r) => r.i)).toEqual(b.map((r) => r.i))
+  })
+
+  it('shuffles differently with different seeds', () => {
+    const rows = Array.from({ length: 50 }, (_, i) => ({ i }))
+    const cols: SortColumn[] = [{ name: 'i', dataType: 'integer' }]
+    const a = applySorts(rows, [chip({ column: 'i', mode: 'random', seed: 1 })], cols)
+    const b = applySorts(rows, [chip({ column: 'i', mode: 'random', seed: 999 })], cols)
+    expect(a.map((r) => r.i)).not.toEqual(b.map((r) => r.i))
+  })
+
+  it('uses independent seeds across multiple random chips', () => {
+    const rows = Array.from({ length: 20 }, (_, i) => ({ g: 'a', n: i }))
+    const cols: SortColumn[] = [
+      { name: 'g', dataType: 'varchar' },
+      { name: 'n', dataType: 'integer' }
+    ]
+    const shuffleAOnly = applySorts(
+      rows,
+      [
+        chip({ column: 'g', direction: 'asc', id: '1' }),
+        chip({ column: 'n', direction: 'asc', id: '2', mode: 'random', seed: 13 })
+      ],
+      cols
+    )
+    const shuffleBOnly = applySorts(
+      rows,
+      [
+        chip({ column: 'g', direction: 'asc', id: '1' }),
+        chip({ column: 'n', direction: 'asc', id: '2', mode: 'random', seed: 99 })
+      ],
+      cols
+    )
+    expect(shuffleAOnly.map((r) => r.n)).not.toEqual(shuffleBOnly.map((r) => r.n))
+  })
+
+  it('groups dates by month when mode is byMonth', () => {
+    const rows = [
+      { id: 1, d: '2024-03-15' },
+      { id: 2, d: '2024-01-20' },
+      { id: 3, d: '2023-01-05' },
+      { id: 4, d: '2024-03-01' }
+    ]
+    const cols: SortColumn[] = [
+      { name: 'id', dataType: 'integer' },
+      { name: 'd', dataType: 'timestamp' }
+    ]
+    const sorted = applySorts(
+      rows,
+      [chip({ column: 'd', direction: 'asc', mode: 'byMonth' })],
+      cols
+    )
+    const months = sorted.map((r) => new Date(r.d).getMonth())
+    expect(months).toEqual([0, 0, 2, 2])
+  })
+
+  it('sorts byDayOfWeek with Monday=0…Sunday=6', () => {
+    const rows = [{ d: '2024-04-07' }, { d: '2024-04-01' }, { d: '2024-04-03' }]
+    const sorted = applySorts(
+      rows,
+      [chip({ column: 'd', direction: 'asc', mode: 'byDayOfWeek' })],
+      COL_D
+    )
+    expect(sorted.map((r) => new Date(r.d).getDay())).toEqual([1, 3, 0])
+  })
+
+  it('sorts byTime ignoring the date component', () => {
+    const rows = [
+      { d: '2024-01-01T15:00:00' },
+      { d: '2023-06-15T03:00:00' },
+      { d: '2025-12-31T09:00:00' }
+    ]
+    const sorted = applySorts(
+      rows,
+      [chip({ column: 'd', direction: 'asc', mode: 'byTime' })],
+      COL_D
+    )
+    expect(sorted.map((r) => new Date(r.d).getHours())).toEqual([3, 9, 15])
+  })
+
+  it('routes invalid dates through the null path in byMonth', () => {
+    const rows = [{ d: '2024-02-01' }, { d: 'not-a-date' }, { d: '2024-05-01' }]
+    const sorted = applySorts(
+      rows,
+      [chip({ column: 'd', direction: 'asc', mode: 'byMonth', nullsPosition: 'last' })],
+      COL_D
+    )
+    expect(sorted.map((r) => r.d)).toEqual(['2024-02-01', '2024-05-01', 'not-a-date'])
+  })
+
+  it('preserves input order for ties (stable sort)', () => {
+    const rows = [
+      { g: 'a', k: 1 },
+      { g: 'a', k: 2 },
+      { g: 'a', k: 3 }
+    ]
+    const cols: SortColumn[] = [
+      { name: 'g', dataType: 'varchar' },
+      { name: 'k', dataType: 'integer' }
+    ]
+    const sorted = applySorts(rows, [chip({ column: 'g', direction: 'asc' })], cols)
+    expect(sorted.map((r) => r.k)).toEqual([1, 2, 3])
+  })
+
+  it('handles empty rows array', () => {
+    const sorted = applySorts([], [chip({ column: 'n', direction: 'asc' })], COL_N)
+    expect(sorted).toEqual([])
+  })
+
+  it('handles all-null column without throwing', () => {
+    const rows = [{ n: null }, { n: null }, { n: null }]
+    const sorted = applySorts(rows, [chip({ column: 'n', direction: 'asc' })], COL_N)
+    expect(sorted).toHaveLength(3)
+  })
+
+  it('sorts boolean columns with true before false', () => {
+    const rows = [{ b: false }, { b: true }, { b: false }, { b: true }]
+    const sorted = applySorts(rows, [chip({ column: 'b', direction: 'asc' })], COL_B)
+    expect(sorted.map((r) => r.b)).toEqual([true, true, false, false])
+  })
+
+  it('sorts timestamp strings chronologically in default mode', () => {
+    const rows = [
+      { d: '2024-03-15T10:00:00' },
+      { d: '2023-01-05T09:00:00' },
+      { d: '2024-01-20T08:00:00' }
+    ]
+    const sorted = applySorts(rows, [chip({ column: 'd', direction: 'asc' })], COL_D)
+    expect(sorted.map((r) => r.d)).toEqual([
+      '2023-01-05T09:00:00',
+      '2024-01-20T08:00:00',
+      '2024-03-15T10:00:00'
+    ])
+  })
+
+  it('absolute mode routes non-numeric values through null path', () => {
+    const rows = [{ n: -3 }, { n: 'x' }, { n: 1 }]
+    const sorted = applySorts(
+      rows,
+      [chip({ column: 'n', direction: 'asc', mode: 'absolute', nullsPosition: 'last' })],
+      COL_N
+    )
+    expect(sorted.map((r) => r.n)).toEqual([1, -3, 'x'])
+  })
+})
+
+describe('toggleColumnSort', () => {
+  const col: SortColumn = { name: 'price', dataType: 'numeric' }
+  const textCol: SortColumn = { name: 'name', dataType: 'varchar' }
+  const dateCol: SortColumn = { name: 'created_at', dataType: 'timestamp' }
+
+  it('adds new chip when column is not sorted (single)', () => {
+    const result = toggleColumnSort([], col)
+    expect(result).toHaveLength(1)
+    expect(result[0].column).toBe('price')
+    expect(result[0].direction).toBe('desc')
+  })
+
+  it('uses asc default for text columns', () => {
+    const result = toggleColumnSort([], textCol)
+    expect(result[0].direction).toBe('asc')
+  })
+
+  it('uses desc default for date columns', () => {
+    const result = toggleColumnSort([], dateCol)
+    expect(result[0].direction).toBe('desc')
+  })
+
+  it('replaces existing chips when not multi', () => {
+    const initial = toggleColumnSort([], textCol)
+    const next = toggleColumnSort(initial, col)
+    expect(next).toHaveLength(1)
+    expect(next[0].column).toBe('price')
+  })
+
+  it('appends when multi=true', () => {
+    const initial = toggleColumnSort([], textCol)
+    const next = toggleColumnSort(initial, col, { multi: true })
+    expect(next).toHaveLength(2)
+  })
+
+  it('flips direction on existing chip', () => {
+    const initial = toggleColumnSort([], col)
+    expect(initial[0].direction).toBe('desc')
+    const flipped = toggleColumnSort(initial, col)
+    expect(flipped).toHaveLength(1)
+    expect(flipped[0].direction).toBe('asc')
+  })
+
+  it('cycles direction without removing the chip', () => {
+    const step1 = toggleColumnSort([], col)
+    const step2 = toggleColumnSort(step1, col)
+    const step3 = toggleColumnSort(step2, col)
+    expect(step3).toHaveLength(1)
+    expect(step3[0].direction).toBe('desc')
+  })
+
+  it('preserves mode and nullsPosition across direction flips', () => {
+    const initial = toggleColumnSort([], dateCol)
+    const customized: SortChip[] = [
+      {
+        id: initial[0].id,
+        column: initial[0].column,
+        direction: initial[0].direction,
+        mode: 'byMonth',
+        nullsPosition: 'first'
+      }
+    ]
+    const flipped = toggleColumnSort(customized, dateCol)
+    expect(flipped[0].mode).toBe('byMonth')
+    expect(flipped[0].nullsPosition).toBe('first')
+  })
+
+  it('flips direction on date column in multi mode while preserving other chips', () => {
+    const initial = toggleColumnSort([], col)
+    const withDate = toggleColumnSort(initial, dateCol, { multi: true })
+    expect(withDate).toHaveLength(2)
+    const flippedDate = toggleColumnSort(withDate, dateCol, { multi: true })
+    expect(flippedDate).toHaveLength(2)
+    expect(flippedDate.find((c) => c.column === 'created_at')?.direction).toBe('asc')
+    expect(flippedDate.find((c) => c.column === 'price')?.direction).toBe('desc')
+  })
+})

--- a/apps/desktop/src/renderer/src/components/data-table.tsx
+++ b/apps/desktop/src/renderer/src/components/data-table.tsx
@@ -4,10 +4,8 @@ import {
   getCoreRowModel,
   getFilteredRowModel,
   getPaginationRowModel,
-  getSortedRowModel,
   useReactTable,
-  type ColumnDef,
-  type SortingState
+  type ColumnDef
 } from '@tanstack/react-table'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { ArrowUpDown, ArrowUp, ArrowDown, Link2, Copy, BarChart2, Lock, Unlock } from 'lucide-react'
@@ -34,6 +32,12 @@ import {
 import { JsonCellValue } from '@/components/json-cell-value'
 import { FKCellValue } from '@/components/fk-cell-value'
 import { SmartFilterBar, chipMatchesRow, type FilterChip } from '@/components/smart-filter-bar'
+import {
+  SmartSortBar,
+  applySorts,
+  toggleColumnSort,
+  type SortChip
+} from '@/components/smart-sort-bar'
 
 import { useCopyToClipboard } from '@/hooks/use-copy-to-clipboard'
 import { getTypeColor } from '@/lib/type-colors'
@@ -244,8 +248,20 @@ export function DataTable<TData extends Record<string, unknown>>({
     ]
   )
   const pageSize = propPageSize ?? defaultPageSize
-  const [sorting, setSorting] = React.useState<SortingState>([])
+  const [sortChips, setSortChips] = React.useState<SortChip[]>([])
   const [filterChips, setFilterChips] = React.useState<FilterChip[]>([])
+
+  const sortedData = React.useMemo(() => {
+    if (sortChips.length === 0) return data
+    return applySorts(data, sortChips, columnDefs)
+  }, [data, sortChips, columnDefs])
+
+  const toggleHeaderSort = React.useCallback(
+    (col: { name: string; dataType: string }, multi: boolean) => {
+      setSortChips((prev) => toggleColumnSort(prev, col, { multi }))
+    },
+    []
+  )
 
   const globalFilterFn = React.useCallback(
     (row: { original: unknown }): boolean => {
@@ -276,13 +292,13 @@ export function DataTable<TData extends Record<string, unknown>>({
   // Notify parent of sorting changes
   React.useEffect(() => {
     if (onSortingChange) {
-      const sorts: DataTableSort[] = sorting.map((s) => ({
-        column: s.id,
-        direction: s.desc ? 'desc' : 'asc'
+      const sorts: DataTableSort[] = sortChips.map((c) => ({
+        column: c.column,
+        direction: c.direction
       }))
       onSortingChange(sorts)
     }
-  }, [sorting, onSortingChange])
+  }, [sortChips, onSortingChange])
 
   // Generate TanStack Table columns from column definitions
   const columns = React.useMemo<ColumnDef<TData>[]>(
@@ -305,8 +321,12 @@ export function DataTable<TData extends Record<string, unknown>>({
         return {
           id: columnId,
           accessorKey: col.name,
-          header: ({ column }) => {
-            const isSorted = column.getIsSorted()
+          enableSorting: false,
+          header: () => {
+            const activeChip = sortChips.find((c) => c.column === col.name)
+            const activeRank = activeChip
+              ? sortChips.findIndex((c) => c.column === col.name) + 1
+              : 0
             const isMasked = effectiveMasked.has(col.name)
             return (
               <div className="flex flex-col gap-0.5">
@@ -314,7 +334,8 @@ export function DataTable<TData extends Record<string, unknown>>({
                   <Button
                     variant="ghost"
                     className="h-auto py-1 px-2 -mx-2 font-medium hover:bg-accent/50 flex-1"
-                    onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
+                    onClick={(e) => toggleHeaderSort(col, e.shiftKey || e.metaKey || e.ctrlKey)}
+                    title="Click to sort, Shift+click for multi-sort"
                   >
                     <span>{displayName}</span>
                     {isMasked && <Lock className="ml-1 size-3 text-amber-500" />}
@@ -325,10 +346,19 @@ export function DataTable<TData extends Record<string, unknown>>({
                     >
                       {col.dataType}
                     </Badge>
-                    {isSorted === 'asc' ? (
-                      <ArrowUp className="ml-1 size-3 text-primary" />
-                    ) : isSorted === 'desc' ? (
-                      <ArrowDown className="ml-1 size-3 text-primary" />
+                    {activeChip ? (
+                      <span className="ml-1 inline-flex items-center gap-0.5">
+                        {activeChip.direction === 'asc' ? (
+                          <ArrowUp className="size-3 text-primary" />
+                        ) : (
+                          <ArrowDown className="size-3 text-primary" />
+                        )}
+                        {sortChips.length > 1 && (
+                          <span className="text-[9px] font-mono font-semibold text-primary/80 tabular-nums">
+                            {activeRank}
+                          </span>
+                        )}
+                      </span>
                     ) : (
                       <ArrowUpDown className="ml-1 size-3 opacity-50" />
                     )}
@@ -447,21 +477,20 @@ export function DataTable<TData extends Record<string, unknown>>({
       effectiveMasked,
       tabId,
       toggleColumnMask,
-      hoverToPeek
+      hoverToPeek,
+      sortChips,
+      toggleHeaderSort
     ]
   )
 
   const table = useReactTable({
-    data,
+    data: sortedData,
     columns,
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
-    getSortedRowModel: getSortedRowModel(),
-    onSortingChange: setSorting,
     globalFilterFn: (row) => globalFilterFn(row),
     state: {
-      sorting,
       globalFilter: filterChips
     },
     initialState: {
@@ -470,6 +499,10 @@ export function DataTable<TData extends Record<string, unknown>>({
       }
     }
   })
+
+  React.useEffect(() => {
+    table.setPageIndex(0)
+  }, [sortChips, filterChips, table])
 
   const tableContainerRef = React.useRef<HTMLDivElement>(null)
   const headerRef = React.useRef<HTMLTableRowElement>(null)
@@ -523,6 +556,13 @@ export function DataTable<TData extends Record<string, unknown>>({
         onApplyToQuery={onApplyToQuery}
         totalRows={data.length}
         filteredRows={table.getFilteredRowModel().rows.length}
+        className="shrink-0"
+      />
+      <SmartSortBar
+        columns={columnDefs}
+        chips={sortChips}
+        onChipsChange={setSortChips}
+        onApplyToQuery={onApplyToQuery}
         className="shrink-0"
       />
 

--- a/apps/desktop/src/renderer/src/components/editable-data-table.tsx
+++ b/apps/desktop/src/renderer/src/components/editable-data-table.tsx
@@ -36,16 +36,20 @@ import { useSettingsStore } from '@/stores/settings-store'
 import { useMaskingStore } from '@/stores/masking-store'
 import { PaginationControls } from '@/components/pagination-controls'
 import { SmartFilterBar, chipMatchesRow, type FilterChip } from '@/components/smart-filter-bar'
+import {
+  SmartSortBar,
+  applySorts,
+  toggleColumnSort,
+  type SortChip
+} from '@/components/smart-sort-bar'
 import type { ColumnInfo, ConnectionConfig, EditContext, ForeignKeyInfo } from '@data-peek/shared'
 import {
   flexRender,
   getCoreRowModel,
   getFilteredRowModel,
   getPaginationRowModel,
-  getSortedRowModel,
   useReactTable,
-  type ColumnDef,
-  type SortingState
+  type ColumnDef
 } from '@tanstack/react-table'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import {
@@ -240,8 +244,20 @@ export function EditableDataTable<TData extends Record<string, unknown>>({
     ]
   )
 
-  const [sorting, setSorting] = React.useState<SortingState>([])
+  const [sortChips, setSortChips] = React.useState<SortChip[]>([])
   const [filterChips, setFilterChips] = React.useState<FilterChip[]>([])
+
+  const sortedData = React.useMemo(() => {
+    if (sortChips.length === 0) return data
+    return applySorts(data, sortChips, columnDefs)
+  }, [data, sortChips, columnDefs])
+
+  const toggleHeaderSort = React.useCallback(
+    (col: { name: string; dataType: string }, multi: boolean) => {
+      setSortChips((prev) => toggleColumnSort(prev, col, { multi }))
+    },
+    []
+  )
 
   const globalFilterFn = React.useCallback(
     (row: { original: unknown }): boolean => {
@@ -414,13 +430,13 @@ export function EditableDataTable<TData extends Record<string, unknown>>({
   // Notify parent of sorting changes
   React.useEffect(() => {
     if (onSortingChange) {
-      const sorts: DataTableSort[] = sorting.map((s) => ({
-        column: s.id,
-        direction: s.desc ? 'desc' : 'asc'
+      const sorts: DataTableSort[] = sortChips.map((c) => ({
+        column: c.column,
+        direction: c.direction
       }))
       onSortingChange(sorts)
     }
-  }, [sorting, onSortingChange])
+  }, [sortChips, onSortingChange])
 
   // Handle toggle edit mode
   const handleToggleEditMode = () => {
@@ -708,8 +724,10 @@ export function EditableDataTable<TData extends Record<string, unknown>>({
         id: columnId,
         // Keep accessorKey as col.name since that's how row data is keyed (even if empty)
         accessorKey: col.name,
-        header: ({ column }) => {
-          const isSorted = column.getIsSorted()
+        enableSorting: false,
+        header: () => {
+          const activeChip = sortChips.find((c) => c.column === col.name)
+          const activeRank = activeChip ? sortChips.findIndex((c) => c.column === col.name) + 1 : 0
           const isMasked = effectiveMasked.has(col.name)
           return (
             <div className="flex flex-col gap-0.5">
@@ -717,7 +735,8 @@ export function EditableDataTable<TData extends Record<string, unknown>>({
                 <Button
                   variant="ghost"
                   className="h-auto py-1 px-2 -mx-2 font-medium hover:bg-accent/50 flex-1"
-                  onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
+                  onClick={(e) => toggleHeaderSort(col, e.shiftKey || e.metaKey || e.ctrlKey)}
+                  title="Click to sort, Shift+click for multi-sort"
                 >
                   <span>{displayName}</span>
                   {col.isPrimaryKey && (
@@ -733,10 +752,19 @@ export function EditableDataTable<TData extends Record<string, unknown>>({
                   >
                     {col.dataType}
                   </Badge>
-                  {isSorted === 'asc' ? (
-                    <ArrowUp className="ml-1 size-3 text-primary" />
-                  ) : isSorted === 'desc' ? (
-                    <ArrowDown className="ml-1 size-3 text-primary" />
+                  {activeChip ? (
+                    <span className="ml-1 inline-flex items-center gap-0.5">
+                      {activeChip.direction === 'asc' ? (
+                        <ArrowUp className="size-3 text-primary" />
+                      ) : (
+                        <ArrowDown className="size-3 text-primary" />
+                      )}
+                      {sortChips.length > 1 && (
+                        <span className="text-[9px] font-mono font-semibold text-primary/80 tabular-nums">
+                          {activeRank}
+                        </span>
+                      )}
+                    </span>
                   ) : (
                     <ArrowUpDown className="ml-1 size-3 opacity-50" />
                   )}
@@ -987,20 +1015,19 @@ export function EditableDataTable<TData extends Record<string, unknown>>({
     onColumnStatsClick,
     effectiveMasked,
     toggleColumnMask,
-    hoverToPeek
+    hoverToPeek,
+    sortChips,
+    toggleHeaderSort
   ])
 
   const table = useReactTable({
-    data,
+    data: sortedData,
     columns,
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
-    getSortedRowModel: getSortedRowModel(),
-    onSortingChange: setSorting,
     globalFilterFn: (row) => globalFilterFn(row),
     state: {
-      sorting,
       globalFilter: filterChips
     },
     initialState: {
@@ -1009,6 +1036,10 @@ export function EditableDataTable<TData extends Record<string, unknown>>({
       }
     }
   })
+
+  React.useEffect(() => {
+    table.setPageIndex(0)
+  }, [sortChips, filterChips, table])
 
   const tableContainerRef = React.useRef<HTMLDivElement>(null)
   const headerRef = React.useRef<HTMLTableRowElement>(null)
@@ -1065,6 +1096,12 @@ export function EditableDataTable<TData extends Record<string, unknown>>({
             onApplyToQuery={onApplyToQuery}
             totalRows={data.length}
             filteredRows={table.getFilteredRowModel().rows.length}
+          />
+          <SmartSortBar
+            columns={columnDefs}
+            chips={sortChips}
+            onChipsChange={setSortChips}
+            onApplyToQuery={onApplyToQuery}
           />
           {canEdit && (
             <div className="flex items-center px-2 py-1 border-b border-border/30">

--- a/apps/desktop/src/renderer/src/components/smart-sort-bar.tsx
+++ b/apps/desktop/src/renderer/src/components/smart-sort-bar.tsx
@@ -1,0 +1,1259 @@
+import * as React from 'react'
+import {
+  ArrowDownUp,
+  ArrowUp,
+  ArrowDown,
+  X,
+  Shuffle,
+  Dices,
+  CircleDashed,
+  CircleDot,
+  GripVertical,
+  Sparkles,
+  Clock,
+  CalendarDays,
+  CalendarClock,
+  Ruler,
+  Sigma,
+  ArrowDownAZ,
+  ArrowDownZA,
+  ArrowDown01,
+  ArrowDown10
+} from 'lucide-react'
+import { Button, cn } from '@data-peek/ui'
+import { getTypeColor } from '@/lib/type-colors'
+
+export interface SortColumn {
+  name: string
+  dataType: string
+}
+
+export type SortDirection = 'asc' | 'desc'
+export type NullsPosition = 'first' | 'last'
+
+export type SortMode =
+  | 'default'
+  | 'natural'
+  | 'length'
+  | 'absolute'
+  | 'byMonth'
+  | 'byDayOfWeek'
+  | 'byTime'
+  | 'random'
+
+interface SortChipBase {
+  id: string
+  column: string
+  direction: SortDirection
+  nullsPosition: NullsPosition
+}
+
+export type SortChip =
+  | (SortChipBase & { mode: Exclude<SortMode, 'random'>; seed?: never })
+  | (SortChipBase & { mode: 'random'; seed: number })
+
+export type TypeCategory = 'bool' | 'numeric' | 'date' | 'string'
+
+function getTypeCategory(dataType: string): TypeCategory {
+  const lower = dataType.toLowerCase()
+  if (lower.includes('bool')) return 'bool'
+  if (
+    lower.includes('int') ||
+    lower.includes('numeric') ||
+    lower.includes('decimal') ||
+    lower.includes('float') ||
+    lower.includes('double') ||
+    lower.includes('real') ||
+    lower.includes('money') ||
+    lower.includes('serial') ||
+    lower.includes('bigint')
+  )
+    return 'numeric'
+  if (lower.includes('timestamp') || lower.includes('date') || lower.includes('time')) return 'date'
+  return 'string'
+}
+
+interface ModeOption {
+  value: SortMode
+  label: string
+  short: string
+  description: string
+  icon: React.ComponentType<{ className?: string }>
+}
+
+const STRING_MODES: ModeOption[] = [
+  {
+    value: 'default',
+    label: 'Alphabetic',
+    short: 'A→Z',
+    description: 'Standard lexical order',
+    icon: ArrowDownAZ
+  },
+  {
+    value: 'natural',
+    label: 'Natural',
+    short: 'nat',
+    description: 'item2 before item10',
+    icon: Sparkles
+  },
+  {
+    value: 'length',
+    label: 'By length',
+    short: 'len',
+    description: 'Shortest to longest',
+    icon: Ruler
+  },
+  {
+    value: 'random',
+    label: 'Shuffle',
+    short: 'rand',
+    description: 'Random seeded order',
+    icon: Shuffle
+  }
+]
+
+const NUMERIC_MODES: ModeOption[] = [
+  {
+    value: 'default',
+    label: 'Numeric',
+    short: '1→9',
+    description: 'Lowest to highest',
+    icon: ArrowDown01
+  },
+  {
+    value: 'absolute',
+    label: 'Absolute',
+    short: '|x|',
+    description: 'By distance from zero',
+    icon: Sigma
+  },
+  {
+    value: 'random',
+    label: 'Shuffle',
+    short: 'rand',
+    description: 'Random seeded order',
+    icon: Shuffle
+  }
+]
+
+const DATE_MODES: ModeOption[] = [
+  {
+    value: 'default',
+    label: 'Chronological',
+    short: 'time',
+    description: 'Oldest to newest',
+    icon: Clock
+  },
+  {
+    value: 'byMonth',
+    label: 'By month',
+    short: 'month',
+    description: 'Group Jan…Dec',
+    icon: CalendarDays
+  },
+  {
+    value: 'byDayOfWeek',
+    label: 'By weekday',
+    short: 'dow',
+    description: 'Group Mon…Sun',
+    icon: CalendarClock
+  },
+  {
+    value: 'byTime',
+    label: 'Time of day',
+    short: 'tod',
+    description: '00:00 → 23:59 only',
+    icon: Clock
+  },
+  {
+    value: 'random',
+    label: 'Shuffle',
+    short: 'rand',
+    description: 'Random seeded order',
+    icon: Shuffle
+  }
+]
+
+const BOOL_MODES: ModeOption[] = [
+  {
+    value: 'default',
+    label: 'Boolean',
+    short: 't/f',
+    description: 'True before false',
+    icon: CircleDot
+  },
+  {
+    value: 'random',
+    label: 'Shuffle',
+    short: 'rand',
+    description: 'Random seeded order',
+    icon: Shuffle
+  }
+]
+
+function modesForType(dataType: string): ModeOption[] {
+  const cat = getTypeCategory(dataType)
+  if (cat === 'numeric') return NUMERIC_MODES
+  if (cat === 'date') return DATE_MODES
+  if (cat === 'bool') return BOOL_MODES
+  return STRING_MODES
+}
+
+function defaultDirectionForType(dataType: string): SortDirection {
+  const cat = getTypeCategory(dataType)
+  if (cat === 'date' || cat === 'numeric') return 'desc'
+  return 'asc'
+}
+
+function modeLabel(chip: SortChip, col: SortColumn | undefined): string {
+  if (!col) return chip.mode
+  const modes = modesForType(col.dataType)
+  const found = modes.find((m) => m.value === chip.mode)
+  return found?.short ?? chip.mode
+}
+
+function nextChipId(): string {
+  return crypto.randomUUID()
+}
+
+function mulberry32(seed: number): () => number {
+  let a = seed | 0
+  return function () {
+    a = (a + 0x6d2b79f5) | 0
+    let t = a
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+function monthOfValue(v: unknown): number {
+  if (v == null) return -1
+  const d = new Date(String(v))
+  const t = d.getTime()
+  if (Number.isNaN(t)) return -1
+  return d.getMonth()
+}
+
+function dayOfWeekOfValue(v: unknown): number {
+  if (v == null) return -1
+  const d = new Date(String(v))
+  const t = d.getTime()
+  if (Number.isNaN(t)) return -1
+  return (d.getDay() + 6) % 7
+}
+
+function timeOfDayOfValue(v: unknown): number {
+  if (v == null) return -1
+  const d = new Date(String(v))
+  const t = d.getTime()
+  if (Number.isNaN(t)) return -1
+  return d.getHours() * 3600 + d.getMinutes() * 60 + d.getSeconds()
+}
+
+const naturalCollator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' })
+const plainCollator = new Intl.Collator(undefined, { sensitivity: 'base' })
+
+function resolveNullOrder(
+  aInvalid: boolean,
+  bInvalid: boolean,
+  nullsPosition: NullsPosition
+): number | null {
+  if (aInvalid && bInvalid) return 0
+  if (aInvalid) return nullsPosition === 'first' ? -1 : 1
+  if (bInvalid) return nullsPosition === 'first' ? 1 : -1
+  return null
+}
+
+function compareByChip(
+  chip: SortChip,
+  xIndex: number,
+  yIndex: number,
+  a: Record<string, unknown>,
+  b: Record<string, unknown>,
+  category: TypeCategory,
+  randomValues: number[] | undefined
+): number {
+  const va = a[chip.column]
+  const vb = b[chip.column]
+
+  const aNull = va === null || va === undefined || va === ''
+  const bNull = vb === null || vb === undefined || vb === ''
+  const nullOrder = resolveNullOrder(aNull, bNull, chip.nullsPosition)
+  if (nullOrder !== null) return nullOrder
+
+  const mul = chip.direction === 'asc' ? 1 : -1
+
+  if (chip.mode === 'random' && randomValues) {
+    return (randomValues[xIndex] - randomValues[yIndex]) * mul
+  }
+
+  if (chip.mode === 'length') {
+    return (String(va).length - String(vb).length) * mul
+  }
+
+  if (chip.mode === 'natural') {
+    return naturalCollator.compare(String(va), String(vb)) * mul
+  }
+
+  if (chip.mode === 'absolute') {
+    const na = Math.abs(Number(va))
+    const nb = Math.abs(Number(vb))
+    const aBad = Number.isNaN(na)
+    const bBad = Number.isNaN(nb)
+    const order = resolveNullOrder(aBad, bBad, chip.nullsPosition)
+    if (order !== null) return order
+    return (na - nb) * mul
+  }
+
+  if (chip.mode === 'byMonth') {
+    const ma = monthOfValue(va)
+    const mb = monthOfValue(vb)
+    const order = resolveNullOrder(ma < 0, mb < 0, chip.nullsPosition)
+    if (order !== null) return order
+    return (ma - mb) * mul
+  }
+
+  if (chip.mode === 'byDayOfWeek') {
+    const da = dayOfWeekOfValue(va)
+    const db = dayOfWeekOfValue(vb)
+    const order = resolveNullOrder(da < 0, db < 0, chip.nullsPosition)
+    if (order !== null) return order
+    return (da - db) * mul
+  }
+
+  if (chip.mode === 'byTime') {
+    const ta = timeOfDayOfValue(va)
+    const tb = timeOfDayOfValue(vb)
+    const order = resolveNullOrder(ta < 0, tb < 0, chip.nullsPosition)
+    if (order !== null) return order
+    return (ta - tb) * mul
+  }
+
+  if (category === 'numeric') {
+    const na = Number(va)
+    const nb = Number(vb)
+    const order = resolveNullOrder(Number.isNaN(na), Number.isNaN(nb), chip.nullsPosition)
+    if (order !== null) return order
+    return (na - nb) * mul
+  }
+
+  if (category === 'date') {
+    const ta = new Date(String(va)).getTime()
+    const tb = new Date(String(vb)).getTime()
+    const order = resolveNullOrder(Number.isNaN(ta), Number.isNaN(tb), chip.nullsPosition)
+    if (order !== null) return order
+    return (ta - tb) * mul
+  }
+
+  if (category === 'bool') {
+    const aBool = va === true || va === 't' || va === 'true' || va === 1 ? 1 : 0
+    const bBool = vb === true || vb === 't' || vb === 'true' || vb === 1 ? 1 : 0
+    return (bBool - aBool) * mul
+  }
+
+  return plainCollator.compare(String(va), String(vb)) * mul
+}
+
+export function applySorts<T extends Record<string, unknown>>(
+  rows: T[],
+  chips: SortChip[],
+  columns: SortColumn[] = []
+): T[] {
+  if (chips.length === 0) return rows
+
+  const categoryByColumn = new Map<string, TypeCategory>()
+  for (const c of columns) categoryByColumn.set(c.name, getTypeCategory(c.dataType))
+
+  const randomValuesByChip = new Map<string, number[]>()
+  for (const chip of chips) {
+    if (chip.mode !== 'random') continue
+    const rng = mulberry32(chip.seed)
+    const arr = new Array<number>(rows.length)
+    for (let i = 0; i < rows.length; i++) arr[i] = rng()
+    randomValuesByChip.set(chip.id, arr)
+  }
+
+  const withIndex = rows.map((r, i) => ({ r, i }))
+  withIndex.sort((x, y) => {
+    for (const chip of chips) {
+      const category = categoryByColumn.get(chip.column) ?? 'string'
+      const randomValues = randomValuesByChip.get(chip.id)
+      const c = compareByChip(chip, x.i, y.i, x.r, y.r, category, randomValues)
+      if (c !== 0) return c
+    }
+    return x.i - y.i
+  })
+  return withIndex.map((w) => w.r)
+}
+
+function PriorityBadge({ rank }: { rank: number }) {
+  const classes =
+    rank === 1
+      ? 'bg-primary text-primary-foreground'
+      : rank === 2
+        ? 'bg-primary/70 text-primary-foreground'
+        : rank === 3
+          ? 'bg-primary/50 text-primary-foreground'
+          : 'bg-primary/30 text-primary-foreground'
+
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center justify-center size-4 rounded-full',
+        'text-[9px] font-mono font-semibold tabular-nums shrink-0',
+        'transition-colors duration-200',
+        classes
+      )}
+      aria-label={`Priority ${rank}`}
+    >
+      {rank}
+    </span>
+  )
+}
+
+interface SortChipButtonProps {
+  chip: SortChip
+  rank: number
+  totalChips: number
+  column: SortColumn | undefined
+  isDragging: boolean
+  isDragTarget: boolean
+  onToggleDirection: () => void
+  onCycleMode: () => void
+  onToggleNulls: () => void
+  onReseed: () => void
+  onRemove: () => void
+  onMovePriority: (delta: number) => void
+  onDragStart: (e: React.DragEvent) => void
+  onDragOver: (e: React.DragEvent) => void
+  onDrop: (e: React.DragEvent) => void
+  onDragEnd: () => void
+}
+
+function SortChipButton({
+  chip,
+  rank,
+  totalChips,
+  column,
+  isDragging,
+  isDragTarget,
+  onToggleDirection,
+  onCycleMode,
+  onToggleNulls,
+  onReseed,
+  onRemove,
+  onMovePriority,
+  onDragStart,
+  onDragOver,
+  onDrop,
+  onDragEnd
+}: SortChipButtonProps) {
+  const [isNew, setIsNew] = React.useState(true)
+  const [flipKey, setFlipKey] = React.useState(0)
+
+  React.useEffect(() => {
+    const raf = requestAnimationFrame(() => setIsNew(false))
+    return () => cancelAnimationFrame(raf)
+  }, [])
+
+  React.useEffect(() => {
+    setFlipKey((k) => k + 1)
+  }, [chip.direction, chip.mode])
+
+  const typeColor = column ? getTypeColor(column.dataType) : 'text-muted-foreground'
+  const isRandom = chip.mode === 'random'
+  const modeShort = modeLabel(chip, column)
+  const showMode = chip.mode !== 'default' || isRandom
+
+  const ariaLabel = `Sort ${chip.column} ${chip.direction}${
+    showMode ? ', mode ' + modeShort : ''
+  }, priority ${rank} of ${totalChips}`
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowLeft' && (e.metaKey || e.ctrlKey || e.altKey)) {
+      e.preventDefault()
+      onMovePriority(-1)
+      return
+    }
+    if (e.key === 'ArrowRight' && (e.metaKey || e.ctrlKey || e.altKey)) {
+      e.preventDefault()
+      onMovePriority(1)
+      return
+    }
+    if (e.key === 'Backspace' || e.key === 'Delete') {
+      e.preventDefault()
+      onRemove()
+      return
+    }
+    if (e.key === ' ' || e.key === 'Enter') {
+      e.preventDefault()
+      onToggleDirection()
+      return
+    }
+    if (e.key === 'm' || e.key === 'M') {
+      e.preventDefault()
+      onCycleMode()
+    }
+  }
+
+  return (
+    <div
+      role="listitem"
+      tabIndex={0}
+      aria-label={ariaLabel}
+      draggable
+      onDragStart={onDragStart}
+      onDragOver={onDragOver}
+      onDrop={onDrop}
+      onDragEnd={onDragEnd}
+      onKeyDown={onKeyDown}
+      className={cn(
+        'group/chip relative flex items-center gap-1 pl-1 pr-1 py-0.5 rounded-md text-xs',
+        'border cursor-grab active:cursor-grabbing select-none',
+        'transition-[border-color,background-color,transform,opacity,box-shadow] duration-150',
+        'hover:border-primary/40 hover:bg-primary/5',
+        'focus-visible:outline-none focus-visible:border-primary/60 focus-visible:ring-1 focus-visible:ring-primary/40',
+        isNew &&
+          'motion-safe:animate-in motion-safe:fade-in-0 motion-safe:zoom-in-90 motion-safe:slide-in-from-left-1 motion-safe:duration-200',
+        isDragging && 'opacity-40 scale-95',
+        isDragTarget && 'border-primary/60 bg-primary/10 ring-1 ring-primary/30 scale-[1.02]',
+        !isDragging && !isDragTarget && 'border-border/60 bg-muted/50'
+      )}
+    >
+      <span className="inline-flex items-center pl-0.5 opacity-0 group-hover/chip:opacity-100 transition-opacity duration-150">
+        <GripVertical className="size-3 text-muted-foreground/60" />
+      </span>
+
+      <PriorityBadge rank={rank} />
+
+      <span className={cn('font-medium px-0.5', typeColor)}>{chip.column}</span>
+
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation()
+          onToggleDirection()
+        }}
+        title={`Direction: ${chip.direction}${isRandom ? ' (n/a for shuffle)' : ''}`}
+        className={cn(
+          'inline-flex items-center justify-center size-4 rounded-sm',
+          'hover:bg-primary/10 text-foreground/80 hover:text-primary',
+          'transition-colors duration-100',
+          isRandom && 'opacity-40'
+        )}
+        disabled={isRandom}
+      >
+        <span
+          key={flipKey}
+          className="inline-flex motion-safe:animate-in motion-safe:spin-in-180 motion-safe:duration-200"
+        >
+          {chip.direction === 'asc' ? (
+            <ArrowUp className="size-3" />
+          ) : (
+            <ArrowDown className="size-3" />
+          )}
+        </span>
+      </button>
+
+      {showMode && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation()
+            onCycleMode()
+          }}
+          title="Cycle sort mode"
+          className={cn(
+            'px-1 py-0 rounded-sm text-[9px] font-mono lowercase',
+            'text-primary/80 hover:text-primary bg-primary/[0.08] hover:bg-primary/15',
+            'transition-colors duration-100'
+          )}
+        >
+          {modeShort}
+        </button>
+      )}
+
+      {isRandom && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation()
+            onReseed()
+          }}
+          title={`Seed: ${chip.seed} — click to reroll`}
+          className={cn(
+            'inline-flex items-center justify-center size-4 rounded-sm',
+            'hover:bg-primary/10 text-foreground/70 hover:text-primary',
+            'transition-[color,background-color,transform] duration-150',
+            'hover:rotate-12'
+          )}
+        >
+          <Dices className="size-3" />
+        </button>
+      )}
+
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation()
+          onToggleNulls()
+        }}
+        title={`Nulls ${chip.nullsPosition}`}
+        className={cn(
+          'inline-flex items-center justify-center size-4 rounded-sm opacity-0 group-hover/chip:opacity-100',
+          'text-muted-foreground hover:text-foreground hover:bg-muted/80',
+          'transition-opacity duration-150'
+        )}
+      >
+        {chip.nullsPosition === 'first' ? (
+          <CircleDashed className="size-3" />
+        ) : (
+          <CircleDot className="size-3" />
+        )}
+      </button>
+
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation()
+          onRemove()
+        }}
+        className={cn(
+          'ml-0.5 inline-flex items-center justify-center size-4 rounded-sm',
+          'opacity-0 group-hover/chip:opacity-100',
+          'text-muted-foreground hover:text-foreground hover:bg-muted/80',
+          'transition-opacity duration-100'
+        )}
+        title="Remove sort"
+      >
+        <X className="size-3" />
+      </button>
+    </div>
+  )
+}
+
+interface PresetDef {
+  id: string
+  label: string
+  icon: React.ComponentType<{ className?: string }>
+  description: string
+  build: (cols: SortColumn[]) => SortChip[] | null
+}
+
+function pickColumn(cols: SortColumn[], category: TypeCategory): SortColumn | undefined {
+  return cols.find((c) => getTypeCategory(c.dataType) === category)
+}
+
+function newSeed(): number {
+  return Math.floor(Math.random() * 1_000_000)
+}
+
+function makeChip(col: SortColumn, direction: SortDirection, mode: SortMode = 'default'): SortChip {
+  const base = {
+    id: nextChipId(),
+    column: col.name,
+    direction,
+    nullsPosition: 'last' as const
+  }
+  if (mode === 'random') {
+    return { ...base, mode: 'random', seed: newSeed() }
+  }
+  return { ...base, mode }
+}
+
+const PRESETS: PresetDef[] = [
+  {
+    id: 'newest',
+    label: 'Newest first',
+    icon: CalendarClock,
+    description: 'Sort by the first timestamp, descending',
+    build: (cols) => {
+      const col = pickColumn(cols, 'date')
+      return col ? [makeChip(col, 'desc')] : null
+    }
+  },
+  {
+    id: 'oldest',
+    label: 'Oldest first',
+    icon: Clock,
+    description: 'Sort by the first timestamp, ascending',
+    build: (cols) => {
+      const col = pickColumn(cols, 'date')
+      return col ? [makeChip(col, 'asc')] : null
+    }
+  },
+  {
+    id: 'az',
+    label: 'A → Z',
+    icon: ArrowDownAZ,
+    description: 'First text column, alphabetical',
+    build: (cols) => {
+      const col = pickColumn(cols, 'string')
+      return col ? [makeChip(col, 'asc')] : null
+    }
+  },
+  {
+    id: 'za',
+    label: 'Z → A',
+    icon: ArrowDownZA,
+    description: 'First text column, reversed',
+    build: (cols) => {
+      const col = pickColumn(cols, 'string')
+      return col ? [makeChip(col, 'desc')] : null
+    }
+  },
+  {
+    id: 'largest',
+    label: 'Largest first',
+    icon: ArrowDown10,
+    description: 'First numeric column, descending',
+    build: (cols) => {
+      const col = pickColumn(cols, 'numeric')
+      return col ? [makeChip(col, 'desc')] : null
+    }
+  },
+  {
+    id: 'smallest',
+    label: 'Smallest first',
+    icon: ArrowDown01,
+    description: 'First numeric column, ascending',
+    build: (cols) => {
+      const col = pickColumn(cols, 'numeric')
+      return col ? [makeChip(col, 'asc')] : null
+    }
+  },
+  {
+    id: 'shuffle',
+    label: 'Shuffle',
+    icon: Shuffle,
+    description: 'Random seeded order (any column)',
+    build: (cols) => {
+      const col = cols[0]
+      return col ? [makeChip(col, 'asc', 'random')] : null
+    }
+  }
+]
+
+interface SmartSortBarProps {
+  columns: SortColumn[]
+  chips: SortChip[]
+  onChipsChange: (chips: SortChip[]) => void
+  onApplyToQuery?: () => void
+  className?: string
+}
+
+export function SmartSortBar({
+  columns,
+  chips,
+  onChipsChange,
+  onApplyToQuery,
+  className
+}: SmartSortBarProps) {
+  const [isPicking, setIsPicking] = React.useState(false)
+  const [query, setQuery] = React.useState('')
+  const [highlighted, setHighlighted] = React.useState(0)
+  const [dragId, setDragId] = React.useState<string | null>(null)
+  const [dragOverId, setDragOverId] = React.useState<string | null>(null)
+
+  const inputRef = React.useRef<HTMLInputElement>(null)
+  const barRef = React.useRef<HTMLDivElement>(null)
+  const dropdownRef = React.useRef<HTMLDivElement>(null)
+
+  const columnByName = React.useMemo(() => {
+    const m = new Map<string, SortColumn>()
+    for (const c of columns) m.set(c.name, c)
+    return m
+  }, [columns])
+
+  const availableColumns = React.useMemo(() => {
+    const used = new Set(chips.map((c) => c.column))
+    return columns.filter((c) => !used.has(c.name))
+  }, [columns, chips])
+
+  const filteredColumns = React.useMemo(() => {
+    if (!query.trim()) return availableColumns
+    const q = query.toLowerCase()
+    return availableColumns.filter(
+      (c) => c.name.toLowerCase().includes(q) || c.dataType.toLowerCase().includes(q)
+    )
+  }, [availableColumns, query])
+
+  const availablePresets = React.useMemo(() => {
+    return PRESETS.filter((p) => {
+      if (!query.trim()) return true
+      const q = query.toLowerCase()
+      return p.label.toLowerCase().includes(q) || p.description.toLowerCase().includes(q)
+    })
+  }, [query])
+
+  React.useEffect(() => {
+    setHighlighted(0)
+  }, [filteredColumns.length, availablePresets.length, query])
+
+  const startPicking = React.useCallback(() => {
+    setIsPicking(true)
+    setQuery('')
+  }, [])
+
+  React.useEffect(() => {
+    if (isPicking) inputRef.current?.focus()
+  }, [isPicking])
+
+  const cancelPicking = React.useCallback(() => {
+    setIsPicking(false)
+    setQuery('')
+  }, [])
+
+  const addChip = React.useCallback(
+    (col: SortColumn) => {
+      const chip = makeChip(col, defaultDirectionForType(col.dataType))
+      onChipsChange([...chips, chip])
+      cancelPicking()
+    },
+    [chips, onChipsChange, cancelPicking]
+  )
+
+  const applyPreset = React.useCallback(
+    (preset: PresetDef) => {
+      const next = preset.build(columns)
+      if (next && next.length > 0) {
+        onChipsChange(next)
+      }
+      cancelPicking()
+    },
+    [columns, onChipsChange, cancelPicking]
+  )
+
+  const removeChip = React.useCallback(
+    (id: string) => {
+      onChipsChange(chips.filter((c) => c.id !== id))
+    },
+    [chips, onChipsChange]
+  )
+
+  const transformChip = React.useCallback(
+    (id: string, transform: (chip: SortChip) => SortChip) => {
+      onChipsChange(chips.map((c) => (c.id === id ? transform(c) : c)))
+    },
+    [chips, onChipsChange]
+  )
+
+  const toggleDirection = React.useCallback(
+    (id: string) => {
+      transformChip(id, (c) => ({ ...c, direction: c.direction === 'asc' ? 'desc' : 'asc' }))
+    },
+    [transformChip]
+  )
+
+  const cycleMode = React.useCallback(
+    (id: string) => {
+      transformChip(id, (c) => {
+        const col = columnByName.get(c.column)
+        if (!col) return c
+        const modes = modesForType(col.dataType)
+        const idx = modes.findIndex((m) => m.value === c.mode)
+        const next = modes[(idx + 1) % modes.length]
+        const base = {
+          id: c.id,
+          column: c.column,
+          direction: c.direction,
+          nullsPosition: c.nullsPosition
+        }
+        if (next.value === 'random') {
+          return { ...base, mode: 'random', seed: c.mode === 'random' ? c.seed : newSeed() }
+        }
+        return { ...base, mode: next.value }
+      })
+    },
+    [columnByName, transformChip]
+  )
+
+  const toggleNulls = React.useCallback(
+    (id: string) => {
+      transformChip(id, (c) => ({
+        ...c,
+        nullsPosition: c.nullsPosition === 'first' ? 'last' : 'first'
+      }))
+    },
+    [transformChip]
+  )
+
+  const reseed = React.useCallback(
+    (id: string) => {
+      transformChip(id, (c) => (c.mode === 'random' ? { ...c, seed: newSeed() } : c))
+    },
+    [transformChip]
+  )
+
+  const movePriority = React.useCallback(
+    (id: string, delta: number) => {
+      const idx = chips.findIndex((c) => c.id === id)
+      if (idx < 0) return
+      const target = Math.max(0, Math.min(chips.length - 1, idx + delta))
+      if (target === idx) return
+      const next = chips.slice()
+      const [moved] = next.splice(idx, 1)
+      next.splice(target, 0, moved)
+      onChipsChange(next)
+    },
+    [chips, onChipsChange]
+  )
+
+  const clearAll = React.useCallback(() => {
+    onChipsChange([])
+    cancelPicking()
+  }, [onChipsChange, cancelPicking])
+
+  const handleDragStart = React.useCallback((id: string, e: React.DragEvent) => {
+    setDragId(id)
+    e.dataTransfer.effectAllowed = 'move'
+    e.dataTransfer.setData('text/plain', id)
+  }, [])
+
+  const handleDragOver = React.useCallback(
+    (id: string, e: React.DragEvent) => {
+      if (!dragId || dragId === id) return
+      e.preventDefault()
+      e.dataTransfer.dropEffect = 'move'
+      setDragOverId(id)
+    },
+    [dragId]
+  )
+
+  const handleDrop = React.useCallback(
+    (targetId: string, e: React.DragEvent) => {
+      e.preventDefault()
+      if (!dragId || dragId === targetId) {
+        setDragId(null)
+        setDragOverId(null)
+        return
+      }
+      const fromIdx = chips.findIndex((c) => c.id === dragId)
+      const toIdx = chips.findIndex((c) => c.id === targetId)
+      if (fromIdx < 0 || toIdx < 0) {
+        setDragId(null)
+        setDragOverId(null)
+        return
+      }
+      const next = chips.slice()
+      const [moved] = next.splice(fromIdx, 1)
+      next.splice(toIdx, 0, moved)
+      onChipsChange(next)
+      setDragId(null)
+      setDragOverId(null)
+    },
+    [dragId, chips, onChipsChange]
+  )
+
+  const handleDragEnd = React.useCallback(() => {
+    setDragId(null)
+    setDragOverId(null)
+  }, [])
+
+  const dropdownRowCount = filteredColumns.length + availablePresets.length
+
+  const handleKeyDown = React.useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        cancelPicking()
+        inputRef.current?.blur()
+        return
+      }
+      if (e.key === 'Backspace' && !query && chips.length > 0 && !isPicking) {
+        e.preventDefault()
+        removeChip(chips[chips.length - 1].id)
+        return
+      }
+      if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        setHighlighted((i) => Math.min(i + 1, dropdownRowCount - 1))
+        return
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        setHighlighted((i) => Math.max(i - 1, 0))
+        return
+      }
+      if (e.key === 'Enter') {
+        e.preventDefault()
+        if (highlighted < availablePresets.length) {
+          applyPreset(availablePresets[highlighted])
+        } else {
+          const colIdx = highlighted - availablePresets.length
+          const col = filteredColumns[colIdx]
+          if (col) addChip(col)
+        }
+      }
+    },
+    [
+      query,
+      chips,
+      isPicking,
+      dropdownRowCount,
+      highlighted,
+      availablePresets,
+      filteredColumns,
+      cancelPicking,
+      removeChip,
+      applyPreset,
+      addChip
+    ]
+  )
+
+  React.useEffect(() => {
+    const onGlobalKey = (e: KeyboardEvent) => {
+      if (!((e.metaKey || e.ctrlKey) && e.shiftKey && (e.key === 'S' || e.key === 's'))) return
+      if (!barRef.current || barRef.current.offsetParent === null) return
+      const target = e.target as HTMLElement | null
+      if (target) {
+        if (target.closest('.monaco-editor') || target.closest('[data-monaco-editor]')) return
+        const isEditable =
+          target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable
+        if (isEditable && target !== inputRef.current && !barRef.current.contains(target)) return
+      }
+      e.preventDefault()
+      if (!isPicking) startPicking()
+      inputRef.current?.focus()
+    }
+    document.addEventListener('keydown', onGlobalKey)
+    return () => document.removeEventListener('keydown', onGlobalKey)
+  }, [isPicking, startPicking])
+
+  React.useEffect(() => {
+    if (!isPicking) return
+    const onClickOutside = (e: MouseEvent) => {
+      if (
+        barRef.current &&
+        !barRef.current.contains(e.target as Node) &&
+        dropdownRef.current &&
+        !dropdownRef.current.contains(e.target as Node)
+      ) {
+        cancelPicking()
+      }
+    }
+    document.addEventListener('mousedown', onClickOutside)
+    return () => document.removeEventListener('mousedown', onClickOutside)
+  }, [isPicking, cancelPicking])
+
+  React.useEffect(() => {
+    if (!isPicking || !dropdownRef.current) return
+    const el = dropdownRef.current.querySelector('[data-highlighted="true"]')
+    el?.scrollIntoView({ block: 'nearest' })
+  }, [highlighted, isPicking])
+
+  const hasSort = chips.length > 0
+  const placeholder = hasSort ? 'Add sort…' : 'Sort rows… (\u2318\u21E7S)'
+
+  return (
+    <div className={cn('relative', className)}>
+      <div
+        ref={barRef}
+        className={cn(
+          'flex items-center gap-1.5 px-2 py-1.5 border-b',
+          'transition-[border-color,background-color] duration-200 ease-out',
+          hasSort ? 'border-primary/20 bg-primary/[0.02]' : 'border-border/30'
+        )}
+      >
+        <ArrowDownUp
+          className={cn(
+            'size-3.5 shrink-0 transition-colors duration-200',
+            hasSort ? 'text-primary/70' : 'text-muted-foreground/50'
+          )}
+        />
+
+        <div
+          role="list"
+          aria-label="Active sort priorities"
+          className="flex items-center gap-1 flex-wrap flex-1 min-w-0"
+        >
+          {chips.map((chip, idx) => {
+            const col = columnByName.get(chip.column)
+            return (
+              <SortChipButton
+                key={chip.id}
+                chip={chip}
+                rank={idx + 1}
+                totalChips={chips.length}
+                column={col}
+                isDragging={dragId === chip.id}
+                isDragTarget={dragOverId === chip.id && dragId !== chip.id}
+                onToggleDirection={() => toggleDirection(chip.id)}
+                onCycleMode={() => cycleMode(chip.id)}
+                onToggleNulls={() => toggleNulls(chip.id)}
+                onReseed={() => reseed(chip.id)}
+                onRemove={() => removeChip(chip.id)}
+                onMovePriority={(delta) => movePriority(chip.id, delta)}
+                onDragStart={(e) => handleDragStart(chip.id, e)}
+                onDragOver={(e) => handleDragOver(chip.id, e)}
+                onDrop={(e) => handleDrop(chip.id, e)}
+                onDragEnd={handleDragEnd}
+              />
+            )
+          })}
+
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onFocus={() => {
+              if (!isPicking) startPicking()
+            }}
+            onKeyDown={handleKeyDown}
+            placeholder={placeholder}
+            className={cn(
+              'flex-1 min-w-[120px] h-6 bg-transparent text-xs outline-none',
+              'placeholder:text-muted-foreground/40'
+            )}
+            spellCheck={false}
+            autoComplete="off"
+          />
+        </div>
+
+        <div className="flex items-center gap-1.5 shrink-0">
+          {hasSort && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-6 px-1.5 text-[10px] text-muted-foreground hover:text-foreground gap-1"
+              onClick={clearAll}
+            >
+              <X className="size-3" />
+              Clear
+            </Button>
+          )}
+
+          {hasSort && onApplyToQuery && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-6 px-1.5 text-[10px] text-primary/80 hover:text-primary gap-1"
+              onClick={onApplyToQuery}
+              title="Push sort into ORDER BY clause"
+            >
+              <Sparkles className="size-3" />
+              Apply
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {isPicking && (
+        <div
+          ref={dropdownRef}
+          className={cn(
+            'absolute left-0 top-full z-50 mt-0.5',
+            'w-80 max-h-72 overflow-auto',
+            'rounded-lg border border-border/60 bg-popover shadow-lg',
+            'motion-safe:animate-in motion-safe:fade-in-0 motion-safe:slide-in-from-top-1 motion-safe:duration-150'
+          )}
+        >
+          {availablePresets.length > 0 && (
+            <>
+              <div className="px-2.5 py-1.5 text-[10px] font-medium text-muted-foreground/60 uppercase tracking-wider border-b border-border/30">
+                Quick presets
+              </div>
+              {availablePresets.map((preset, i) => {
+                const Icon = preset.icon
+                const isHi = i === highlighted
+                return (
+                  <button
+                    key={preset.id}
+                    data-highlighted={isHi}
+                    className={cn(
+                      'w-full flex items-center gap-2 px-2.5 py-1.5 text-xs',
+                      'cursor-pointer transition-colors duration-75',
+                      isHi
+                        ? 'bg-primary/10 text-foreground'
+                        : 'text-foreground/80 hover:bg-muted/60'
+                    )}
+                    onClick={() => applyPreset(preset)}
+                    onMouseEnter={() => setHighlighted(i)}
+                  >
+                    <Icon className="size-3 text-primary/70 shrink-0" />
+                    <span className="font-medium">{preset.label}</span>
+                    <span className="ml-auto text-[10px] text-muted-foreground/70 truncate">
+                      {preset.description}
+                    </span>
+                  </button>
+                )
+              })}
+            </>
+          )}
+
+          {filteredColumns.length > 0 && (
+            <>
+              <div className="px-2.5 py-1.5 text-[10px] font-medium text-muted-foreground/60 uppercase tracking-wider border-y border-border/30">
+                {query ? 'Matching columns' : 'Columns'}
+              </div>
+              {filteredColumns.map((col, i) => {
+                const idx = i + availablePresets.length
+                const isHi = idx === highlighted
+                return (
+                  <button
+                    key={col.name}
+                    data-highlighted={isHi}
+                    className={cn(
+                      'w-full flex items-center justify-between px-2.5 py-1.5 text-xs',
+                      'cursor-pointer transition-colors duration-75',
+                      isHi
+                        ? 'bg-primary/10 text-foreground'
+                        : 'text-foreground/80 hover:bg-muted/60'
+                    )}
+                    onClick={() => addChip(col)}
+                    onMouseEnter={() => setHighlighted(idx)}
+                  >
+                    <span className="font-medium">{col.name}</span>
+                    <span className={cn('text-[10px]', getTypeColor(col.dataType))}>
+                      {col.dataType}
+                    </span>
+                  </button>
+                )
+              })}
+            </>
+          )}
+
+          {filteredColumns.length === 0 && availablePresets.length === 0 && (
+            <div className="px-2.5 py-4 text-xs text-muted-foreground/60 text-center">
+              No matching columns or presets
+            </div>
+          )}
+
+          {availableColumns.length === 0 && query === '' && (
+            <div className="px-2.5 py-2 text-[10px] text-muted-foreground/60 text-center border-t border-border/30">
+              All columns are in the sort stack
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function toggleColumnSort(
+  chips: SortChip[],
+  column: SortColumn,
+  opts: { multi?: boolean } = {}
+): SortChip[] {
+  const existing = chips.find((c) => c.column === column.name)
+
+  if (!existing) {
+    const newChip: SortChip = {
+      id: nextChipId(),
+      column: column.name,
+      direction: defaultDirectionForType(column.dataType),
+      mode: 'default',
+      nullsPosition: 'last'
+    }
+    return opts.multi ? [...chips, newChip] : [newChip]
+  }
+
+  const flipped: SortChip = {
+    ...existing,
+    direction: existing.direction === 'asc' ? 'desc' : 'asc'
+  }
+  if (opts.multi) return chips.map((c) => (c.id === existing.id ? flipped : c))
+  return [flipped]
+}


### PR DESCRIPTION
## Summary

Adds a chip-based multi-column sort bar parallel to the existing [smart-filter-bar.tsx](apps/desktop/src/renderer/src/components/smart-filter-bar.tsx). Replaces TanStack's single-column internal sort state with a composable priority stack that supports type-aware modes, keyboard reorder, and sensible defaults for SQL column types.

## What's new

- **Multi-sort chips** with cascading OKLCH-primary priority badges (rank 1 solid, rank 2 70%, rank 3 50%).
- **Type-aware modes** per column category:
  - Strings: default (lexical) · natural (\`item2\` before \`item10\`) · by length · shuffle
  - Numbers: default · absolute (\`|x|\`) · shuffle
  - Dates: chronological · by month · by weekday (Mon=0…Sun=6) · time-of-day · shuffle
  - Booleans: default · shuffle
- **Drag to reorder** priority via HTML5 drag; keyboard users reorder with ⌥/⌘+←→ on the focused chip.
- **Nulls first/last** toggle per chip; invalid dates route through the nulls path instead of sorting as phantom bucket -1.
- **Random mode** uses a seeded \`mulberry32\` stream per chip. The dice icon rerolls the seed.
- **Quick presets**: Newest first · Oldest first · A→Z · Z→A · Largest · Smallest · Shuffle — auto-pick the first column of the right category.
- **Keyboard**: \`⌘⇧S\` focuses the bar (scoped to the visible instance; bails when target is Monaco or another editable field).
- **Column headers** still work as click-to-sort; shift/⌘-click appends for multi-sort. Repeated clicks cycle direction without removing the chip, so user mode/nulls/seed customizations survive.

## Design

- \`SortChip\` is a discriminated union on \`mode\` — the compiler now requires a \`seed\` when \`mode === 'random'\` and forbids it otherwise.
- \`applySorts\` takes the columns array and dispatches by declared \`TypeCategory\` (no cross-type sniffing that silently reorders string columns as numbers or dates).
- Per-chip random maps (\`Map<chipId, number[]>\` keyed by input-array index) are stable across re-renders and independent per seed.
- Pagination resets to page 1 when sort/filter chips change, so users don't land on an empty page after filtering.
- Chips are \`role=\"listitem\"\` with \`aria-label\`, \`tabIndex=0\`, and keyboard handlers for Space/Enter (toggle direction), Delete/Backspace (remove), \`M\` (cycle mode).

## Test plan

- [x] \`pnpm typecheck:web\` — clean
- [x] \`pnpm test --run\` — 438 passing (35 new in \`smart-sort-bar.test.ts\` covering comparator paths, null handling, stable-sort invariant, byDayOfWeek/byTime/byMonth/absolute modes, independent random seeds, \`toggleColumnSort\` cycle semantics)
- [x] ESLint clean on the four changed files
- [ ] Manual: exercise drag-to-reorder, multi-sort via shift-click headers, preset apply, shuffle reroll, keyboard reorder with ⌘+←→ on focused chip
- [ ] Manual: verify \`⌘⇧S\` does not steal focus while typing in the Monaco editor or an edit cell

## Files

- **New:** \`apps/desktop/src/renderer/src/components/smart-sort-bar.tsx\`
- **New:** \`apps/desktop/src/renderer/src/components/__tests__/smart-sort-bar.test.ts\`
- **Modified:** \`apps/desktop/src/renderer/src/components/data-table.tsx\`, \`editable-data-table.tsx\` — integrate the bar, pre-sort data before TanStack, dispatch header clicks to chip state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Advanced multi-column sorting with diverse modes: natural text ordering, string length, numeric absolute values, date/time grouping by month/day/time, and random shuffle with deterministic seeding
  * Interactive sorting interface with draggable sort chips and keyboard/mouse controls for reordering and mode changes
  * Quick sort presets based on column type (newest/oldest, alphabetical, size-based, shuffle)
  * Configurable null value placement (first or last) for each sorted column
  * Sort configuration management with Clear and Apply actions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->