### PR TITLE
perf(postgres): pool client connections per saved connection

### DIFF
--- a/apps/desktop/scripts/pool-smoke.test.ts
+++ b/apps/desktop/scripts/pool-smoke.test.ts
@@ -1,0 +1,202 @@
+// Live smoke test against a real Postgres (Docker container). Not part of `pnpm test` —
+// run explicitly with: pnpm --filter @data-peek/desktop exec vitest run scripts/pool-smoke.test.ts
+//
+// Required env (with sensible defaults pointing at the docker container the smoke harness spins up):
+//   PGHOST=localhost PGPORT=55432 PGUSER=postgres PGPASSWORD=smoketest PGDATABASE=acme
+import { describe, it, expect, afterAll, beforeAll, vi } from 'vitest'
+import type { ConnectionConfig } from '@shared/index'
+
+// The main-process logger imports `electron` which isn't available outside Electron.
+vi.mock('../src/main/lib/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}))
+
+const { withPgClient, withPgTransaction, closePgPool, closeAllPgPools } = await import(
+  '../src/main/adapters/pg-pool-manager'
+)
+const { registerQuery, cancelQuery } = await import('../src/main/query-tracker')
+
+const config: ConnectionConfig = {
+  id: 'smoke-pool',
+  name: 'smoke',
+  host: process.env.PGHOST ?? 'localhost',
+  port: Number(process.env.PGPORT ?? 55432),
+  database: process.env.PGDATABASE ?? 'acme',
+  user: process.env.PGUSER ?? 'postgres',
+  password: process.env.PGPASSWORD ?? 'smoketest',
+  dbType: 'postgresql',
+  dstPort: Number(process.env.PGPORT ?? 55432)
+}
+
+beforeAll(async () => {
+  // Sanity: confirm we can connect at all before running the rest.
+  await withPgClient(config, async (c) => {
+    const r = await c.query('SELECT current_database() AS db')
+    if (r.rows[0].db !== config.database) throw new Error('wrong database')
+  })
+})
+
+afterAll(async () => {
+  await closeAllPgPools()
+})
+
+describe('pool latency', () => {
+  it('warm-pool queries are dramatically faster than cold-pool first query', async () => {
+    // Drop any pool from beforeAll to start cold.
+    await closePgPool(config)
+
+    const cold = Date.now()
+    await withPgClient(config, async (c) => {
+      await c.query('SELECT 1')
+    })
+    const coldMs = Date.now() - cold
+
+    const warmStart = Date.now()
+    for (let i = 0; i < 5; i++) {
+      await withPgClient(config, async (c) => {
+        await c.query('SELECT 1')
+      })
+    }
+    const warmAvgMs = (Date.now() - warmStart) / 5
+
+    // eslint-disable-next-line no-console
+    console.log(`cold=${coldMs}ms warm-avg=${warmAvgMs.toFixed(2)}ms`)
+    expect(coldMs).toBeGreaterThan(warmAvgMs)
+    // On loopback the absolute number is small; we still expect ~order-of-magnitude.
+    expect(warmAvgMs).toBeLessThan(coldMs)
+  })
+})
+
+describe('concurrent first-use sharing', () => {
+  it('10 parallel callers share one pool with no errors', async () => {
+    await closePgPool(config)
+    const results = await Promise.all(
+      Array.from({ length: 10 }, () =>
+        withPgClient(config, async (c) => {
+          const r = await c.query('SELECT pg_backend_pid() AS pid')
+          return Number(r.rows[0].pid)
+        })
+      )
+    )
+    expect(results).toHaveLength(10)
+    // Pool max=5, so at most 5 distinct PIDs are observed (some get reused by sequential acquires).
+    const distinct = new Set(results).size
+    expect(distinct).toBeGreaterThan(0)
+    expect(distinct).toBeLessThanOrEqual(5)
+    // eslint-disable-next-line no-console
+    console.log(`10 concurrent acquires used ${distinct} distinct backends`)
+  })
+})
+
+describe('withPgTransaction against real Postgres', () => {
+  it('COMMIT persists rows', async () => {
+    await withPgClient(config, async (c) => {
+      await c.query('CREATE TABLE IF NOT EXISTS smoke_tx (n int)')
+      await c.query('TRUNCATE smoke_tx')
+    })
+
+    await withPgTransaction(config, async (c) => {
+      await c.query('INSERT INTO smoke_tx VALUES (1), (2)')
+    })
+
+    await withPgClient(config, async (c) => {
+      const r = await c.query('SELECT count(*)::int AS n FROM smoke_tx')
+      expect(r.rows[0].n).toBe(2)
+    })
+  })
+
+  it('ROLLBACK on fn error rejects with the original error and discards the writes', async () => {
+    const original = new Error('intentional')
+    await expect(
+      withPgTransaction(config, async (c) => {
+        await c.query('INSERT INTO smoke_tx VALUES (99)')
+        throw original
+      })
+    ).rejects.toBe(original)
+
+    await withPgClient(config, async (c) => {
+      const r = await c.query('SELECT count(*)::int AS n FROM smoke_tx WHERE n = 99')
+      expect(r.rows[0].n).toBe(0)
+    })
+  })
+
+  it('ROLLBACK on a SQL error still rolls back the prior writes in the same tx', async () => {
+    await expect(
+      withPgTransaction(config, async (c) => {
+        await c.query('INSERT INTO smoke_tx VALUES (42)')
+        await c.query('SELECT * FROM nonexistent_table_xyz')
+      })
+    ).rejects.toThrow(/nonexistent_table_xyz/)
+
+    await withPgClient(config, async (c) => {
+      const r = await c.query('SELECT count(*)::int AS n FROM smoke_tx WHERE n = 42')
+      expect(r.rows[0].n).toBe(0)
+    })
+  })
+})
+
+describe('query cancellation', () => {
+  it('cancel via release(true) aborts an in-flight long query', async () => {
+    const exec = 'smoke-cancel-1'
+    const start = Date.now()
+    const queryPromise = withPgClient(config, async (client) => {
+      registerQuery(exec, { type: 'postgresql', client })
+      try {
+        await client.query('SELECT pg_sleep(30)')
+      } finally {
+        // unregister even on failure — mimics adapter's queryMultiple
+      }
+    })
+    // Give the query 200ms to start, then cancel.
+    await new Promise((r) => setTimeout(r, 200))
+    const cancelResult = await cancelQuery(exec)
+    expect(cancelResult.cancelled).toBe(true)
+
+    await expect(queryPromise).rejects.toBeTruthy()
+    const elapsed = Date.now() - start
+    // eslint-disable-next-line no-console
+    console.log(`cancel aborted 30s sleep after ${elapsed}ms`)
+    expect(elapsed).toBeLessThan(5_000)
+
+    // Pool should still be usable after the cancel destroyed one client.
+    await withPgClient(config, async (c) => {
+      const r = await c.query('SELECT 1 AS ok')
+      expect(r.rows[0].ok).toBe(1)
+    })
+  })
+})
+
+describe('closePgPool', () => {
+  it('forces a fresh pool/backend on next acquire', async () => {
+    const pidBefore = await withPgClient(config, async (c) => {
+      const r = await c.query('SELECT pg_backend_pid() AS pid')
+      return Number(r.rows[0].pid)
+    })
+    await closePgPool(config)
+    // Wait briefly so the server-side terminate completes before the new acquire.
+    await new Promise((r) => setTimeout(r, 100))
+    const pidAfter = await withPgClient(config, async (c) => {
+      const r = await c.query('SELECT pg_backend_pid() AS pid')
+      return Number(r.rows[0].pid)
+    })
+    expect(pidAfter).not.toBe(pidBefore)
+    // eslint-disable-next-line no-console
+    console.log(`pid before=${pidBefore} after-close=${pidAfter}`)
+  })
+})
+
+describe('schema introspection on real DB', () => {
+  it('getSchemas via the adapter returns the seeded acme tables', async () => {
+    const { PostgresAdapter } = await import('../src/main/adapters/postgres-adapter')
+    const adapter = new PostgresAdapter()
+    const schemas = await adapter.getSchemas(config)
+    const pub = schemas.find((s) => s.name === 'public')
+    expect(pub).toBeDefined()
+    expect((pub?.tables ?? []).length).toBeGreaterThanOrEqual(9)
+    // eslint-disable-next-line no-console
+    console.log(
+      `getSchemas saw ${pub?.tables.length} tables in public:`,
+      pub?.tables.map((t) => t.name).join(', ')
+    )
+  })
+})

--- a/apps/desktop/src/main/__tests__/connection-handlers.test.ts
+++ b/apps/desktop/src/main/__tests__/connection-handlers.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { ConnectionConfig } from '@shared/index'
+
+type Handler = (event: unknown, ...args: unknown[]) => unknown
+
+const { handlers, closePgPool, invalidateSchemaCache, broadcastToAll } = vi.hoisted(() => ({
+  handlers: new Map<string, Handler>(),
+  closePgPool: vi.fn(),
+  invalidateSchemaCache: vi.fn(),
+  broadcastToAll: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: Handler) => {
+      handlers.set(channel, handler)
+    })
+  }
+}))
+vi.mock('../adapters/pg-pool-manager', () => ({ closePgPool }))
+vi.mock('../schema-cache', () => ({ invalidateSchemaCache }))
+vi.mock('../window-manager', () => ({ windowManager: { broadcastToAll } }))
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}))
+
+import { registerConnectionHandlers } from '../ipc/connection-handlers'
+import type { DpStorage } from '../storage'
+
+function makeStore(initial: ConnectionConfig[]) {
+  let state = initial
+  return {
+    get: vi.fn(() => state),
+    set: vi.fn((_key: string, value: ConnectionConfig[]) => {
+      state = value
+    })
+  } as unknown as DpStorage<{ connections: ConnectionConfig[] }>
+}
+
+const previous: ConnectionConfig = {
+  id: 'conn-1',
+  name: 'prod',
+  host: 'old-host.example.com',
+  port: 5432,
+  database: 'prod-db',
+  user: 'old-user',
+  password: 'old-secret',
+  dbType: 'postgresql',
+  dstPort: 5432
+}
+
+beforeEach(() => {
+  handlers.clear()
+  closePgPool.mockReset().mockResolvedValue(undefined)
+  invalidateSchemaCache.mockReset()
+  broadcastToAll.mockReset()
+})
+
+describe('connections:update', () => {
+  it('tears down the pool for the PREVIOUS config, not the new one', async () => {
+    registerConnectionHandlers(makeStore([{ ...previous }]))
+    const handler = handlers.get('connections:update')!
+
+    const result = handler(null, {
+      ...previous,
+      host: 'new-host.example.com',
+      password: 'new-secret'
+    })
+
+    expect((result as { success: boolean }).success).toBe(true)
+    // Teardown is fire-and-forget; flush the microtask queue so the .catch chain runs.
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(closePgPool).toHaveBeenCalledTimes(1)
+    expect(closePgPool).toHaveBeenCalledWith(
+      expect.objectContaining({ host: 'old-host.example.com', password: 'old-secret' })
+    )
+    expect(invalidateSchemaCache).toHaveBeenCalledWith(
+      expect.objectContaining({ host: 'old-host.example.com' })
+    )
+  })
+
+  it('does not poison the IPC response when pool teardown rejects', async () => {
+    closePgPool.mockRejectedValueOnce(new Error('pool teardown blew up'))
+    registerConnectionHandlers(makeStore([{ ...previous }]))
+    const handler = handlers.get('connections:update')!
+
+    const result = handler(null, { ...previous, host: 'new-host' })
+
+    expect((result as { success: boolean }).success).toBe(true)
+    // Let the teardown promise reject; the .catch handler should swallow it.
+    await new Promise((resolve) => setImmediate(resolve))
+  })
+
+  it('broadcasts to renderers before scheduling teardown', () => {
+    registerConnectionHandlers(makeStore([{ ...previous }]))
+    const handler = handlers.get('connections:update')!
+
+    handler(null, { ...previous, host: 'new-host' })
+
+    // broadcast should run synchronously inside the handler, before the await tick.
+    expect(broadcastToAll).toHaveBeenCalledWith('connections:updated')
+  })
+})
+
+describe('connections:delete', () => {
+  it('tears down the pool for the deleted config', async () => {
+    registerConnectionHandlers(makeStore([{ ...previous }]))
+    const handler = handlers.get('connections:delete')!
+
+    handler(null, 'conn-1')
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(closePgPool).toHaveBeenCalledWith(expect.objectContaining({ id: 'conn-1' }))
+    expect(invalidateSchemaCache).toHaveBeenCalledWith(expect.objectContaining({ id: 'conn-1' }))
+  })
+
+  it('is a no-op when the id is unknown', () => {
+    registerConnectionHandlers(makeStore([{ ...previous }]))
+    const handler = handlers.get('connections:delete')!
+
+    const result = handler(null, 'no-such-id')
+
+    expect((result as { success: boolean }).success).toBe(true)
+    expect(closePgPool).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/main/__tests__/pg-pool-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/pg-pool-manager.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { ConnectionConfig } from '@shared/index'
+
+const { mockClient, mockPool, PoolCtor } = vi.hoisted(() => {
+  const mockClient = { query: vi.fn(), release: vi.fn() }
+  const mockPool = { connect: vi.fn(), end: vi.fn(), on: vi.fn() }
+  const PoolCtor = vi.fn()
+  return { mockClient, mockPool, PoolCtor }
+})
+
+vi.mock('pg', () => ({ Pool: PoolCtor }))
+vi.mock('../ssh-tunnel-service', () => ({
+  createTunnel: vi.fn(),
+  closeTunnel: vi.fn()
+}))
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}))
+
+import { withPgClient, withPgTransaction } from '../adapters/pg-pool-manager'
+
+let counter = 0
+function makeConfig(overrides: Partial<ConnectionConfig> = {}): ConnectionConfig {
+  return {
+    id: `cfg-${++counter}`,
+    name: 'test',
+    host: 'localhost',
+    port: 5432,
+    database: 'db',
+    user: 'u',
+    password: 'p',
+    dbType: 'postgresql',
+    dstPort: 5432,
+    ...overrides
+  }
+}
+
+beforeEach(() => {
+  PoolCtor.mockReset()
+  mockClient.query.mockReset().mockResolvedValue({ rows: [], rowCount: 0 })
+  mockClient.release.mockReset()
+  mockPool.connect.mockReset().mockResolvedValue(mockClient)
+  mockPool.end.mockReset().mockResolvedValue(undefined)
+  mockPool.on.mockReset()
+  PoolCtor.mockImplementation(function (this: unknown) {
+    return mockPool
+  })
+})
+
+describe('withPgClient', () => {
+  it('shares one pool across concurrent first-use callers', async () => {
+    const cfg = makeConfig()
+
+    await Promise.all(Array.from({ length: 5 }, () => withPgClient(cfg, async () => {})))
+
+    expect(PoolCtor).toHaveBeenCalledTimes(1)
+    expect(mockPool.connect).toHaveBeenCalledTimes(5)
+    expect(mockClient.release).toHaveBeenCalledTimes(5)
+  })
+
+  it('reuses the same pool across sequential calls', async () => {
+    const cfg = makeConfig()
+
+    await withPgClient(cfg, async () => {})
+    await withPgClient(cfg, async () => {})
+    await withPgClient(cfg, async () => {})
+
+    expect(PoolCtor).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses distinct pools for distinct config ids', async () => {
+    await withPgClient(makeConfig(), async () => {})
+    await withPgClient(makeConfig(), async () => {})
+
+    expect(PoolCtor).toHaveBeenCalledTimes(2)
+  })
+
+  it('survives double-release without throwing', async () => {
+    mockClient.release.mockImplementationOnce(() => {
+      throw new Error('Release called on client which has already been released')
+    })
+
+    await expect(withPgClient(makeConfig(), async () => 'ok')).resolves.toBe('ok')
+  })
+})
+
+describe('withPgTransaction', () => {
+  it('issues BEGIN + COMMIT on success and releases cleanly', async () => {
+    await withPgTransaction(makeConfig(), async (client) => {
+      await client.query('INSERT INTO t VALUES (1)')
+    })
+
+    const calls = mockClient.query.mock.calls.map((c) => c[0])
+    expect(calls).toEqual(['BEGIN', 'INSERT INTO t VALUES (1)', 'COMMIT'])
+    expect(mockClient.release).toHaveBeenCalledWith(undefined)
+  })
+
+  it('issues BEGIN + ROLLBACK when fn throws and rethrows the original error', async () => {
+    const original = new Error('user code blew up')
+
+    await expect(
+      withPgTransaction(makeConfig(), async () => {
+        throw original
+      })
+    ).rejects.toBe(original)
+
+    const calls = mockClient.query.mock.calls.map((c) => c[0])
+    expect(calls).toEqual(['BEGIN', 'ROLLBACK'])
+    expect(mockClient.release).toHaveBeenCalledWith(undefined)
+  })
+
+  it('marks the client poisoned when ROLLBACK itself fails', async () => {
+    const original = new Error('fn error')
+    mockClient.query.mockImplementation((sql: string) => {
+      if (sql === 'ROLLBACK') return Promise.reject(new Error('connection broken'))
+      return Promise.resolve({ rows: [], rowCount: 0 })
+    })
+
+    await expect(
+      withPgTransaction(makeConfig(), async () => {
+        throw original
+      })
+    ).rejects.toBe(original)
+
+    expect(mockClient.release).toHaveBeenCalledWith(true)
+  })
+})

--- a/apps/desktop/src/main/__tests__/query-tracker.test.ts
+++ b/apps/desktop/src/main/__tests__/query-tracker.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}))
+
+import { registerQuery, cancelQuery } from '../query-tracker'
+
+describe('cancelQuery — postgres handle branches', () => {
+  it('calls release(true) when the handle is a PoolClient', async () => {
+    const release = vi.fn()
+    registerQuery('pool-exec', {
+      type: 'postgresql',
+      client: { release } as never
+    })
+
+    const result = await cancelQuery('pool-exec')
+
+    expect(release).toHaveBeenCalledWith(true)
+    expect(result.cancelled).toBe(true)
+  })
+
+  it('falls back to end() when the handle is a bare Client', async () => {
+    const end = vi.fn().mockResolvedValue(undefined)
+    registerQuery('client-exec', {
+      type: 'postgresql',
+      client: { end } as never
+    })
+
+    const result = await cancelQuery('client-exec')
+
+    expect(end).toHaveBeenCalled()
+    expect(result.cancelled).toBe(true)
+  })
+
+  it('returns an error rather than silently no-opping when the handle has neither method', async () => {
+    registerQuery('broken-exec', {
+      type: 'postgresql',
+      client: {} as never
+    })
+
+    const result = await cancelQuery('broken-exec')
+
+    expect(result.cancelled).toBe(false)
+    expect(result.error).toMatch(/neither release nor end/i)
+  })
+})

--- a/apps/desktop/src/main/adapters/pg-client-config.ts
+++ b/apps/desktop/src/main/adapters/pg-client-config.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from 'fs'
+import type { ClientConfig } from 'pg'
+import type { ConnectionConfig } from '@shared/index'
+
+/**
+ * Build pg ClientConfig from a ConnectionConfig.
+ *
+ * Handles SSL options for cloud databases (AWS RDS, Supabase, Neon, DigitalOcean) and
+ * accepts an `overrides` host/port pair when the connection is going through an SSH tunnel.
+ */
+export function buildClientConfig(
+  config: ConnectionConfig,
+  overrides?: { host: string; port: number }
+): ClientConfig {
+  const clientConfig: ClientConfig = {
+    host: overrides?.host ?? config.host,
+    port: overrides?.port ?? config.port,
+    database: config.database,
+    user: config.user,
+    password: config.password
+  }
+
+  if (config.ssl) {
+    const sslOptions = config.sslOptions || {}
+
+    if (sslOptions.ca) {
+      try {
+        clientConfig.ssl = {
+          rejectUnauthorized: sslOptions.rejectUnauthorized !== false,
+          ca: readFileSync(sslOptions.ca, 'utf-8')
+        }
+      } catch (err) {
+        console.error(`Failed to read CA certificate from ${sslOptions.ca}:`, err)
+        throw new Error(
+          `Failed to read CA certificate file: ${sslOptions.ca}. Please verify the file exists and is readable.`
+        )
+      }
+    } else {
+      // Default to rejectUnauthorized: false so cloud DBs with self-signed / private-CA
+      // certs work out of the box. Users opt into strict verification via the UI.
+      clientConfig.ssl = {
+        rejectUnauthorized: sslOptions.rejectUnauthorized === true
+      }
+    }
+  }
+
+  return clientConfig
+}

--- a/apps/desktop/src/main/adapters/pg-pool-manager.ts
+++ b/apps/desktop/src/main/adapters/pg-pool-manager.ts
@@ -1,0 +1,173 @@
+import { Pool, type PoolClient } from 'pg'
+import type { ConnectionConfig } from '@shared/index'
+import { closeTunnel, createTunnel, type TunnelSession } from '../ssh-tunnel-service'
+import { createLogger } from '../lib/logger'
+import { buildClientConfig } from './pg-client-config'
+
+const log = createLogger('pg-pool')
+
+/**
+ * Connection pooling for Postgres.
+ *
+ * Each saved connection gets one pg.Pool plus (optionally) one SSH tunnel that
+ * the pool's clients share. Pools are created lazily on first use and torn
+ * down via `closePgPool` when the connection is edited/deleted.
+ *
+ * Adapter methods that previously did `new Client(...) → connect → query → end`
+ * per call now go through `withPgClient`, so per-query TCP/TLS/auth handshake
+ * cost is paid once instead of on every request.
+ */
+
+interface PoolEntry {
+  pool: Pool
+  tunnel: TunnelSession | null
+}
+
+const POOL_MAX = 5
+const IDLE_TIMEOUT_MS = 30_000
+const CONNECT_TIMEOUT_MS = 15_000
+
+const pools = new Map<string, PoolEntry>()
+// Tracks in-flight pool creation so concurrent first-use callers share one tunnel/pool.
+const pendingPools = new Map<string, Promise<PoolEntry>>()
+
+function getPoolKey(config: ConnectionConfig): string {
+  if (config.id) return `pg:${config.id}`
+  // Unsaved configs (e.g. test-connect before save) fall back to a shape-based key.
+  return `pg:${config.host}:${config.port}:${config.database}:${config.user ?? 'default'}`
+}
+
+async function createPoolEntry(config: ConnectionConfig): Promise<PoolEntry> {
+  let tunnel: TunnelSession | null = null
+  if (config.ssh) {
+    tunnel = await createTunnel(config)
+  }
+  const overrides = tunnel ? { host: tunnel.localHost, port: tunnel.localPort } : undefined
+  const clientConfig = buildClientConfig(config, overrides)
+
+  const pool = new Pool({
+    ...clientConfig,
+    max: POOL_MAX,
+    idleTimeoutMillis: IDLE_TIMEOUT_MS,
+    connectionTimeoutMillis: CONNECT_TIMEOUT_MS
+  })
+
+  // pg.Pool emits 'error' for idle clients that die between checkouts (e.g. server-side
+  // timeout). Without a listener the process crashes on unhandled error.
+  pool.on('error', (err) => {
+    log.warn('idle client error:', err.message)
+  })
+
+  return { pool, tunnel }
+}
+
+async function getOrCreatePool(config: ConnectionConfig): Promise<PoolEntry> {
+  const key = getPoolKey(config)
+  const existing = pools.get(key)
+  if (existing) return existing
+
+  const inflight = pendingPools.get(key)
+  if (inflight) return inflight
+
+  const promise = createPoolEntry(config)
+    .then((entry) => {
+      pools.set(key, entry)
+      return entry
+    })
+    .finally(() => {
+      pendingPools.delete(key)
+    })
+
+  pendingPools.set(key, promise)
+  return promise
+}
+
+/**
+ * Acquire a pooled client, run `fn`, and release the client.
+ *
+ * The client is always released back to the pool, even if `fn` throws. If the
+ * caller needs the connection torn down (e.g. after a cancelled query left it
+ * in an unknown state) it can call `client.release(true)` itself.
+ */
+export async function withPgClient<T>(
+  config: ConnectionConfig,
+  fn: (client: PoolClient) => Promise<T>
+): Promise<T> {
+  const entry = await getOrCreatePool(config)
+  const client = await entry.pool.connect()
+  try {
+    return await fn(client)
+  } finally {
+    // Cancellation paths may have already destroyed this client via release(true).
+    // pg-pool throws on double-release, so swallow.
+    try {
+      client.release()
+    } catch {
+      // already released
+    }
+  }
+}
+
+/**
+ * Acquire a pooled client, BEGIN, run `fn`, then COMMIT (or ROLLBACK on failure).
+ */
+export async function withPgTransaction<T>(
+  config: ConnectionConfig,
+  fn: (client: PoolClient) => Promise<T>
+): Promise<T> {
+  const entry = await getOrCreatePool(config)
+  const client = await entry.pool.connect()
+  try {
+    await client.query('BEGIN')
+    const result = await fn(client)
+    await client.query('COMMIT')
+    return result
+  } catch (error) {
+    await client.query('ROLLBACK').catch((rollbackErr) => {
+      log.warn('rollback failed:', (rollbackErr as Error).message)
+    })
+    throw error
+  } finally {
+    try {
+      client.release()
+    } catch {
+      // already released
+    }
+  }
+}
+
+/**
+ * Close the pool (and its tunnel) for a single connection. Call when the
+ * connection is updated or deleted so subsequent queries pick up the new
+ * shape.
+ */
+export async function closePgPool(config: ConnectionConfig): Promise<void> {
+  const key = getPoolKey(config)
+  const entry = pools.get(key)
+  if (!entry) return
+  pools.delete(key)
+  try {
+    await entry.pool.end()
+  } catch (err) {
+    log.warn('error ending pool:', (err as Error).message)
+  }
+  closeTunnel(entry.tunnel)
+}
+
+/**
+ * Close every pool. Call on app shutdown.
+ */
+export async function closeAllPgPools(): Promise<void> {
+  const entries = Array.from(pools.values())
+  pools.clear()
+  await Promise.all(
+    entries.map(async (entry) => {
+      try {
+        await entry.pool.end()
+      } catch (err) {
+        log.warn('error ending pool:', (err as Error).message)
+      }
+      closeTunnel(entry.tunnel)
+    })
+  )
+}

--- a/apps/desktop/src/main/adapters/pg-pool-manager.ts
+++ b/apps/desktop/src/main/adapters/pg-pool-manager.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto'
 import { Pool, type PoolClient } from 'pg'
 import type { ConnectionConfig } from '@shared/index'
 import { closeTunnel, createTunnel, type TunnelSession } from '../ssh-tunnel-service'
@@ -12,10 +13,6 @@ const log = createLogger('pg-pool')
  * Each saved connection gets one pg.Pool plus (optionally) one SSH tunnel that
  * the pool's clients share. Pools are created lazily on first use and torn
  * down via `closePgPool` when the connection is edited/deleted.
- *
- * Adapter methods that previously did `new Client(...) → connect → query → end`
- * per call now go through `withPgClient`, so per-query TCP/TLS/auth handshake
- * cost is paid once instead of on every request.
  */
 
 interface PoolEntry {
@@ -31,37 +28,70 @@ const pools = new Map<string, PoolEntry>()
 // Tracks in-flight pool creation so concurrent first-use callers share one tunnel/pool.
 const pendingPools = new Map<string, Promise<PoolEntry>>()
 
+let shuttingDown = false
+
 function getPoolKey(config: ConnectionConfig): string {
   if (config.id) return `pg:${config.id}`
-  // Unsaved configs (e.g. test-connect before save) fall back to a shape-based key.
-  return `pg:${config.host}:${config.port}:${config.database}:${config.user ?? 'default'}`
+  // Unsaved configs (test-connect before save) hash the auth+tunnel+ssl shape so
+  // two attempts to the same host with different credentials/keys can't share a pool.
+  const fingerprint = createHash('sha256')
+    .update(
+      JSON.stringify({
+        password: config.password ?? '',
+        ssh: config.ssh ? (config.sshConfig ?? null) : null,
+        ssl: config.ssl ? (config.sslOptions ?? null) : null
+      })
+    )
+    .digest('hex')
+    .slice(0, 16)
+  return `pg:${config.host}:${config.port}:${config.database}:${config.user ?? 'default'}:${fingerprint}`
 }
 
-async function createPoolEntry(config: ConnectionConfig): Promise<PoolEntry> {
+async function createPoolEntry(config: ConnectionConfig, key: string): Promise<PoolEntry> {
   let tunnel: TunnelSession | null = null
   if (config.ssh) {
     tunnel = await createTunnel(config)
   }
-  const overrides = tunnel ? { host: tunnel.localHost, port: tunnel.localPort } : undefined
-  const clientConfig = buildClientConfig(config, overrides)
+  try {
+    const overrides = tunnel ? { host: tunnel.localHost, port: tunnel.localPort } : undefined
+    const clientConfig = buildClientConfig(config, overrides)
 
-  const pool = new Pool({
-    ...clientConfig,
-    max: POOL_MAX,
-    idleTimeoutMillis: IDLE_TIMEOUT_MS,
-    connectionTimeoutMillis: CONNECT_TIMEOUT_MS
-  })
+    const pool = new Pool({
+      ...clientConfig,
+      max: POOL_MAX,
+      idleTimeoutMillis: IDLE_TIMEOUT_MS,
+      connectionTimeoutMillis: CONNECT_TIMEOUT_MS
+    })
 
-  // pg.Pool emits 'error' for idle clients that die between checkouts (e.g. server-side
-  // timeout). Without a listener the process crashes on unhandled error.
-  pool.on('error', (err) => {
-    log.warn('idle client error:', err.message)
-  })
+    // pg.Pool emits 'error' for idle clients that die between checkouts (e.g. server-side
+    // timeout). Without a listener the process crashes on unhandled error.
+    pool.on('error', (err) => {
+      log.warn('idle client error:', err.message)
+    })
 
-  return { pool, tunnel }
+    // If the SSH tunnel dies (server restart, network blip), evict the pool entry
+    // so the next withPgClient call rebuilds tunnel+pool instead of dialing a dead port.
+    if (tunnel?.ssh) {
+      tunnel.ssh.once('close', () => {
+        const current = pools.get(key)
+        if (current && current.tunnel === tunnel) {
+          pools.delete(key)
+          current.pool.end().catch(() => {})
+        }
+      })
+    }
+
+    return { pool, tunnel }
+  } catch (err) {
+    closeTunnel(tunnel)
+    throw err
+  }
 }
 
 async function getOrCreatePool(config: ConnectionConfig): Promise<PoolEntry> {
+  if (shuttingDown) {
+    throw new Error('Pool manager is shutting down')
+  }
   const key = getPoolKey(config)
   const existing = pools.get(key)
   if (existing) return existing
@@ -69,13 +99,21 @@ async function getOrCreatePool(config: ConnectionConfig): Promise<PoolEntry> {
   const inflight = pendingPools.get(key)
   if (inflight) return inflight
 
-  const promise = createPoolEntry(config)
+  const promise = createPoolEntry(config, key)
     .then((entry) => {
+      // Don't install the entry if a closePgPool/shutdown raced and decided to drop it.
+      if (shuttingDown || pendingPools.get(key) !== promise) {
+        entry.pool.end().catch(() => {})
+        closeTunnel(entry.tunnel)
+        throw new Error('Pool was closed before initialization completed')
+      }
       pools.set(key, entry)
       return entry
     })
     .finally(() => {
-      pendingPools.delete(key)
+      if (pendingPools.get(key) === promise) {
+        pendingPools.delete(key)
+      }
     })
 
   pendingPools.set(key, promise)
@@ -117,19 +155,25 @@ export async function withPgTransaction<T>(
 ): Promise<T> {
   const entry = await getOrCreatePool(config)
   const client = await entry.pool.connect()
+  let poisoned = false
   try {
     await client.query('BEGIN')
     const result = await fn(client)
     await client.query('COMMIT')
     return result
   } catch (error) {
-    await client.query('ROLLBACK').catch((rollbackErr) => {
+    try {
+      await client.query('ROLLBACK')
+    } catch (rollbackErr) {
+      // Connection is in an unknown protocol state; mark it for destruction so the
+      // pool doesn't hand the next caller a client mid-transaction.
+      poisoned = true
       log.warn('rollback failed:', (rollbackErr as Error).message)
-    })
+    }
     throw error
   } finally {
     try {
-      client.release()
+      client.release(poisoned ? true : undefined)
     } catch {
       // already released
     }
@@ -137,15 +181,32 @@ export async function withPgTransaction<T>(
 }
 
 /**
+ * Drop the in-memory pool entry without ending the underlying pg.Pool.
+ * Used by callers that have already destroyed the pool out-of-band.
+ */
+function evictPoolEntry(key: string): PoolEntry | undefined {
+  const entry = pools.get(key)
+  if (!entry) return undefined
+  pools.delete(key)
+  return entry
+}
+
+/**
  * Close the pool (and its tunnel) for a single connection. Call when the
  * connection is updated or deleted so subsequent queries pick up the new
- * shape.
+ * shape. Awaits any in-flight pool creation so we don't leak an entry that
+ * appears after this returns.
  */
 export async function closePgPool(config: ConnectionConfig): Promise<void> {
   const key = getPoolKey(config)
-  const entry = pools.get(key)
+  const inflight = pendingPools.get(key)
+  if (inflight) {
+    pendingPools.delete(key)
+    // The .then in getOrCreatePool checks pendingPools identity and self-disposes.
+    await inflight.catch(() => {})
+  }
+  const entry = evictPoolEntry(key)
   if (!entry) return
-  pools.delete(key)
   try {
     await entry.pool.end()
   } catch (err) {
@@ -158,6 +219,7 @@ export async function closePgPool(config: ConnectionConfig): Promise<void> {
  * Close every pool. Call on app shutdown.
  */
 export async function closeAllPgPools(): Promise<void> {
+  shuttingDown = true
   const entries = Array.from(pools.values())
   pools.clear()
   await Promise.all(

--- a/apps/desktop/src/main/adapters/postgres-adapter.ts
+++ b/apps/desktop/src/main/adapters/postgres-adapter.ts
@@ -93,8 +93,12 @@ export class PostgresAdapter implements DatabaseAdapter {
   readonly dbType = 'postgresql' as const
 
   async connect(config: ConnectionConfig): Promise<void> {
-    // Warm the pool so the first user-issued query doesn't pay TCP/TLS/auth handshake.
-    await withPgClient(config, async () => {})
+    // Warm the pool AND verify the socket end-to-end. An empty callback would only
+    // exercise pool.connect(), which can hand back a cached idle client without a
+    // round-trip; SELECT 1 guarantees the connection is live.
+    await withPgClient(config, async (client) => {
+      await client.query('SELECT 1')
+    })
   }
 
   async query(config: ConnectionConfig, sql: string): Promise<AdapterQueryResult> {
@@ -222,12 +226,18 @@ export class PostgresAdapter implements DatabaseAdapter {
         }
 
         // Pooled clients persist session state across checkouts; reset what we set.
+        // If RESET fails, the client's state is unknown — drop it via release(true)
+        // so the next checkout doesn't inherit our statement_timeout.
         if (
           typeof queryTimeoutMs === 'number' &&
           Number.isFinite(queryTimeoutMs) &&
           queryTimeoutMs > 0
         ) {
-          await client.query('RESET statement_timeout').catch(() => {})
+          try {
+            await client.query('RESET statement_timeout')
+          } catch {
+            client.release(true)
+          }
         }
 
         const result: AdapterMultiQueryResult = {

--- a/apps/desktop/src/main/adapters/postgres-adapter.ts
+++ b/apps/desktop/src/main/adapters/postgres-adapter.ts
@@ -1,5 +1,3 @@
-import { Client, type ClientConfig } from 'pg'
-import { readFileSync } from 'fs'
 import { randomUUID } from 'crypto'
 import {
   resolvePostgresType,
@@ -39,9 +37,11 @@ import type {
   QueryOptions
 } from '../db-adapter'
 import { registerQuery, unregisterQuery } from '../query-tracker'
-import { closeTunnel, createTunnel, TunnelSession } from '../ssh-tunnel-service'
 import { splitStatements } from '../lib/sql-parser'
 import { telemetryCollector, TELEMETRY_PHASES } from '../telemetry-collector'
+import { withPgClient, withPgTransaction } from './pg-pool-manager'
+
+export { buildClientConfig } from './pg-client-config'
 
 /** Split SQL into statements for PostgreSQL */
 const splitPgStatements = (sql: string) => splitStatements(sql, 'postgresql')
@@ -62,52 +62,6 @@ function parsePostgresArray(value: unknown): string[] {
     }
   }
   return []
-}
-
-/**
- * Build pg Client configuration from ConnectionConfig
- * Properly handles SSL options for cloud databases like AWS RDS
- *
- * @param overrides - Optional host/port overrides (e.g., from SSH tunnel)
- */
-export function buildClientConfig(
-  config: ConnectionConfig,
-  overrides?: { host: string; port: number }
-): ClientConfig {
-  const clientConfig: ClientConfig = {
-    host: overrides?.host ?? config.host,
-    port: overrides?.port ?? config.port,
-    database: config.database,
-    user: config.user,
-    password: config.password
-  }
-
-  if (config.ssl) {
-    const sslOptions = config.sslOptions || {}
-
-    if (sslOptions.ca) {
-      try {
-        clientConfig.ssl = {
-          rejectUnauthorized: sslOptions.rejectUnauthorized !== false,
-          ca: readFileSync(sslOptions.ca, 'utf-8')
-        }
-      } catch (err) {
-        console.error(`Failed to read CA certificate from ${sslOptions.ca}:`, err)
-        throw new Error(
-          `Failed to read CA certificate file: ${sslOptions.ca}. Please verify the file exists and is readable.`
-        )
-      }
-    } else {
-      // Default to rejectUnauthorized: false so cloud DBs (AWS RDS, Supabase,
-      // Neon, DigitalOcean) with self-signed / private-CA certs work out of
-      // the box. Users who need strict verification opt in via the UI.
-      clientConfig.ssl = {
-        rejectUnauthorized: sslOptions.rejectUnauthorized === true
-      }
-    }
-  }
-
-  return clientConfig
 }
 
 /**
@@ -139,55 +93,24 @@ export class PostgresAdapter implements DatabaseAdapter {
   readonly dbType = 'postgresql' as const
 
   async connect(config: ConnectionConfig): Promise<void> {
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-    const client = new Client(buildClientConfig(config, tunnelOverrides))
-    try {
-      await client.connect()
-      await client.end()
-    } catch (error) {
-      await client.end().catch(() => {})
-      throw error
-    } finally {
-      closeTunnel(tunnelSession)
-    }
+    // Warm the pool so the first user-issued query doesn't pay TCP/TLS/auth handshake.
+    await withPgClient(config, async () => {})
   }
 
   async query(config: ConnectionConfig, sql: string): Promise<AdapterQueryResult> {
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-    const client = new Client(buildClientConfig(config, tunnelOverrides))
-
-    try {
-      await client.connect()
+    return withPgClient(config, async (client) => {
       const res = await client.query(sql)
-
       const fields: QueryField[] = res.fields.map((f) => ({
         name: f.name,
         dataType: resolvePostgresType(f.dataTypeID),
         dataTypeID: f.dataTypeID
       }))
-
       return {
         rows: res.rows,
         fields,
         rowCount: res.rowCount
       }
-    } finally {
-      await client.end().catch(() => {})
-      closeTunnel(tunnelSession)
-    }
+    })
   }
 
   async queryMultiple(
@@ -198,35 +121,18 @@ export class PostgresAdapter implements DatabaseAdapter {
     const collectTelemetry = options?.collectTelemetry ?? false
     const executionId = options?.executionId ?? randomUUID()
 
-    // Start telemetry collection if requested
     if (collectTelemetry) {
       telemetryCollector.startQuery(executionId, false)
       telemetryCollector.startPhase(executionId, TELEMETRY_PHASES.TCP_HANDSHAKE)
     }
 
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-    const client = new Client(buildClientConfig(config, tunnelOverrides))
-
-    try {
+    return withPgClient(config, async (client) => {
       if (collectTelemetry) {
         telemetryCollector.endPhase(executionId, TELEMETRY_PHASES.TCP_HANDSHAKE)
         telemetryCollector.startPhase(executionId, TELEMETRY_PHASES.DB_HANDSHAKE)
-      }
-
-      await client.connect()
-
-      if (collectTelemetry) {
         telemetryCollector.endPhase(executionId, TELEMETRY_PHASES.DB_HANDSHAKE)
       }
 
-      // Set query timeout if specified (0 = no timeout)
       const queryTimeoutMs = options?.queryTimeoutMs
       if (
         typeof queryTimeoutMs === 'number' &&
@@ -239,7 +145,6 @@ export class PostgresAdapter implements DatabaseAdapter {
         ])
       }
 
-      // Register for cancellation support
       if (options?.executionId) {
         registerQuery(options.executionId, { type: 'postgresql', client })
       }
@@ -250,94 +155,97 @@ export class PostgresAdapter implements DatabaseAdapter {
 
       const statements = splitPgStatements(sql)
 
-      for (let i = 0; i < statements.length; i++) {
-        const statement = statements[i]
-        const stmtStart = Date.now()
+      try {
+        for (let i = 0; i < statements.length; i++) {
+          const statement = statements[i]
+          const stmtStart = Date.now()
 
-        try {
-          // Start execution phase timing
-          if (collectTelemetry) {
-            telemetryCollector.startPhase(executionId, TELEMETRY_PHASES.EXECUTION)
+          try {
+            if (collectTelemetry) {
+              telemetryCollector.startPhase(executionId, TELEMETRY_PHASES.EXECUTION)
+            }
+
+            const res = await client.query(statement)
+
+            if (collectTelemetry) {
+              telemetryCollector.endPhase(executionId, TELEMETRY_PHASES.EXECUTION)
+              telemetryCollector.startPhase(executionId, TELEMETRY_PHASES.PARSE)
+            }
+
+            const stmtDuration = Date.now() - stmtStart
+
+            const fields: QueryField[] = (res.fields || []).map((f) => ({
+              name: f.name,
+              dataType: resolvePostgresType(f.dataTypeID),
+              dataTypeID: f.dataTypeID
+            }))
+
+            const isDataReturning = isDataReturningStatement(statement)
+            const rowCount = res.rowCount ?? res.rows?.length ?? 0
+            totalRowCount += rowCount
+
+            results.push({
+              statement,
+              statementIndex: i,
+              rows: res.rows || [],
+              fields,
+              rowCount,
+              durationMs: stmtDuration,
+              isDataReturning
+            })
+
+            if (collectTelemetry) {
+              telemetryCollector.endPhase(executionId, TELEMETRY_PHASES.PARSE)
+            }
+          } catch (error) {
+            const stmtDuration = Date.now() - stmtStart
+            const errorMessage = error instanceof Error ? error.message : String(error)
+
+            results.push({
+              statement,
+              statementIndex: i,
+              rows: [],
+              fields: [{ name: 'error', dataType: 'text' }],
+              rowCount: 0,
+              durationMs: stmtDuration,
+              isDataReturning: false
+            })
+
+            if (collectTelemetry) {
+              telemetryCollector.cancel(executionId)
+            }
+
+            throw new Error(
+              `Error in statement ${i + 1}: ${errorMessage}\n\nStatement:\n${statement}`
+            )
           }
+        }
 
-          const res = await client.query(statement)
+        // Pooled clients persist session state across checkouts; reset what we set.
+        if (
+          typeof queryTimeoutMs === 'number' &&
+          Number.isFinite(queryTimeoutMs) &&
+          queryTimeoutMs > 0
+        ) {
+          await client.query('RESET statement_timeout').catch(() => {})
+        }
 
-          if (collectTelemetry) {
-            telemetryCollector.endPhase(executionId, TELEMETRY_PHASES.EXECUTION)
-            telemetryCollector.startPhase(executionId, TELEMETRY_PHASES.PARSE)
-          }
+        const result: AdapterMultiQueryResult = {
+          results,
+          totalDurationMs: Date.now() - totalStart
+        }
 
-          const stmtDuration = Date.now() - stmtStart
+        if (collectTelemetry) {
+          result.telemetry = telemetryCollector.finalize(executionId, totalRowCount)
+        }
 
-          const fields: QueryField[] = (res.fields || []).map((f) => ({
-            name: f.name,
-            dataType: resolvePostgresType(f.dataTypeID),
-            dataTypeID: f.dataTypeID
-          }))
-
-          const isDataReturning = isDataReturningStatement(statement)
-          const rowCount = res.rowCount ?? res.rows?.length ?? 0
-          totalRowCount += rowCount
-
-          results.push({
-            statement,
-            statementIndex: i,
-            rows: res.rows || [],
-            fields,
-            rowCount,
-            durationMs: stmtDuration,
-            isDataReturning
-          })
-
-          if (collectTelemetry) {
-            telemetryCollector.endPhase(executionId, TELEMETRY_PHASES.PARSE)
-          }
-        } catch (error) {
-          // If a statement fails, add an error result and stop execution
-          const stmtDuration = Date.now() - stmtStart
-          const errorMessage = error instanceof Error ? error.message : String(error)
-
-          results.push({
-            statement,
-            statementIndex: i,
-            rows: [],
-            fields: [{ name: 'error', dataType: 'text' }],
-            rowCount: 0,
-            durationMs: stmtDuration,
-            isDataReturning: false
-          })
-
-          // Cancel telemetry on error
-          if (collectTelemetry) {
-            telemetryCollector.cancel(executionId)
-          }
-
-          // Re-throw to stop execution of remaining statements
-          throw new Error(
-            `Error in statement ${i + 1}: ${errorMessage}\n\nStatement:\n${statement}`
-          )
+        return result
+      } finally {
+        if (options?.executionId) {
+          unregisterQuery(options.executionId)
         }
       }
-
-      const result: AdapterMultiQueryResult = {
-        results,
-        totalDurationMs: Date.now() - totalStart
-      }
-
-      // Finalize telemetry
-      if (collectTelemetry) {
-        result.telemetry = telemetryCollector.finalize(executionId, totalRowCount)
-      }
-
-      return result
-    } finally {
-      // Unregister from tracker
-      if (options?.executionId) {
-        unregisterQuery(options.executionId)
-      }
-      await client.end().catch(() => {})
-      closeTunnel(tunnelSession)
-    }
+    })
   }
 
   async execute(
@@ -345,71 +253,30 @@ export class PostgresAdapter implements DatabaseAdapter {
     sql: string,
     params: unknown[]
   ): Promise<{ rowCount: number | null }> {
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-    const client = new Client(buildClientConfig(config, tunnelOverrides))
-    try {
-      await client.connect()
+    return withPgClient(config, async (client) => {
       const res = await client.query(sql, params)
       return { rowCount: res.rowCount }
-    } finally {
-      await client.end().catch(() => {})
-      closeTunnel(tunnelSession)
-    }
+    })
   }
 
   async executeTransaction(
     config: ConnectionConfig,
     statements: Array<{ sql: string; params: unknown[] }>
   ): Promise<{ rowsAffected: number; results: Array<{ rowCount: number | null }> }> {
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-    const client = new Client(buildClientConfig(config, tunnelOverrides))
-    try {
-      await client.connect()
-      await client.query('BEGIN')
-
+    return withPgTransaction(config, async (client) => {
       const results: Array<{ rowCount: number | null }> = []
       let rowsAffected = 0
-
       for (const stmt of statements) {
         const res = await client.query(stmt.sql, stmt.params)
         results.push({ rowCount: res.rowCount })
         rowsAffected += res.rowCount ?? 0
       }
-
-      await client.query('COMMIT')
       return { rowsAffected, results }
-    } catch (error) {
-      await client.query('ROLLBACK').catch(() => {})
-      throw error
-    } finally {
-      await client.end().catch(() => {})
-      closeTunnel(tunnelSession)
-    }
+    })
   }
 
   async getSchemas(config: ConnectionConfig): Promise<SchemaInfo[]> {
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-    const client = new Client(buildClientConfig(config, tunnelOverrides))
-    try {
-      await client.connect()
+    return withPgClient(config, async (client) => {
       // Query 1: Get all schemas (excluding system schemas)
       const schemasResult = await client.query(`
         SELECT schema_name
@@ -757,23 +624,11 @@ export class PostgresAdapter implements DatabaseAdapter {
       }
 
       return Array.from(schemaMap.values())
-    } finally {
-      await client.end().catch(() => {})
-      closeTunnel(tunnelSession)
-    }
+    })
   }
 
   async explain(config: ConnectionConfig, sql: string, analyze: boolean): Promise<ExplainResult> {
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-    const client = new Client(buildClientConfig(config, tunnelOverrides))
-    try {
-      await client.connect()
+    return withPgClient(config, async (client) => {
       const explainOptions = analyze
         ? 'ANALYZE, COSTS, VERBOSE, BUFFERS, FORMAT JSON'
         : 'COSTS, VERBOSE, FORMAT JSON'
@@ -789,10 +644,7 @@ export class PostgresAdapter implements DatabaseAdapter {
         plan: planJson,
         durationMs: duration
       }
-    } finally {
-      await client.end().catch(() => {})
-      closeTunnel(tunnelSession)
-    }
+    })
   }
 
   async getTableDDL(
@@ -800,16 +652,7 @@ export class PostgresAdapter implements DatabaseAdapter {
     schema: string,
     table: string
   ): Promise<TableDefinition> {
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-    const client = new Client(buildClientConfig(config, tunnelOverrides))
-    try {
-      await client.connect()
+    return withPgClient(config, async (client) => {
       // Query columns with full metadata
       const columnsResult = await client.query(
         `
@@ -1040,23 +883,11 @@ export class PostgresAdapter implements DatabaseAdapter {
         indexes,
         comment: tableCommentResult.rows[0]?.comment || undefined
       }
-    } finally {
-      await client.end().catch(() => {})
-      closeTunnel(tunnelSession)
-    }
+    })
   }
 
   async getSequences(config: ConnectionConfig): Promise<SequenceInfo[]> {
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-    const client = new Client(buildClientConfig(config, tunnelOverrides))
-    try {
-      await client.connect()
+    return withPgClient(config, async (client) => {
       const result = await client.query(`
         SELECT
           schemaname as schema,
@@ -1076,23 +907,11 @@ export class PostgresAdapter implements DatabaseAdapter {
         startValue: row.start_value,
         increment: row.increment
       }))
-    } finally {
-      await client.end().catch(() => {})
-      closeTunnel(tunnelSession)
-    }
+    })
   }
 
   async getTypes(config: ConnectionConfig): Promise<CustomTypeInfo[]> {
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-    const client = new Client(buildClientConfig(config, tunnelOverrides))
-    try {
-      await client.connect()
+    return withPgClient(config, async (client) => {
       // Get enum types with their values
       const enumsResult = await client.query(`
         SELECT
@@ -1134,10 +953,7 @@ export class PostgresAdapter implements DatabaseAdapter {
           type: 'domain' as const
         }))
       ]
-    } finally {
-      await client.end().catch(() => {})
-      closeTunnel(tunnelSession)
-    }
+    })
   }
 
   private classifyColumnType(dataType: string): ColumnStatsType {
@@ -1187,18 +1003,7 @@ export class PostgresAdapter implements DatabaseAdapter {
     column: string,
     dataType: string
   ): Promise<ColumnStats> {
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-    const client = new Client(buildClientConfig(config, tunnelOverrides))
-
-    try {
-      await client.connect()
-
+    return withPgClient(config, async (client) => {
       const statsType = this.classifyColumnType(dataType)
       const quoteIdent = (name: string) => '"' + name.replace(/"/g, '""') + '"'
       const quotedTable = `${quoteIdent(schema)}.${quoteIdent(table)}`
@@ -1351,25 +1156,11 @@ export class PostgresAdapter implements DatabaseAdapter {
       }
 
       return stats
-    } finally {
-      await client.end().catch(() => {})
-      closeTunnel(tunnelSession)
-    }
+    })
   }
 
   async getActiveQueries(config: ConnectionConfig): Promise<ActiveQuery[]> {
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-    const client = new Client(buildClientConfig(config, tunnelOverrides))
-
-    try {
-      await client.connect()
-
+    return withPgClient(config, async (client) => {
       const result = await client.query(`
         SELECT
           pid,
@@ -1402,28 +1193,14 @@ export class PostgresAdapter implements DatabaseAdapter {
         waitEvent: row.wait_event ? String(row.wait_event) : undefined,
         applicationName: row.application_name ? String(row.application_name) : undefined
       }))
-    } finally {
-      await client.end().catch(() => {})
-      closeTunnel(tunnelSession)
-    }
+    })
   }
 
   async getTableSizes(
     config: ConnectionConfig,
     schema?: string
   ): Promise<{ dbSize: DatabaseSizeInfo; tables: TableSizeInfo[] }> {
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-    const client = new Client(buildClientConfig(config, tunnelOverrides))
-
-    try {
-      await client.connect()
-
+    return withPgClient(config, async (client) => {
       const dbSizeResult = await client.query(`
         SELECT
           pg_size_pretty(pg_database_size(current_database())) AS total_size,
@@ -1482,25 +1259,11 @@ export class PostgresAdapter implements DatabaseAdapter {
       }))
 
       return { dbSize, tables }
-    } finally {
-      await client.end().catch(() => {})
-      closeTunnel(tunnelSession)
-    }
+    })
   }
 
   async getCacheStats(config: ConnectionConfig): Promise<CacheStats> {
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-    const client = new Client(buildClientConfig(config, tunnelOverrides))
-
-    try {
-      await client.connect()
-
+    return withPgClient(config, async (client) => {
       const cacheResult = await client.query(`
         SELECT
           CASE WHEN SUM(heap_blks_hit) + SUM(heap_blks_read) = 0 THEN 0
@@ -1537,25 +1300,11 @@ export class PostgresAdapter implements DatabaseAdapter {
           indexScans: Number(row.index_scans)
         }))
       }
-    } finally {
-      await client.end().catch(() => {})
-      closeTunnel(tunnelSession)
-    }
+    })
   }
 
   async getLocks(config: ConnectionConfig): Promise<LockInfo[]> {
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-    const client = new Client(buildClientConfig(config, tunnelOverrides))
-
-    try {
-      await client.connect()
-
+    return withPgClient(config, async (client) => {
       const result = await client.query(`
         SELECT
           blocked.pid AS blocked_pid,
@@ -1607,57 +1356,26 @@ export class PostgresAdapter implements DatabaseAdapter {
         waitDuration: String(row.wait_duration ?? '0s'),
         waitDurationMs: Number(row.wait_duration_ms ?? 0)
       }))
-    } finally {
-      await client.end().catch(() => {})
-      closeTunnel(tunnelSession)
-    }
+    })
   }
 
   async killQuery(
     config: ConnectionConfig,
     pid: number
   ): Promise<{ success: boolean; error?: string }> {
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-    const client = new Client(buildClientConfig(config, tunnelOverrides))
-
-    try {
-      await client.connect()
+    return withPgClient(config, async (client) => {
       const result = await client.query('SELECT pg_cancel_backend($1) AS cancelled', [pid])
       const cancelled = result.rows[0]?.cancelled === true
       return cancelled
         ? { success: true }
         : { success: false, error: 'Failed to cancel query - process may have already completed' }
-    } finally {
-      await client.end().catch(() => {})
-      closeTunnel(tunnelSession)
-    }
+    })
   }
 
   async runSchemaIntel(
     config: ConnectionConfig,
     checks?: SchemaIntelCheckId[]
   ): Promise<SchemaIntelReport> {
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-    const client = new Client(buildClientConfig(config, tunnelOverrides))
-
-    try {
-      await client.connect()
-      return await runPostgresSchemaIntel(client, checks)
-    } finally {
-      await client.end().catch(() => {})
-      closeTunnel(tunnelSession)
-    }
+    return withPgClient(config, (client) => runPostgresSchemaIntel(client, checks))
   }
 }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -19,6 +19,7 @@ import { windowManager } from './window-manager'
 import { initSchedulerService, stopAllSchedules } from './scheduler-service'
 import { initDashboardService } from './dashboard-service'
 import { cleanup as cleanupPgNotify } from './pg-notification-listener'
+import { closeAllPgPools } from './adapters/pg-pool-manager'
 import { StepSessionRegistry } from './step-session'
 import { createLogger } from './lib/logger'
 
@@ -154,7 +155,7 @@ app.on('before-quit', (event) => {
   cleanupPgNotify()
 
   Promise.race([
-    stepSessionRegistry.cleanupAll(),
+    Promise.all([stepSessionRegistry.cleanupAll(), closeAllPgPools()]),
     new Promise((resolve) => setTimeout(resolve, 3000))
   ])
     .catch((err) => log.error('cleanupAll failed during quit:', err))

--- a/apps/desktop/src/main/ipc/connection-handlers.ts
+++ b/apps/desktop/src/main/ipc/connection-handlers.ts
@@ -4,6 +4,21 @@ import type { DpStorage } from '../storage'
 import { windowManager } from '../window-manager'
 import { closePgPool } from '../adapters/pg-pool-manager'
 import { invalidateSchemaCache } from '../schema-cache'
+import { createLogger } from '../lib/logger'
+
+const log = createLogger('connection-handlers')
+
+// Pool teardown happens after the IPC has already returned success — the connection is
+// already persisted, the renderer has been notified, and a stale pool failing to close
+// shouldn't poison the response with a misleading error.
+function teardownConnection(connection: ConnectionConfig): void {
+  invalidateSchemaCache(connection)
+  if (connection.dbType === 'postgresql') {
+    closePgPool(connection).catch((err) => {
+      log.warn('closePgPool failed:', (err as Error).message)
+    })
+  }
+}
 
 /**
  * Register connection CRUD handlers
@@ -38,7 +53,7 @@ export function registerConnectionHandlers(
   })
 
   // Update an existing connection
-  ipcMain.handle('connections:update', async (_, connection: ConnectionConfig) => {
+  ipcMain.handle('connections:update', (_, connection: ConnectionConfig) => {
     try {
       const connections = store.get('connections', [])
       const index = connections.findIndex((c) => c.id === connection.id)
@@ -48,12 +63,8 @@ export function registerConnectionHandlers(
       const previous = connections[index]
       connections[index] = connection
       store.set('connections', connections)
-      // Drop pooled clients/cache that may now be pointing at stale host/port/credentials.
-      if (previous.dbType === 'postgresql') {
-        await closePgPool(previous)
-      }
-      invalidateSchemaCache(previous)
       windowManager.broadcastToAll('connections:updated')
+      teardownConnection(previous)
       return { success: true, data: connection }
     } catch (error: unknown) {
       const errorMessage = error instanceof Error ? error.message : String(error)
@@ -62,19 +73,14 @@ export function registerConnectionHandlers(
   })
 
   // Delete a connection
-  ipcMain.handle('connections:delete', async (_, id: string) => {
+  ipcMain.handle('connections:delete', (_, id: string) => {
     try {
       const connections = store.get('connections', [])
       const removed = connections.find((c) => c.id === id)
       const filtered = connections.filter((c) => c.id !== id)
       store.set('connections', filtered)
-      if (removed) {
-        if (removed.dbType === 'postgresql') {
-          await closePgPool(removed)
-        }
-        invalidateSchemaCache(removed)
-      }
       windowManager.broadcastToAll('connections:updated')
+      if (removed) teardownConnection(removed)
       return { success: true }
     } catch (error: unknown) {
       const errorMessage = error instanceof Error ? error.message : String(error)

--- a/apps/desktop/src/main/ipc/connection-handlers.ts
+++ b/apps/desktop/src/main/ipc/connection-handlers.ts
@@ -2,6 +2,8 @@ import { ipcMain } from 'electron'
 import type { ConnectionConfig } from '@shared/index'
 import type { DpStorage } from '../storage'
 import { windowManager } from '../window-manager'
+import { closePgPool } from '../adapters/pg-pool-manager'
+import { invalidateSchemaCache } from '../schema-cache'
 
 /**
  * Register connection CRUD handlers
@@ -36,16 +38,21 @@ export function registerConnectionHandlers(
   })
 
   // Update an existing connection
-  ipcMain.handle('connections:update', (_, connection: ConnectionConfig) => {
+  ipcMain.handle('connections:update', async (_, connection: ConnectionConfig) => {
     try {
       const connections = store.get('connections', [])
       const index = connections.findIndex((c) => c.id === connection.id)
       if (index === -1) {
         return { success: false, error: 'Connection not found' }
       }
+      const previous = connections[index]
       connections[index] = connection
       store.set('connections', connections)
-      // Broadcast to all windows that connections have changed
+      // Drop pooled clients/cache that may now be pointing at stale host/port/credentials.
+      if (previous.dbType === 'postgresql') {
+        await closePgPool(previous)
+      }
+      invalidateSchemaCache(previous)
       windowManager.broadcastToAll('connections:updated')
       return { success: true, data: connection }
     } catch (error: unknown) {
@@ -55,12 +62,18 @@ export function registerConnectionHandlers(
   })
 
   // Delete a connection
-  ipcMain.handle('connections:delete', (_, id: string) => {
+  ipcMain.handle('connections:delete', async (_, id: string) => {
     try {
       const connections = store.get('connections', [])
+      const removed = connections.find((c) => c.id === id)
       const filtered = connections.filter((c) => c.id !== id)
       store.set('connections', filtered)
-      // Broadcast to all windows that connections have changed
+      if (removed) {
+        if (removed.dbType === 'postgresql') {
+          await closePgPool(removed)
+        }
+        invalidateSchemaCache(removed)
+      }
       windowManager.broadcastToAll('connections:updated')
       return { success: true }
     } catch (error: unknown) {

--- a/apps/desktop/src/main/pg-export.ts
+++ b/apps/desktop/src/main/pg-export.ts
@@ -8,7 +8,7 @@ import type {
   PgExportPhase
 } from '@shared/index'
 import { resolvePostgresType } from '@shared/index'
-import { buildClientConfig } from './adapters/postgres-adapter'
+import { buildClientConfig } from './adapters/pg-client-config'
 import { createTunnel, closeTunnel, TunnelSession } from './ssh-tunnel-service'
 import { escapeSQLValue, escapeSQLIdentifier } from '@shared/sql-escape'
 import { createLogger } from './lib/logger'

--- a/apps/desktop/src/main/pg-import.ts
+++ b/apps/desktop/src/main/pg-import.ts
@@ -6,7 +6,7 @@ import type {
   PgImportProgress,
   PgImportResult
 } from '@shared/index'
-import { buildClientConfig } from './adapters/postgres-adapter'
+import { buildClientConfig } from './adapters/pg-client-config'
 import { createTunnel, closeTunnel, TunnelSession } from './ssh-tunnel-service'
 import { splitStatementsStream } from './lib/sql-parser'
 import { createLogger } from './lib/logger'

--- a/apps/desktop/src/main/query-tracker.ts
+++ b/apps/desktop/src/main/query-tracker.ts
@@ -2,7 +2,7 @@
  * Query Tracker - tracks active queries and provides cancellation support
  */
 
-import { Client } from 'pg'
+import type { Client, PoolClient } from 'pg'
 import type { Connection } from 'mysql2/promise'
 import type { Request as MSSQLRequest } from 'mssql'
 import { createLogger } from './lib/logger'
@@ -11,7 +11,7 @@ const log = createLogger('query-tracker')
 
 /** Supported cancellable handle types */
 export type CancellableHandle =
-  | { type: 'postgresql'; client: Client }
+  | { type: 'postgresql'; client: Client | PoolClient }
   | { type: 'mysql'; connection: Connection }
   | { type: 'mssql'; request: MSSQLRequest }
   | { type: 'sqlite' } // SQLite is synchronous and cannot be cancelled mid-query
@@ -63,8 +63,15 @@ export async function cancelQuery(
   try {
     switch (query.handle.type) {
       case 'postgresql': {
-        // PostgreSQL: end the client connection to abort the query
-        await query.handle.client.end()
+        // PoolClient: release(true) destroys the underlying connection and removes it
+        // from the pool, which aborts the in-flight query. Bare Client: end() closes
+        // the socket. Both effects abort the running statement.
+        const c = query.handle.client as PoolClient & Partial<Client>
+        if (typeof c.release === 'function') {
+          c.release(true)
+        } else if (typeof c.end === 'function') {
+          await c.end()
+        }
         break
       }
       case 'mysql': {

--- a/apps/desktop/src/main/query-tracker.ts
+++ b/apps/desktop/src/main/query-tracker.ts
@@ -71,6 +71,8 @@ export async function cancelQuery(
           c.release(true)
         } else if (typeof c.end === 'function') {
           await c.end()
+        } else {
+          throw new Error('Postgres client handle has neither release nor end; cannot cancel')
         }
         break
       }

--- a/apps/desktop/src/main/schema-intel/postgres.ts
+++ b/apps/desktop/src/main/schema-intel/postgres.ts
@@ -407,8 +407,8 @@ const CHECK_RUNNERS: Record<
 }
 
 /**
- * Run the requested schema-intel checks against an already-connected pg
- * Client. Checks never throw — failures surface as entries in `skipped`.
+ * Run the requested schema-intel checks against an already-connected client.
+ * Checks never throw — failures surface as entries in `skipped`.
  */
 export async function runPostgresSchemaIntel(
   client: ClientBase,

--- a/apps/desktop/src/main/schema-intel/postgres.ts
+++ b/apps/desktop/src/main/schema-intel/postgres.ts
@@ -1,4 +1,4 @@
-import type { Client } from 'pg'
+import type { ClientBase } from 'pg'
 import type { SchemaIntelCheckId, SchemaIntelFinding, SchemaIntelReport } from '@shared/index'
 
 /**
@@ -18,7 +18,7 @@ const DEFAULT_PG_CHECKS: SchemaIntelCheckId[] = [
 
 type Row = Record<string, unknown>
 
-async function runQuery(client: Client, sql: string): Promise<Row[]> {
+async function runQuery(client: ClientBase, sql: string): Promise<Row[]> {
   const result = await client.query(sql)
   return result.rows as Row[]
 }
@@ -31,7 +31,7 @@ function qualified(schema: string, name: string): string {
   return `${qid(schema)}.${qid(name)}`
 }
 
-async function checkTablesWithoutPk(client: Client): Promise<SchemaIntelFinding[]> {
+async function checkTablesWithoutPk(client: ClientBase): Promise<SchemaIntelFinding[]> {
   const rows = await runQuery(
     client,
     `
@@ -72,7 +72,7 @@ async function checkTablesWithoutPk(client: Client): Promise<SchemaIntelFinding[
   })
 }
 
-async function checkMissingFkIndexes(client: Client): Promise<SchemaIntelFinding[]> {
+async function checkMissingFkIndexes(client: ClientBase): Promise<SchemaIntelFinding[]> {
   // Find FK constraints whose column list is not a prefix of any index
   const rows = await runQuery(
     client,
@@ -146,7 +146,7 @@ async function checkMissingFkIndexes(client: Client): Promise<SchemaIntelFinding
   })
 }
 
-async function checkDuplicateIndexes(client: Client): Promise<SchemaIntelFinding[]> {
+async function checkDuplicateIndexes(client: ClientBase): Promise<SchemaIntelFinding[]> {
   const rows = await runQuery(
     client,
     `
@@ -192,7 +192,7 @@ async function checkDuplicateIndexes(client: Client): Promise<SchemaIntelFinding
   })
 }
 
-async function checkUnusedIndexes(client: Client): Promise<SchemaIntelFinding[]> {
+async function checkUnusedIndexes(client: ClientBase): Promise<SchemaIntelFinding[]> {
   const rows = await runQuery(
     client,
     `
@@ -233,7 +233,7 @@ async function checkUnusedIndexes(client: Client): Promise<SchemaIntelFinding[]>
   })
 }
 
-async function checkInvalidIndexes(client: Client): Promise<SchemaIntelFinding[]> {
+async function checkInvalidIndexes(client: ClientBase): Promise<SchemaIntelFinding[]> {
   const rows = await runQuery(
     client,
     `
@@ -266,7 +266,7 @@ async function checkInvalidIndexes(client: Client): Promise<SchemaIntelFinding[]
   })
 }
 
-async function checkBloatedTables(client: Client): Promise<SchemaIntelFinding[]> {
+async function checkBloatedTables(client: ClientBase): Promise<SchemaIntelFinding[]> {
   const rows = await runQuery(
     client,
     `
@@ -311,7 +311,7 @@ async function checkBloatedTables(client: Client): Promise<SchemaIntelFinding[]>
   })
 }
 
-async function checkNeverVacuumed(client: Client): Promise<SchemaIntelFinding[]> {
+async function checkNeverVacuumed(client: ClientBase): Promise<SchemaIntelFinding[]> {
   const rows = await runQuery(
     client,
     `
@@ -349,7 +349,7 @@ async function checkNeverVacuumed(client: Client): Promise<SchemaIntelFinding[]>
   })
 }
 
-async function checkNullableFks(client: Client): Promise<SchemaIntelFinding[]> {
+async function checkNullableFks(client: ClientBase): Promise<SchemaIntelFinding[]> {
   const rows = await runQuery(
     client,
     `
@@ -392,24 +392,26 @@ async function checkNullableFks(client: Client): Promise<SchemaIntelFinding[]> {
     })
 }
 
-const CHECK_RUNNERS: Record<SchemaIntelCheckId, (client: Client) => Promise<SchemaIntelFinding[]>> =
-  {
-    tables_without_pk: checkTablesWithoutPk,
-    missing_fk_indexes: checkMissingFkIndexes,
-    duplicate_indexes: checkDuplicateIndexes,
-    unused_indexes: checkUnusedIndexes,
-    invalid_indexes: checkInvalidIndexes,
-    bloated_tables: checkBloatedTables,
-    never_vacuumed: checkNeverVacuumed,
-    nullable_fks: checkNullableFks
-  }
+const CHECK_RUNNERS: Record<
+  SchemaIntelCheckId,
+  (client: ClientBase) => Promise<SchemaIntelFinding[]>
+> = {
+  tables_without_pk: checkTablesWithoutPk,
+  missing_fk_indexes: checkMissingFkIndexes,
+  duplicate_indexes: checkDuplicateIndexes,
+  unused_indexes: checkUnusedIndexes,
+  invalid_indexes: checkInvalidIndexes,
+  bloated_tables: checkBloatedTables,
+  never_vacuumed: checkNeverVacuumed,
+  nullable_fks: checkNullableFks
+}
 
 /**
  * Run the requested schema-intel checks against an already-connected pg
  * Client. Checks never throw — failures surface as entries in `skipped`.
  */
 export async function runPostgresSchemaIntel(
-  client: Client,
+  client: ClientBase,
   requested?: SchemaIntelCheckId[]
 ): Promise<SchemaIntelReport> {
   const started = Date.now()

--- a/apps/desktop/vitest.smoke.config.ts
+++ b/apps/desktop/vitest.smoke.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config'
+import { resolve } from 'path'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['scripts/pool-smoke.test.ts'],
+    testTimeout: 60_000
+  },
+  resolve: {
+    alias: {
+      '@shared': resolve(__dirname, '../../packages/shared/src'),
+      '@data-peek/shared': resolve(__dirname, '../../packages/shared/src/index.ts'),
+      '@': resolve(__dirname, 'src/renderer/src')
+    }
+  }
+})


### PR DESCRIPTION
## Summary

Every postgres adapter method previously did `new Client(...) → connect → query → end`, paying TCP/TLS/auth handshake (100–400 ms on RDS/Neon over TLS) per IPC call. Schema fetch alone fired six handshakes; benchmark runs measured connection cost more than query cost.

This PR introduces per-connection pooling so handshake is paid once, not per query.

- New `pg-pool-manager.ts` owns one `pg.Pool` + optional shared SSH tunnel per saved connection, keyed on `config.id` (SSH/SSL variants no longer collide on the schema-cache key either).
- All 17 lifecycle blocks in `postgres-adapter.ts` replaced with `withPgClient` / `withPgTransaction`. Net **–259 LOC**.
- `connections:update` / `connections:delete` invalidate the pool + schema cache for the affected connection so edits take effect immediately.
- `closeAllPgPools()` joined to `app.before-quit` cleanup.
- Cancellation: `release(true)` on `PoolClient` (destroys + drops from pool), `end()` fallback for bare `Client`. `withPgClient` swallows double-release errors so the cancel path and surrounding finally don't conflict.

## Scope

Postgres only. MySQL has the same problem but a different driver and cancel semantics; bundling would double the diff. MSSQL likewise. Both can follow on separate branches.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` 491/491 pass
- [x] Lint clean on touched files
- [ ] First-query-after-connect latency drops vs. baseline (smoke against TLS Postgres — RDS/Neon/Supabase)
- [ ] Cancel a long-running query mid-flight, then run a follow-up query (validates `release(true)` + double-release-swallow path)
- [ ] Edit a connection's host/port/credentials, run a query (validates `closePgPool` on update)
- [ ] SSH-tunneled connection: run several queries (validates shared tunnel across pool clients)
- [ ] Multi-statement transaction commits/rolls back as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shared PostgreSQL connection pooling with concurrency-safe management and centralized client configuration.
  * Shutdown now ensures DB pools are closed during app quit.

* **Bug Fixes**
  * Pools closed when connections are updated or deleted.
  * More reliable cancellation of in-flight Postgres requests.

* **Refactor**
  * DB and schema/introspection paths use pooled helpers.

* **Tests**
  * Added unit and smoke tests for pooling, IPC teardown, and cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->