### PR TITLE
fix: post-audit silent-corruption + lifecycle hardening

### DIFF
--- a/apps/desktop/src/main/__tests__/schema-cache.test.ts
+++ b/apps/desktop/src/main/__tests__/schema-cache.test.ts
@@ -107,6 +107,80 @@ describe('getOrFetchCachedSchema dogpile guard', () => {
     expect(getCachedSchema(config)?.timestamp).toBe(7777)
   })
 
+  it('aborts the cache write when invalidateSchemaCache runs mid-fetch', async () => {
+    // Repro for the silent regression: a fetch starts at pre-DDL state, a DDL handler
+    // fires `invalidateSchemaCache`, and the fetcher then resolves. Without the
+    // generation guard, its setCachedSchema call would repopulate the cache with the
+    // pre-DDL data and the next reader would see stale schemas for the full TTL.
+    const config = makeConfig('mid-fetch')
+    invalidateSchemaCache(config)
+
+    let resolveFetcher: ((value: { schemas: SchemaInfo[]; customTypes: []; timestamp: number }) => void) | null =
+      null
+    const fetcher = vi.fn(
+      () =>
+        new Promise<{ schemas: SchemaInfo[]; customTypes: []; timestamp: number }>(
+          (resolve) => {
+            resolveFetcher = resolve
+          }
+        )
+    )
+
+    const inFlight = getOrFetchCachedSchema(config, fetcher)
+
+    // DDL fires while the fetch is in-flight.
+    invalidateSchemaCache(config)
+
+    // Now the fetch resolves — with what would have been pre-DDL data.
+    resolveFetcher!({ schemas: fakeSchemas, customTypes: [], timestamp: 999 })
+    await inFlight
+
+    // The cache must NOT have been repopulated with the stale result.
+    expect(getCachedSchema(config)).toBeUndefined()
+  })
+
+  it('keeps a fresh fetch alive when an older fetch finishes after invalidation', async () => {
+    // Repro: A starts, invalidate runs, C starts a fresh fetch, A finishes. The old
+    // finally must not delete C's pendingFetches entry, otherwise a fourth caller D
+    // would dogpile (start a third underlying fetcher) instead of waiting for C.
+    const config = makeConfig('ownership')
+    invalidateSchemaCache(config)
+
+    let resolveA: ((v: { schemas: SchemaInfo[]; customTypes: []; timestamp: number }) => void) | null = null
+    const fetcherA = vi.fn(
+      () => new Promise<{ schemas: SchemaInfo[]; customTypes: []; timestamp: number }>((r) => {
+        resolveA = r
+      })
+    )
+    const fetchA = getOrFetchCachedSchema(config, fetcherA)
+
+    invalidateSchemaCache(config)
+
+    let resolveC: ((v: { schemas: SchemaInfo[]; customTypes: []; timestamp: number }) => void) | null = null
+    const fetcherC = vi.fn(
+      () => new Promise<{ schemas: SchemaInfo[]; customTypes: []; timestamp: number }>((r) => {
+        resolveC = r
+      })
+    )
+    const fetchC = getOrFetchCachedSchema(config, fetcherC)
+
+    // A finishes first — its finally must NOT delete C's slot.
+    resolveA!({ schemas: fakeSchemas, customTypes: [], timestamp: 1 })
+    await fetchA
+
+    // D arrives now and should coalesce with C, not start a third fetcher.
+    const fetcherD = vi.fn()
+    const fetchD = getOrFetchCachedSchema(config, fetcherD)
+    expect(fetcherD).not.toHaveBeenCalled()
+
+    resolveC!({ schemas: fakeSchemas, customTypes: [], timestamp: 2 })
+    await Promise.all([fetchC, fetchD])
+
+    expect(fetcherC).toHaveBeenCalledTimes(1)
+    expect(fetcherD).toHaveBeenCalledTimes(0)
+    expect(getCachedSchema(config)?.timestamp).toBe(2)
+  })
+
   it('does not coalesce fetches across different connection ids', async () => {
     const a = makeConfig('dogpile-a')
     const b = makeConfig('dogpile-b')

--- a/apps/desktop/src/main/__tests__/schema-cache.test.ts
+++ b/apps/desktop/src/main/__tests__/schema-cache.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { ConnectionConfig, SchemaInfo } from '@shared/index'
+
+vi.mock('electron', () => ({
+  app: { getPath: vi.fn(() => '/tmp') },
+  safeStorage: { isEncryptionAvailable: vi.fn(() => false) }
+}))
+
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}))
+
+vi.mock('../storage', () => ({
+  DpStorage: class {
+    static async create() {
+      return new this()
+    }
+    private state: Record<string, unknown> = { cache: {} }
+    get(key: string, fallback?: unknown) {
+      return this.state[key] ?? fallback
+    }
+    set(key: string, value: unknown) {
+      this.state[key] = value
+    }
+  }
+}))
+
+import {
+  getOrFetchCachedSchema,
+  getCachedSchema,
+  invalidateSchemaCache,
+  initSchemaCache
+} from '../schema-cache'
+
+const makeConfig = (id: string): ConnectionConfig => ({
+  id,
+  name: id,
+  host: 'localhost',
+  port: 5432,
+  database: 'test',
+  user: 'u',
+  password: 'p',
+  dbType: 'postgresql',
+  dstPort: 5432
+})
+
+const fakeSchemas: SchemaInfo[] = []
+
+describe('getOrFetchCachedSchema dogpile guard', () => {
+  beforeEach(async () => {
+    await initSchemaCache()
+  })
+
+  it('coalesces concurrent fetches to a single underlying fetcher call', async () => {
+    const config = makeConfig('dogpile-1')
+    invalidateSchemaCache(config)
+
+    let resolveFetcher: ((value: { schemas: SchemaInfo[]; customTypes: []; timestamp: number }) => void) | null = null
+    const fetcher = vi.fn(
+      () =>
+        new Promise<{ schemas: SchemaInfo[]; customTypes: []; timestamp: number }>((resolve) => {
+          resolveFetcher = resolve
+        })
+    )
+
+    // Two concurrent callers — both miss cache, both hit getOrFetch.
+    const p1 = getOrFetchCachedSchema(config, fetcher)
+    const p2 = getOrFetchCachedSchema(config, fetcher)
+
+    expect(fetcher).toHaveBeenCalledTimes(1)
+
+    // Resolve once; both callers receive the result.
+    resolveFetcher!({ schemas: fakeSchemas, customTypes: [], timestamp: 123 })
+    const [r1, r2] = await Promise.all([p1, p2])
+    expect(r1).toEqual(r2)
+    expect(r1.timestamp).toBe(123)
+  })
+
+  it('clears the pending entry after completion so a later call refetches', async () => {
+    const config = makeConfig('dogpile-2')
+    invalidateSchemaCache(config)
+
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce({ schemas: fakeSchemas, customTypes: [], timestamp: 1 })
+      .mockResolvedValueOnce({ schemas: fakeSchemas, customTypes: [], timestamp: 2 })
+
+    await getOrFetchCachedSchema(config, fetcher)
+    invalidateSchemaCache(config)
+    await getOrFetchCachedSchema(config, fetcher)
+
+    expect(fetcher).toHaveBeenCalledTimes(2)
+  })
+
+  it('caches the result so subsequent direct cache reads see it', async () => {
+    const config = makeConfig('dogpile-3')
+    invalidateSchemaCache(config)
+
+    await getOrFetchCachedSchema(config, async () => ({
+      schemas: fakeSchemas,
+      customTypes: [],
+      timestamp: 7777
+    }))
+
+    expect(getCachedSchema(config)?.timestamp).toBe(7777)
+  })
+
+  it('does not coalesce fetches across different connection ids', async () => {
+    const a = makeConfig('dogpile-a')
+    const b = makeConfig('dogpile-b')
+    invalidateSchemaCache(a)
+    invalidateSchemaCache(b)
+
+    const fetcherA = vi.fn().mockResolvedValue({ schemas: fakeSchemas, customTypes: [], timestamp: 1 })
+    const fetcherB = vi.fn().mockResolvedValue({ schemas: fakeSchemas, customTypes: [], timestamp: 2 })
+
+    await Promise.all([
+      getOrFetchCachedSchema(a, fetcherA),
+      getOrFetchCachedSchema(b, fetcherB)
+    ])
+
+    expect(fetcherA).toHaveBeenCalledTimes(1)
+    expect(fetcherB).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/desktop/src/main/__tests__/schema-cache.test.ts
+++ b/apps/desktop/src/main/__tests__/schema-cache.test.ts
@@ -55,7 +55,9 @@ describe('getOrFetchCachedSchema dogpile guard', () => {
     const config = makeConfig('dogpile-1')
     invalidateSchemaCache(config)
 
-    let resolveFetcher: ((value: { schemas: SchemaInfo[]; customTypes: []; timestamp: number }) => void) | null = null
+    let resolveFetcher:
+      | ((value: { schemas: SchemaInfo[]; customTypes: []; timestamp: number }) => void)
+      | null = null
     const fetcher = vi.fn(
       () =>
         new Promise<{ schemas: SchemaInfo[]; customTypes: []; timestamp: number }>((resolve) => {
@@ -111,13 +113,14 @@ describe('getOrFetchCachedSchema dogpile guard', () => {
     invalidateSchemaCache(a)
     invalidateSchemaCache(b)
 
-    const fetcherA = vi.fn().mockResolvedValue({ schemas: fakeSchemas, customTypes: [], timestamp: 1 })
-    const fetcherB = vi.fn().mockResolvedValue({ schemas: fakeSchemas, customTypes: [], timestamp: 2 })
+    const fetcherA = vi
+      .fn()
+      .mockResolvedValue({ schemas: fakeSchemas, customTypes: [], timestamp: 1 })
+    const fetcherB = vi
+      .fn()
+      .mockResolvedValue({ schemas: fakeSchemas, customTypes: [], timestamp: 2 })
 
-    await Promise.all([
-      getOrFetchCachedSchema(a, fetcherA),
-      getOrFetchCachedSchema(b, fetcherB)
-    ])
+    await Promise.all([getOrFetchCachedSchema(a, fetcherA), getOrFetchCachedSchema(b, fetcherB)])
 
     expect(fetcherA).toHaveBeenCalledTimes(1)
     expect(fetcherB).toHaveBeenCalledTimes(1)

--- a/apps/desktop/src/main/ipc/ddl-handlers.ts
+++ b/apps/desktop/src/main/ipc/ddl-handlers.ts
@@ -8,6 +8,7 @@ import {
   buildPreviewDDL,
   validateTableDefinition
 } from '../ddl-builder'
+import { invalidateSchemaCache } from '../schema-cache'
 import { createLogger } from '../lib/logger'
 
 const log = createLogger('ddl-handlers')
@@ -60,6 +61,9 @@ export function registerDDLHandlers(): void {
 
         await adapter.executeTransaction(config, stmtParams)
 
+        // Drop cached schemas so callers see the new table on the next read.
+        invalidateSchemaCache(config)
+
         return { success: true, data: result }
       } catch (error: unknown) {
         log.error('Create table error:', error)
@@ -92,6 +96,9 @@ export function registerDDLHandlers(): void {
         log.debug('Executing SQL:', result.executedSql)
 
         await adapter.executeTransaction(config, statements)
+
+        // Cached column sets / FK metadata are now stale; force the next read.
+        invalidateSchemaCache(config)
 
         return { success: true, data: result }
       } catch (error: unknown) {
@@ -126,6 +133,9 @@ export function registerDDLHandlers(): void {
         log.debug('Executing SQL:', sql)
 
         await adapter.executeTransaction(config, [{ sql, params: [] }])
+
+        // Drop cached schemas so the dropped table disappears from the next read.
+        invalidateSchemaCache(config)
 
         return {
           success: true,

--- a/apps/desktop/src/main/ipc/query-handlers.ts
+++ b/apps/desktop/src/main/ipc/query-handlers.ts
@@ -14,7 +14,7 @@ import { buildQuery, validateOperation, buildPreviewSql } from '../sql-builder'
 import {
   getCachedSchema,
   isCacheValid,
-  setCachedSchema,
+  getOrFetchCachedSchema,
   invalidateSchemaCache,
   type CachedSchema
 } from '../schema-cache'
@@ -156,35 +156,32 @@ export function registerQueryHandlers(): void {
           }
         }
 
-        // Fetch fresh data
+        // Fetch fresh data — coalesce concurrent calls so two tabs opening at the
+        // same time don't each trigger a full pg_catalog scan.
         if (forceRefresh) {
           log.debug('Force refresh, fetching from database...')
         } else {
           log.debug('Cache miss, fetching from database...')
         }
         const adapter = getAdapter(config)
-        const schemas = await adapter.getSchemas(config)
 
-        // Also fetch custom types
-        let customTypes: CachedSchema['customTypes'] = []
-        try {
-          customTypes = await adapter.getTypes(config)
-        } catch {
-          // Types are optional, ignore errors
-        }
-
-        const timestamp = Date.now()
-
-        // Update both memory and disk cache
-        const cacheEntry: CachedSchema = { schemas, customTypes, timestamp }
-        setCachedSchema(config, cacheEntry)
+        const cacheEntry = await getOrFetchCachedSchema(config, async () => {
+          const schemas = await adapter.getSchemas(config)
+          let customTypes: CachedSchema['customTypes'] = []
+          try {
+            customTypes = await adapter.getTypes(config)
+          } catch {
+            // Types are optional, ignore errors
+          }
+          return { schemas, customTypes, timestamp: Date.now() }
+        })
 
         return {
           success: true,
           data: {
-            schemas,
-            customTypes,
-            fetchedAt: timestamp,
+            schemas: cacheEntry.schemas,
+            customTypes: cacheEntry.customTypes,
+            fetchedAt: cacheEntry.timestamp,
             fromCache: false
           }
         }

--- a/apps/desktop/src/main/schema-cache.ts
+++ b/apps/desktop/src/main/schema-cache.ts
@@ -30,6 +30,12 @@ const schemaMemoryCache = new Map<string, CachedSchema>()
 // pg_catalog scan against the same connection.
 const pendingFetches = new Map<string, Promise<CachedSchema>>()
 
+// Per-key generation counter. invalidateSchemaCache bumps it; in-flight fetchers
+// capture the value at start, and refuse to write their result if the generation has
+// moved on. This is the lock that prevents an old, slow `getSchemas` from undoing a
+// post-DDL invalidation by repopulating the cache with pre-DDL data.
+const cacheGenerations = new Map<string, number>()
+
 let schemaCacheStore: DpStorage<SchemaCacheStore> | null = null
 
 /**
@@ -118,6 +124,12 @@ export function setCachedSchema(config: ConnectionConfig, cacheEntry: CachedSche
  * Coalesce concurrent fetches for the same connection. Returns an existing in-flight
  * promise if one is already running for this key; otherwise runs `fetcher`, stores the
  * result via setCachedSchema, and resolves all callers with the same value.
+ *
+ * The fetcher captures the cache generation at start. If `invalidateSchemaCache` runs
+ * during the fetch (e.g. a DDL handler fires while we're mid-pg_catalog-scan), the
+ * generation moves on and the fetcher's write is suppressed — otherwise the fetcher's
+ * pre-DDL result would silently undo the invalidation. The same ownership check guards
+ * the `pendingFetches` cleanup so a stale finally can't delete a newer fetcher's slot.
  */
 export function getOrFetchCachedSchema(
   config: ConnectionConfig,
@@ -127,16 +139,32 @@ export function getOrFetchCachedSchema(
   const existing = pendingFetches.get(key)
   if (existing) return existing
 
+  const startGeneration = cacheGenerations.get(key) ?? 0
+  // Use a box so the run closure can refer to its own promise without TDZ issues.
+  const handle: { promise: Promise<CachedSchema> | null } = { promise: null }
+
   const run = async (): Promise<CachedSchema> => {
     try {
       const result = await fetcher()
-      setCachedSchema(config, result)
+      // Only persist if no invalidation has run since we started AND we still own
+      // the slot. Either condition failing means our result is stale.
+      if (
+        (cacheGenerations.get(key) ?? 0) === startGeneration &&
+        pendingFetches.get(key) === handle.promise
+      ) {
+        setCachedSchema(config, result)
+      }
       return result
     } finally {
-      pendingFetches.delete(key)
+      // Only clear our own slot — a newer fetch may have taken over after invalidation.
+      if (pendingFetches.get(key) === handle.promise) {
+        pendingFetches.delete(key)
+      }
     }
   }
+
   const promise = run()
+  handle.promise = promise
   pendingFetches.set(key, promise)
   return promise
 }
@@ -145,21 +173,25 @@ export function getOrFetchCachedSchema(
  * Invalidate cache for a connection
  */
 export function invalidateSchemaCache(config: ConnectionConfig): void {
+  const cacheKey = getSchemaCacheKey(config)
+
+  // Bump the generation BEFORE clearing pendingFetches so any in-flight fetcher
+  // that's already past its `await fetcher()` and about to call setCachedSchema
+  // still sees the new generation and aborts the write.
+  cacheGenerations.set(cacheKey, (cacheGenerations.get(cacheKey) ?? 0) + 1)
+
+  // Pure in-memory ops happen unconditionally — they don't depend on the disk store
+  // being initialised. Skipping these because the store hasn't booted would silently
+  // leave a stale entry in memory and let an in-flight fetch repopulate the disk
+  // cache once the store is ready.
+  schemaMemoryCache.delete(cacheKey)
+  pendingFetches.delete(cacheKey)
+
   if (!schemaCacheStore) {
-    log.warn('Cache store not initialized')
+    log.warn('Cache store not initialized; in-memory invalidation only')
     return
   }
 
-  const cacheKey = getSchemaCacheKey(config)
-
-  // Remove from memory cache
-  schemaMemoryCache.delete(cacheKey)
-
-  // Drop any in-flight fetch so the next caller refetches against the new state of
-  // the database (e.g. after a CREATE/ALTER/DROP TABLE).
-  pendingFetches.delete(cacheKey)
-
-  // Remove from disk cache
   const allCache = schemaCacheStore.get('cache', {})
   delete allCache[cacheKey]
   schemaCacheStore.set('cache', allCache)

--- a/apps/desktop/src/main/schema-cache.ts
+++ b/apps/desktop/src/main/schema-cache.ts
@@ -25,6 +25,11 @@ const MAX_CACHE_ENTRIES = 30
 // Map preserves insertion order; we delete + re-set on access to maintain LRU order.
 const schemaMemoryCache = new Map<string, CachedSchema>()
 
+// In-flight fetch promises keyed by connection cache key. Used to coalesce concurrent
+// db:schemas requests so two tabs opening at the same time don't each trigger a full
+// pg_catalog scan against the same connection.
+const pendingFetches = new Map<string, Promise<CachedSchema>>()
+
 let schemaCacheStore: DpStorage<SchemaCacheStore> | null = null
 
 /**
@@ -110,6 +115,33 @@ export function setCachedSchema(config: ConnectionConfig, cacheEntry: CachedSche
 }
 
 /**
+ * Coalesce concurrent fetches for the same connection. Returns an existing in-flight
+ * promise if one is already running for this key; otherwise runs `fetcher`, stores the
+ * result via setCachedSchema, and resolves all callers with the same value.
+ */
+export function getOrFetchCachedSchema(
+  config: ConnectionConfig,
+  fetcher: () => Promise<CachedSchema>
+): Promise<CachedSchema> {
+  const key = getSchemaCacheKey(config)
+  const existing = pendingFetches.get(key)
+  if (existing) return existing
+
+  const run = async (): Promise<CachedSchema> => {
+    try {
+      const result = await fetcher()
+      setCachedSchema(config, result)
+      return result
+    } finally {
+      pendingFetches.delete(key)
+    }
+  }
+  const promise = run()
+  pendingFetches.set(key, promise)
+  return promise
+}
+
+/**
  * Invalidate cache for a connection
  */
 export function invalidateSchemaCache(config: ConnectionConfig): void {
@@ -122,6 +154,10 @@ export function invalidateSchemaCache(config: ConnectionConfig): void {
 
   // Remove from memory cache
   schemaMemoryCache.delete(cacheKey)
+
+  // Drop any in-flight fetch so the next caller refetches against the new state of
+  // the database (e.g. after a CREATE/ALTER/DROP TABLE).
+  pendingFetches.delete(cacheKey)
 
   // Remove from disk cache
   const allCache = schemaCacheStore.get('cache', {})

--- a/apps/desktop/src/renderer/src/components/editable-data-table.tsx
+++ b/apps/desktop/src/renderer/src/components/editable-data-table.tsx
@@ -655,9 +655,8 @@ export function EditableDataTable<TData extends Record<string, unknown>>({
         id: '_select',
         header: () => null,
         cell: ({ row }) => {
-          const rowIndex = row.index
-          const isDeleted = isRowMarkedForDeletion(tabId, rowIndex)
           const originalRow = row.original as Record<string, unknown>
+          const isDeleted = isRowMarkedForDeletion(tabId, originalRow)
 
           return (
             <div className="flex items-center gap-1">
@@ -668,7 +667,7 @@ export function EditableDataTable<TData extends Record<string, unknown>>({
                       variant="ghost"
                       size="icon"
                       className="size-6 text-muted-foreground hover:text-foreground"
-                      onClick={() => unmarkRowForDeletion(tabId, rowIndex)}
+                      onClick={() => unmarkRowForDeletion(tabId, originalRow)}
                     >
                       <RotateCcw className="size-3" />
                     </Button>
@@ -696,7 +695,7 @@ export function EditableDataTable<TData extends Record<string, unknown>>({
                     </DropdownMenuItem>
                     <DropdownMenuSeparator />
                     <DropdownMenuItem
-                      onClick={() => markRowForDeletion(tabId, rowIndex, originalRow)}
+                      onClick={() => markRowForDeletion(tabId, originalRow)}
                       className="gap-2 text-red-500 focus:text-red-500"
                     >
                       <Trash2 className="size-4" />
@@ -814,11 +813,11 @@ export function EditableDataTable<TData extends Record<string, unknown>>({
         cell: ({ row, getValue }) => {
           const rowIndex = row.index
           const value = getValue()
-          const isDeleted = isRowMarkedForDeletion(tabId, rowIndex)
-          const isModified = isCellModified(tabId, rowIndex, col.name)
-          const modifiedValue = getModifiedCellValue(tabId, rowIndex, col.name)
-          const displayValue = isModified ? modifiedValue : value
           const originalRow = row.original as Record<string, unknown>
+          const isDeleted = isRowMarkedForDeletion(tabId, originalRow)
+          const isModified = isCellModified(tabId, originalRow, col.name)
+          const modifiedValue = getModifiedCellValue(tabId, originalRow, col.name)
+          const displayValue = isModified ? modifiedValue : value
           const isEditing =
             tabEdit?.editingCell?.rowIndex === rowIndex &&
             tabEdit?.editingCell?.columnName === col.name
@@ -855,12 +854,10 @@ export function EditableDataTable<TData extends Record<string, unknown>>({
                 enumValues={col.enumValues}
                 columnName={col.name}
                 onStartEdit={() => startCellEdit(tabId, rowIndex, col.name)}
-                onSave={(newValue) =>
-                  updateCellValue(tabId, rowIndex, col.name, newValue, originalRow)
-                }
+                onSave={(newValue) => updateCellValue(tabId, originalRow, col.name, newValue)}
                 onCancel={() => cancelCellEdit(tabId)}
                 onRevert={
-                  isModified ? () => revertCellChange(tabId, rowIndex, col.name) : undefined
+                  isModified ? () => revertCellChange(tabId, originalRow, col.name) : undefined
                 }
               />
             )
@@ -1163,7 +1160,8 @@ export function EditableDataTable<TData extends Record<string, unknown>>({
                           {virtualizer.getVirtualItems().map((virtualRow) => {
                             const row = rows[virtualRow.index]
                             const rowIndex = row.index
-                            const isDeleted = isRowMarkedForDeletion(tabId, rowIndex)
+                            const originalRow = row.original as Record<string, unknown>
+                            const isDeleted = isRowMarkedForDeletion(tabId, originalRow)
                             return (
                               <div
                                 key={row.id}
@@ -1203,9 +1201,8 @@ export function EditableDataTable<TData extends Record<string, unknown>>({
                     </tr>
                   ) : (
                     rows.map((row) => {
-                      const rowIndex = row.index
-                      const isDeleted = isRowMarkedForDeletion(tabId, rowIndex)
                       const originalRow = row.original as Record<string, unknown>
+                      const isDeleted = isRowMarkedForDeletion(tabId, originalRow)
 
                       return (
                         <RowContextMenu
@@ -1219,7 +1216,7 @@ export function EditableDataTable<TData extends Record<string, unknown>>({
                           }
                           onDelete={
                             canEdit && editContext && !isDeleted
-                              ? () => markRowForDeletion(tabId, rowIndex, originalRow)
+                              ? () => markRowForDeletion(tabId, originalRow)
                               : undefined
                           }
                         >

--- a/apps/desktop/src/renderer/src/components/tab-query-editor.tsx
+++ b/apps/desktop/src/renderer/src/components/tab-query-editor.tsx
@@ -343,6 +343,15 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
       const executionId = crypto.randomUUID()
       updateTabExecuting(tabId, true, executionId)
 
+      // Drop any state writes from this execution if the tab has moved on (cancelled,
+      // re-run, or closed-and-reopened in the same session). Without this, a slow
+      // response from execution A can clobber the result of execution B that started
+      // after the user hit Stop or Run again.
+      const isStillCurrent = (): boolean => {
+        const t = useTabStore.getState().getTab(tabId)
+        return !!t && isExecutableTab(t) && t.executionId === executionId
+      }
+
       // Clear previous benchmark when running a new query
       setBenchmark(null)
 
@@ -354,6 +363,8 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
           executionId,
           queryTimeoutMs
         )
+
+        if (!isStillCurrent()) return
 
         if (response.success && response.data) {
           const data = response.data as {
@@ -392,7 +403,7 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
                 )
                 const countQuery = buildCountQuery(countTableRef)
                 const countResponse = await window.api.db.query(tabConnection, countQuery)
-                if (countResponse.success && countResponse.data) {
+                if (isStillCurrent() && countResponse.success && countResponse.data) {
                   const countData = countResponse.data as IpcQueryResult
                   if (countData.rows?.[0]) {
                     const totalCount = Number((countData.rows[0] as Record<string, unknown>).total)
@@ -454,11 +465,13 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
           })
         }
       } catch (error) {
+        if (!isStillCurrent()) return
         const errorMessage = error instanceof Error ? error.message : String(error)
         updateTabMultiResult(tabId, null, errorMessage)
         setTelemetry(null)
       } finally {
-        updateTabExecuting(tabId, false)
+        // CAS by executionId so a stale finally can't unset a newer execution's flag.
+        updateTabExecuting(tabId, false, undefined, executionId)
       }
     },
     [
@@ -480,11 +493,23 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
     if (!tab || !isExecutableTab(tab)) return
     if (!tab.isExecuting || !tab.executionId) return
 
+    // Snapshot the executionId we're cancelling. If the user starts a new query before
+    // the cancel response comes back, we mustn't overwrite the new query's state with
+    // "Query cancelled by user".
+    const cancelledExecutionId = tab.executionId
+
     try {
-      const response = await window.api.db.cancelQuery(tab.executionId)
+      const response = await window.api.db.cancelQuery(cancelledExecutionId)
       if (response.success) {
-        updateTabMultiResult(tabId, null, 'Query cancelled by user')
-        updateTabExecuting(tabId, false, null)
+        const current = useTabStore.getState().getTab(tabId)
+        if (
+          current &&
+          isExecutableTab(current) &&
+          current.executionId === cancelledExecutionId
+        ) {
+          updateTabMultiResult(tabId, null, 'Query cancelled by user')
+          updateTabExecuting(tabId, false, null, cancelledExecutionId)
+        }
       }
     } catch (error) {
       console.error('Failed to cancel query:', error)

--- a/apps/desktop/src/renderer/src/components/tab-query-editor.tsx
+++ b/apps/desktop/src/renderer/src/components/tab-query-editor.tsx
@@ -70,7 +70,7 @@ import {
   type DataTableColumn as EditableDataTableColumn
 } from '@/components/editable-data-table'
 import type { EditContext, TableInfo } from '@data-peek/shared'
-import { analyzeEditableSelect } from '@/lib/editable-select'
+import { analyzeEditableSelect, sqlMatchesStoredTable } from '@/lib/editable-select'
 import { SQLEditor } from '@/components/sql-editor'
 import { formatSQL } from '@/lib/sql-formatter'
 import { downloadCSV, downloadJSON, downloadSQL, generateExportFilename } from '@/lib/export'
@@ -393,8 +393,18 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
             updateTabMultiResult(tabId, multiResult, null)
             markTabSaved(tabId)
 
-            // For table preview tabs, fetch total count for server-side pagination
-            if (currentTab.type === 'table-preview') {
+            // For table preview tabs, fetch total count for server-side pagination —
+            // but only if the executed SQL still queries the stored table. If the user
+            // rewrote the SQL to a different table, the stored table's count would be
+            // wrong and would mislead the pagination footer.
+            const previewSqlMatches =
+              currentTab.type === 'table-preview' &&
+              sqlMatchesStoredTable(
+                queryToRun,
+                { schema: currentTab.schemaName, table: currentTab.tableName },
+                tabConnection.dbType
+              )
+            if (currentTab.type === 'table-preview' && previewSqlMatches) {
               try {
                 const countTableRef = buildQualifiedTableRef(
                   currentTab.schemaName,
@@ -529,8 +539,33 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
       )
         return
 
-      // Update pagination state and query in the store
-      updateTablePreviewPagination(tabId, page, pageSize)
+      // If the user has rewritten the editor SQL to a different table, we cannot
+      // safely rebuild a server-side pagination query — that would silently replace
+      // their typed SQL with a SELECT against the stored table. Update pagination
+      // state only; rendering falls back to client-side over the existing result set.
+      const sqlStillMatches = sqlMatchesStoredTable(
+        currentTab.savedQuery ?? currentTab.query,
+        { schema: currentTab.schemaName, table: currentTab.tableName },
+        tabConnection.dbType
+      )
+
+      if (!sqlStillMatches) {
+        updateTablePreviewPagination(tabId, page, pageSize, null)
+        return
+      }
+
+      const offset = (page - 1) * pageSize
+      const sqlTableRef = buildQualifiedTableRef(
+        currentTab.schemaName,
+        currentTab.tableName,
+        tabConnection.dbType
+      )
+      const rebuiltQuery = buildSelectQuery(sqlTableRef, tabConnection.dbType, {
+        limit: pageSize,
+        offset
+      })
+
+      updateTablePreviewPagination(tabId, page, pageSize, rebuiltQuery)
 
       // Re-run the query - handleRunQuery reads fresh state from store
       handleRunQuery()
@@ -1178,8 +1213,19 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
   const buildQueryWithFilters = (): string => {
     if (!tab || !isExecutableTab(tab)) return ''
 
-    // For table preview tabs, rebuild from scratch
-    if (tab.type === 'table-preview') {
+    // For table preview tabs, rebuild from the stored table — but only when the
+    // user hasn't rewritten the editor SQL to query something else. Otherwise we'd
+    // silently throw away their query and run a filtered statement against a
+    // different table than the one they've been looking at.
+    if (
+      tab.type === 'table-preview' &&
+      tabConnection &&
+      sqlMatchesStoredTable(
+        tab.savedQuery ?? tab.query,
+        { schema: tab.schemaName, table: tab.tableName },
+        tabConnection.dbType
+      )
+    ) {
       const tableRef = buildQualifiedTableRef(tab.schemaName, tab.tableName, tabConnection?.dbType)
       const wherePart = generateWhereClause(tableFilters)
       const orderPart = generateOrderByClause(tableSorting)
@@ -1191,6 +1237,8 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
         .replace(/\s+/g, ' ')
         .trim()
     }
+    // Fallthrough — when SQL has been rewritten, treat the tab as a query tab
+    // and inject WHERE/ORDER BY into the user's SQL.
 
     // For query tabs, try to inject WHERE/ORDER BY
     // This is simplified - a full implementation would parse the SQL AST

--- a/apps/desktop/src/renderer/src/components/tab-query-editor.tsx
+++ b/apps/desktop/src/renderer/src/components/tab-query-editor.tsx
@@ -404,26 +404,39 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
                 { schema: currentTab.schemaName, table: currentTab.tableName },
                 tabConnection.dbType
               )
-            if (currentTab.type === 'table-preview' && previewSqlMatches) {
-              try {
-                const countTableRef = buildQualifiedTableRef(
-                  currentTab.schemaName,
-                  currentTab.tableName,
-                  tabConnection.dbType
-                )
-                const countQuery = buildCountQuery(countTableRef)
-                const countResponse = await window.api.db.query(tabConnection, countQuery)
-                if (isStillCurrent() && countResponse.success && countResponse.data) {
-                  const countData = countResponse.data as IpcQueryResult
-                  if (countData.rows?.[0]) {
-                    const totalCount = Number((countData.rows[0] as Record<string, unknown>).total)
-                    if (!isNaN(totalCount)) {
-                      setTablePreviewTotalCount(tabId, totalCount)
+            if (currentTab.type === 'table-preview') {
+              if (previewSqlMatches) {
+                try {
+                  const countTableRef = buildQualifiedTableRef(
+                    currentTab.schemaName,
+                    currentTab.tableName,
+                    tabConnection.dbType
+                  )
+                  const countQuery = buildCountQuery(countTableRef)
+                  const countResponse = await window.api.db.query(tabConnection, countQuery)
+                  if (isStillCurrent() && countResponse.success && countResponse.data) {
+                    const countData = countResponse.data as IpcQueryResult
+                    if (countData.rows?.[0]) {
+                      const totalCount = Number(
+                        (countData.rows[0] as Record<string, unknown>).total
+                      )
+                      if (!isNaN(totalCount)) {
+                        setTablePreviewTotalCount(tabId, totalCount)
+                      }
                     }
+                  } else if (isStillCurrent()) {
+                    // Count query failed — drop any stale total so the footer falls back
+                    // to client-side pagination over the result we did get.
+                    setTablePreviewTotalCount(tabId, null)
                   }
+                } catch {
+                  if (isStillCurrent()) setTablePreviewTotalCount(tabId, null)
                 }
-              } catch {
-                // Silently fail count query - pagination will fall back to client-side
+              } else if (isStillCurrent()) {
+                // SQL diverged from the stored table — the previous totalRowCount was for
+                // a different row set; clear it so the UI exits server-side pagination
+                // mode rather than showing the wrong total.
+                setTablePreviewTotalCount(tabId, null)
               }
             }
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/editable-select.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/editable-select.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { analyzeEditableSelect } from '../editable-select'
+import { analyzeEditableSelect, sqlMatchesStoredTable } from '../editable-select'
 
 describe('analyzeEditableSelect', () => {
   describe('simple single-table selects', () => {
@@ -8,7 +8,8 @@ describe('analyzeEditableSelect', () => {
         schema: null,
         table: 'users',
         alias: null,
-        projection: { type: 'star' }
+        projection: { type: 'star' },
+        hasFilters: false
       })
     })
 
@@ -17,7 +18,8 @@ describe('analyzeEditableSelect', () => {
         schema: null,
         table: 'users',
         alias: null,
-        projection: { type: 'star' }
+        projection: { type: 'star' },
+        hasFilters: false
       })
     })
 
@@ -211,5 +213,71 @@ describe('analyzeEditableSelect', () => {
     it('MSSQL TOP', () => {
       expect(analyzeEditableSelect('SELECT TOP 10 * FROM users', 'mssql')).toBeNull()
     })
+  })
+
+  describe('hasFilters', () => {
+    it('is false for a bare SELECT *', () => {
+      expect(analyzeEditableSelect('SELECT * FROM users', 'postgresql')?.hasFilters).toBe(false)
+    })
+
+    it('is false when only LIMIT/OFFSET/ORDER BY is present', () => {
+      expect(
+        analyzeEditableSelect('SELECT * FROM users ORDER BY name LIMIT 10 OFFSET 5', 'postgresql')
+          ?.hasFilters
+      ).toBe(false)
+    })
+
+    it('is true for WHERE', () => {
+      expect(
+        analyzeEditableSelect('SELECT * FROM users WHERE id = 1', 'postgresql')?.hasFilters
+      ).toBe(true)
+    })
+
+    it('is true for FOR UPDATE / FOR SHARE', () => {
+      expect(
+        analyzeEditableSelect('SELECT * FROM users FOR UPDATE', 'postgresql')?.hasFilters
+      ).toBe(true)
+    })
+  })
+})
+
+describe('sqlMatchesStoredTable', () => {
+  const stored = { schema: 'public', table: 'users' }
+
+  it('returns true for the auto-built original', () => {
+    expect(sqlMatchesStoredTable('SELECT * FROM users LIMIT 100', stored, 'postgresql')).toBe(true)
+  })
+
+  it('returns true for ORDER BY + LIMIT (count is unaffected)', () => {
+    expect(
+      sqlMatchesStoredTable(
+        'SELECT * FROM users ORDER BY name LIMIT 100',
+        stored,
+        'postgresql'
+      )
+    ).toBe(true)
+  })
+
+  it('returns false when SQL has a WHERE — count of stored table no longer matches', () => {
+    // Repro for the silent footer bug: if this returned true, the COUNT(*) over
+    // public.users would tell the user "1 — 50 of 10000" while the actual filtered
+    // result has far fewer rows.
+    expect(
+      sqlMatchesStoredTable(
+        'SELECT * FROM users WHERE deleted = false',
+        stored,
+        'postgresql'
+      )
+    ).toBe(false)
+  })
+
+  it('returns false when SQL queries a different table', () => {
+    expect(sqlMatchesStoredTable('SELECT * FROM orders', stored, 'postgresql')).toBe(false)
+  })
+
+  it('returns true for empty/whitespace SQL (assumed initial auto-built)', () => {
+    expect(sqlMatchesStoredTable('', stored, 'postgresql')).toBe(true)
+    expect(sqlMatchesStoredTable('   ', stored, 'postgresql')).toBe(true)
+    expect(sqlMatchesStoredTable(null, stored, 'postgresql')).toBe(true)
   })
 })

--- a/apps/desktop/src/renderer/src/lib/editable-select.ts
+++ b/apps/desktop/src/renderer/src/lib/editable-select.ts
@@ -7,7 +7,28 @@ export interface EditableSelectInfo {
   table: string
   alias: string | null
   projection: ProjectionShape
+  /**
+   * Whether the SELECT carries a row-set-modifying clause (WHERE, GROUP BY, HAVING,
+   * UNION/INTERSECT/EXCEPT, FOR UPDATE/SHARE) at depth 0. ORDER BY / LIMIT / OFFSET
+   * don't count — they don't change the rows that come out, only their order/window,
+   * so a COUNT(*) over the bare table still answers the right question.
+   *
+   * Used by `sqlMatchesStoredTable` to decide whether the auto-built COUNT and the
+   * pagination/filter rebuild paths can still be trusted.
+   */
+  hasFilters: boolean
 }
+
+const FILTER_KEYWORDS = new Set([
+  'WHERE',
+  'GROUP',
+  'HAVING',
+  'UNION',
+  'INTERSECT',
+  'EXCEPT',
+  'FOR',
+  'WINDOW'
+])
 
 interface DialectConfig {
   dollarQuotes: boolean
@@ -327,21 +348,24 @@ const BLOCKING_KEYWORDS = new Set([
 ])
 
 /**
- * Returns true iff `sql` is a simple SELECT against the named table.
+ * Returns true iff `sql` is a simple, unfiltered SELECT against the named table —
+ * i.e. the count of rows the SQL returns equals the count of rows in the table.
  *
- * Use to gate features that assume the executed SQL still corresponds to a known
- * (schema, table) — e.g. table-preview's COUNT-for-pagination, server-side pagination
- * SQL rebuild, "Apply to Query" filter injection. When the user rewrites a table-preview
- * tab's SQL to something else, those features must NOT trust the tab's stored table name.
+ * Used by features that rebuild SQL or run a side-channel COUNT against the stored
+ * table: table-preview's COUNT-for-pagination, server-side pagination rebuild,
+ * "Apply to Query" filter injection. If the executed SQL has a WHERE/GROUP BY/HAVING
+ * etc., the row count of the stored table no longer equals what's onscreen and the
+ * COUNT(*)/rebuild would silently report or replace the wrong number of rows.
  */
 export function sqlMatchesStoredTable(
   sql: string | null | undefined,
   stored: { schema: string; table: string },
   dbType: DatabaseType
 ): boolean {
-  if (!sql) return true // Empty/missing SQL: assume the auto-built original.
+  if (!sql || !sql.trim()) return true // Empty/whitespace SQL: assume auto-built original.
   const info = analyzeEditableSelect(sql, dbType)
   if (!info) return false
+  if (info.hasFilters) return false // Predicates change the row set; can't trust stored counts.
   const lower = (s: string) => s.toLowerCase()
   if (lower(info.table) !== lower(stored.table)) return false
   if (info.schema && lower(info.schema) !== lower(stored.schema)) return false
@@ -409,11 +433,26 @@ export function analyzeEditableSelect(
   const table = parseFromTable(fromToks)
   if (!table) return null
 
+  // Walk the post-FROM tail at depth 0 looking for any row-set-modifying keyword.
+  // ORDER BY / LIMIT / OFFSET / FETCH are intentionally NOT in FILTER_KEYWORDS — they
+  // affect ordering and windowing but not the underlying row set.
+  let hasFilters = false
+  depth = 0
+  for (const t of afterFrom.slice(fromEnd)) {
+    if (t.type === 'LPAREN') depth++
+    else if (t.type === 'RPAREN') depth--
+    else if (depth === 0 && t.type === 'KEYWORD' && FILTER_KEYWORDS.has(t.value)) {
+      hasFilters = true
+      break
+    }
+  }
+
   return {
     schema: table.schema,
     table: table.table,
     alias: table.alias,
-    projection
+    projection,
+    hasFilters
   }
 }
 

--- a/apps/desktop/src/renderer/src/lib/editable-select.ts
+++ b/apps/desktop/src/renderer/src/lib/editable-select.ts
@@ -326,6 +326,28 @@ const BLOCKING_KEYWORDS = new Set([
   'INTO'
 ])
 
+/**
+ * Returns true iff `sql` is a simple SELECT against the named table.
+ *
+ * Use to gate features that assume the executed SQL still corresponds to a known
+ * (schema, table) — e.g. table-preview's COUNT-for-pagination, server-side pagination
+ * SQL rebuild, "Apply to Query" filter injection. When the user rewrites a table-preview
+ * tab's SQL to something else, those features must NOT trust the tab's stored table name.
+ */
+export function sqlMatchesStoredTable(
+  sql: string | null | undefined,
+  stored: { schema: string; table: string },
+  dbType: DatabaseType
+): boolean {
+  if (!sql) return true // Empty/missing SQL: assume the auto-built original.
+  const info = analyzeEditableSelect(sql, dbType)
+  if (!info) return false
+  const lower = (s: string) => s.toLowerCase()
+  if (lower(info.table) !== lower(stored.table)) return false
+  if (info.schema && lower(info.schema) !== lower(stored.schema)) return false
+  return true
+}
+
 export function analyzeEditableSelect(
   sql: string,
   dbType: DatabaseType

--- a/apps/desktop/src/renderer/src/stores/__tests__/edit-store.test.ts
+++ b/apps/desktop/src/renderer/src/stores/__tests__/edit-store.test.ts
@@ -95,122 +95,176 @@ describe('useEditStore', () => {
     })
   })
 
-  describe('cell editing', () => {
+  describe('cell editing (PK-keyed identity)', () => {
     beforeEach(() => {
       const store = useEditStore.getState()
       store.enterEditMode(tabId, createContext())
     })
 
-    it('should start cell edit', () => {
-      const store = useEditStore.getState()
-
-      store.startCellEdit(tabId, 0, 'name')
-
-      // Need to get fresh state after action
-      const tabEdit = useEditStore.getState().tabEdits.get(tabId)
-      expect(tabEdit?.editingCell).toEqual({ rowIndex: 0, columnName: 'name' })
-    })
-
-    it('should cancel cell edit', () => {
-      const store = useEditStore.getState()
-
-      store.startCellEdit(tabId, 0, 'name')
-      store.cancelCellEdit(tabId)
-
-      const tabEdit = store.tabEdits.get(tabId)
-      expect(tabEdit?.editingCell).toBeNull()
-    })
-
-    it('should update cell value', () => {
+    it('updates cell value identified by the row primary key', () => {
       const store = useEditStore.getState()
       const originalRow = { id: 1, name: 'John', email: 'john@example.com' }
 
-      store.updateCellValue(tabId, 0, 'name', 'Jane', originalRow)
+      store.updateCellValue(tabId, originalRow, 'name', 'Jane')
 
-      expect(store.getModifiedCellValue(tabId, 0, 'name')).toBe('Jane')
-      expect(store.isCellModified(tabId, 0, 'name')).toBe(true)
+      expect(store.getModifiedCellValue(tabId, originalRow, 'name')).toBe('Jane')
+      expect(store.isCellModified(tabId, originalRow, 'name')).toBe(true)
     })
 
-    it('should remove modification when value matches original', () => {
+    it('removes the modification when the value matches the original row value', () => {
       const store = useEditStore.getState()
       const originalRow = { id: 1, name: 'John', email: 'john@example.com' }
 
-      store.updateCellValue(tabId, 0, 'name', 'Jane', originalRow)
-      expect(store.isCellModified(tabId, 0, 'name')).toBe(true)
+      store.updateCellValue(tabId, originalRow, 'name', 'Jane')
+      expect(store.isCellModified(tabId, originalRow, 'name')).toBe(true)
 
-      store.updateCellValue(tabId, 0, 'name', 'John', originalRow)
-      expect(store.isCellModified(tabId, 0, 'name')).toBe(false)
+      store.updateCellValue(tabId, originalRow, 'name', 'John')
+      expect(store.isCellModified(tabId, originalRow, 'name')).toBe(false)
     })
 
-    it('should treat empty string as null when comparing to original null', () => {
+    it('treats empty string as null when the original value is null', () => {
       const store = useEditStore.getState()
       const originalRow = { id: 1, name: null, email: 'test@test.com' }
 
-      store.updateCellValue(tabId, 0, 'name', '', originalRow)
+      store.updateCellValue(tabId, originalRow, 'name', '')
 
-      // Empty string matching null should not be a modification
-      expect(store.isCellModified(tabId, 0, 'name')).toBe(false)
+      expect(store.isCellModified(tabId, originalRow, 'name')).toBe(false)
     })
 
-    it('should clear editing cell after update', () => {
+    it('tracks multiple cell modifications for the same row', () => {
       const store = useEditStore.getState()
       const originalRow = { id: 1, name: 'John', email: 'john@example.com' }
 
-      store.startCellEdit(tabId, 0, 'name')
-      store.updateCellValue(tabId, 0, 'name', 'Jane', originalRow)
+      store.updateCellValue(tabId, originalRow, 'name', 'Jane')
+      store.updateCellValue(tabId, originalRow, 'email', 'jane@example.com')
 
-      const tabEdit = store.tabEdits.get(tabId)
-      expect(tabEdit?.editingCell).toBeNull()
+      expect(store.isCellModified(tabId, originalRow, 'name')).toBe(true)
+      expect(store.isCellModified(tabId, originalRow, 'email')).toBe(true)
+      expect(store.getModifiedCellValue(tabId, originalRow, 'name')).toBe('Jane')
+      expect(store.getModifiedCellValue(tabId, originalRow, 'email')).toBe('jane@example.com')
     })
 
-    it('should track multiple cell modifications in the same row', () => {
+    it('refuses to record an edit when the row has a null primary key value', () => {
+      // Row with no usable PK identity. The store cannot safely build a WHERE clause
+      // for this row, so it must reject the edit instead of silently corrupting data.
       const store = useEditStore.getState()
-      const originalRow = { id: 1, name: 'John', email: 'john@example.com' }
+      const originalRow = { id: null, name: 'Orphan' }
 
-      store.updateCellValue(tabId, 0, 'name', 'Jane', originalRow)
-      store.updateCellValue(tabId, 0, 'email', 'jane@example.com', originalRow)
+      store.updateCellValue(tabId, originalRow, 'name', 'NewName')
 
-      expect(store.isCellModified(tabId, 0, 'name')).toBe(true)
-      expect(store.isCellModified(tabId, 0, 'email')).toBe(true)
-      expect(store.getModifiedCellValue(tabId, 0, 'name')).toBe('Jane')
-      expect(store.getModifiedCellValue(tabId, 0, 'email')).toBe('jane@example.com')
+      expect(store.isCellModified(tabId, originalRow, 'name')).toBe(false)
+      expect(store.hasPendingChanges(tabId)).toBe(false)
+    })
+
+    it('refuses to record an edit when the original row is missing a primary key column', () => {
+      const store = useEditStore.getState()
+      const originalRow = { name: 'Missing PK' } // no `id`
+
+      store.updateCellValue(tabId, originalRow, 'name', 'NewName')
+
+      expect(store.hasPendingChanges(tabId)).toBe(false)
+    })
+
+    it('handles composite primary keys', () => {
+      const store = useEditStore.getState()
+      store.enterEditMode(
+        'composite-tab',
+        createContext({
+          table: 'memberships',
+          primaryKeyColumns: ['userId', 'orgId']
+        })
+      )
+
+      const rowA = { userId: 1, orgId: 10, role: 'member' }
+      const rowB = { userId: 1, orgId: 20, role: 'member' }
+
+      store.updateCellValue('composite-tab', rowA, 'role', 'admin')
+      store.updateCellValue('composite-tab', rowB, 'role', 'owner')
+
+      expect(store.getModifiedCellValue('composite-tab', rowA, 'role')).toBe('admin')
+      expect(store.getModifiedCellValue('composite-tab', rowB, 'role')).toBe('owner')
+      expect(store.getPendingChangesCount('composite-tab').updates).toBe(2)
     })
   })
 
-  describe('row deletion', () => {
+  describe('row identity stability across display reordering', () => {
+    // These tests cover the silent-corruption class of bug fixed by PK-based keying.
     beforeEach(() => {
       const store = useEditStore.getState()
       store.enterEditMode(tabId, createContext())
     })
 
-    it('should mark row for deletion', () => {
+    it('merges edits to the same row reached via different display positions', () => {
+      // Repro: user edits row {id:5} at display index 0, then sorts the table; the same
+      // row is now at display index 3; user edits another column on it. The store should
+      // see ONE logical row with TWO column changes, not two separate operations.
       const store = useEditStore.getState()
-      const originalRow = { id: 1, name: 'John', email: 'john@example.com' }
+      const row = { id: 5, name: 'Original', email: 'orig@example.com' }
 
-      store.markRowForDeletion(tabId, 0, originalRow)
+      store.updateCellValue(tabId, row, 'name', 'Renamed')
+      // ... sort happens; rowIndex changes; but originalRow is the same object/values
+      store.updateCellValue(tabId, row, 'email', 'renamed@example.com')
 
-      expect(store.isRowMarkedForDeletion(tabId, 0)).toBe(true)
+      const batch = store.buildEditBatch(tabId, testColumns)
+      expect(batch).not.toBeNull()
+      expect(batch!.operations).toHaveLength(1)
+
+      const op = batch!.operations[0] as {
+        type: 'update'
+        changes: Array<{ column: string; newValue: unknown }>
+      }
+      expect(op.type).toBe('update')
+      expect(op.changes.map((c) => c.column).sort()).toEqual(['email', 'name'])
     })
 
-    it('should unmark row for deletion', () => {
+    it('keeps edits independent for different rows that happen to share a display position', () => {
+      // Repro: user edits row {id:5} on page 1. Switches to page 2; now row {id:50} sits
+      // at the same display position. Editing it must NOT collide with the first edit.
       const store = useEditStore.getState()
-      const originalRow = { id: 1, name: 'John', email: 'john@example.com' }
+      const rowOnPage1 = { id: 5, name: 'A', email: 'a@example.com' }
+      const rowOnPage2 = { id: 50, name: 'B', email: 'b@example.com' }
 
-      store.markRowForDeletion(tabId, 0, originalRow)
-      store.unmarkRowForDeletion(tabId, 0)
+      store.updateCellValue(tabId, rowOnPage1, 'name', 'A-edit')
+      store.updateCellValue(tabId, rowOnPage2, 'name', 'B-edit')
 
-      expect(store.isRowMarkedForDeletion(tabId, 0)).toBe(false)
+      expect(store.getModifiedCellValue(tabId, rowOnPage1, 'name')).toBe('A-edit')
+      expect(store.getModifiedCellValue(tabId, rowOnPage2, 'name')).toBe('B-edit')
+
+      const batch = store.buildEditBatch(tabId, testColumns)
+      expect(batch!.operations).toHaveLength(2)
     })
 
-    it('should track multiple deleted rows', () => {
+    it('preserves the original PK in the WHERE clause regardless of edit ordering', () => {
+      // Even if the user edits the same row many times from different display positions,
+      // the WHERE clause must use the row's PK from the captured snapshot.
       const store = useEditStore.getState()
+      const originalRow = { id: 42, name: 'Old', email: 'old@example.com' }
 
-      store.markRowForDeletion(tabId, 0, { id: 1, name: 'A' })
-      store.markRowForDeletion(tabId, 2, { id: 3, name: 'C' })
+      store.updateCellValue(tabId, originalRow, 'name', 'X')
+      store.updateCellValue(tabId, originalRow, 'name', 'Y')
+      store.updateCellValue(tabId, originalRow, 'name', 'Z')
 
-      expect(store.isRowMarkedForDeletion(tabId, 0)).toBe(true)
-      expect(store.isRowMarkedForDeletion(tabId, 1)).toBe(false)
-      expect(store.isRowMarkedForDeletion(tabId, 2)).toBe(true)
+      const batch = store.buildEditBatch(tabId, testColumns)
+      const op = batch!.operations[0] as {
+        type: 'update'
+        primaryKeys: Array<{ column: string; value: unknown }>
+        changes: Array<{ column: string; newValue: unknown }>
+      }
+      expect(op.primaryKeys[0].value).toBe(42)
+      expect(op.changes[0].newValue).toBe('Z')
+    })
+
+    it('marks the correct row for deletion by PK identity', () => {
+      const store = useEditStore.getState()
+      const rowA = { id: 1, name: 'A' }
+      const rowB = { id: 2, name: 'B' }
+
+      store.markRowForDeletion(tabId, rowA)
+      expect(store.isRowMarkedForDeletion(tabId, rowA)).toBe(true)
+      expect(store.isRowMarkedForDeletion(tabId, rowB)).toBe(false)
+
+      store.unmarkRowForDeletion(tabId, rowA)
+      expect(store.isRowMarkedForDeletion(tabId, rowA)).toBe(false)
     })
   })
 
@@ -266,55 +320,56 @@ describe('useEditStore', () => {
       store.enterEditMode(tabId, createContext())
     })
 
-    it('should revert single cell change', () => {
+    it('reverts a single cell change', () => {
       const store = useEditStore.getState()
       const originalRow = { id: 1, name: 'John', email: 'john@example.com' }
 
-      store.updateCellValue(tabId, 0, 'name', 'Jane', originalRow)
-      store.updateCellValue(tabId, 0, 'email', 'jane@example.com', originalRow)
+      store.updateCellValue(tabId, originalRow, 'name', 'Jane')
+      store.updateCellValue(tabId, originalRow, 'email', 'jane@example.com')
 
-      store.revertCellChange(tabId, 0, 'name')
+      store.revertCellChange(tabId, originalRow, 'name')
 
-      expect(store.isCellModified(tabId, 0, 'name')).toBe(false)
-      expect(store.isCellModified(tabId, 0, 'email')).toBe(true)
+      expect(store.isCellModified(tabId, originalRow, 'name')).toBe(false)
+      expect(store.isCellModified(tabId, originalRow, 'email')).toBe(true)
     })
 
-    it('should revert all row changes', () => {
+    it('reverts all changes for a row', () => {
       const store = useEditStore.getState()
       const originalRow = { id: 1, name: 'John', email: 'john@example.com' }
 
-      store.updateCellValue(tabId, 0, 'name', 'Jane', originalRow)
-      store.updateCellValue(tabId, 0, 'email', 'jane@example.com', originalRow)
+      store.updateCellValue(tabId, originalRow, 'name', 'Jane')
+      store.updateCellValue(tabId, originalRow, 'email', 'jane@example.com')
 
-      store.revertRowChanges(tabId, 0)
+      store.revertRowChanges(tabId, originalRow)
 
-      expect(store.isCellModified(tabId, 0, 'name')).toBe(false)
-      expect(store.isCellModified(tabId, 0, 'email')).toBe(false)
+      expect(store.isCellModified(tabId, originalRow, 'name')).toBe(false)
+      expect(store.isCellModified(tabId, originalRow, 'email')).toBe(false)
     })
 
-    it('should revert deletion when reverting row changes', () => {
+    it('reverts deletion when reverting row changes', () => {
       const store = useEditStore.getState()
       const originalRow = { id: 1, name: 'John', email: 'john@example.com' }
 
-      store.markRowForDeletion(tabId, 0, originalRow)
-      expect(store.isRowMarkedForDeletion(tabId, 0)).toBe(true)
+      store.markRowForDeletion(tabId, originalRow)
+      expect(store.isRowMarkedForDeletion(tabId, originalRow)).toBe(true)
 
-      store.revertRowChanges(tabId, 0)
-      expect(store.isRowMarkedForDeletion(tabId, 0)).toBe(false)
+      store.revertRowChanges(tabId, originalRow)
+      expect(store.isRowMarkedForDeletion(tabId, originalRow)).toBe(false)
     })
 
-    it('should revert all changes', () => {
+    it('reverts everything', () => {
       const store = useEditStore.getState()
-      const originalRow = { id: 1, name: 'John', email: 'john@example.com' }
+      const rowA = { id: 1, name: 'John', email: 'john@example.com' }
+      const rowB = { id: 2, name: 'Bob' }
 
-      store.updateCellValue(tabId, 0, 'name', 'Jane', originalRow)
-      store.markRowForDeletion(tabId, 1, { id: 2, name: 'Bob' })
+      store.updateCellValue(tabId, rowA, 'name', 'Jane')
+      store.markRowForDeletion(tabId, rowB)
       store.addNewRow(tabId, { name: 'New' })
 
       store.revertAllChanges(tabId)
 
-      expect(store.isCellModified(tabId, 0, 'name')).toBe(false)
-      expect(store.isRowMarkedForDeletion(tabId, 1)).toBe(false)
+      expect(store.isCellModified(tabId, rowA, 'name')).toBe(false)
+      expect(store.isRowMarkedForDeletion(tabId, rowB)).toBe(false)
       expect(store.getNewRows(tabId)).toHaveLength(0)
     })
   })
@@ -325,17 +380,19 @@ describe('useEditStore', () => {
       store.enterEditMode(tabId, createContext())
     })
 
-    it('should count pending updates', () => {
+    it('counts pending updates by unique row identity', () => {
       const store = useEditStore.getState()
 
-      store.updateCellValue(tabId, 0, 'name', 'A', { id: 1, name: 'B', email: 'test@test.com' })
-      store.updateCellValue(tabId, 1, 'name', 'C', { id: 2, name: 'D', email: 'test2@test.com' })
+      store.updateCellValue(tabId, { id: 1, name: 'B', email: 'a@x' }, 'name', 'A')
+      store.updateCellValue(tabId, { id: 2, name: 'D', email: 'b@x' }, 'name', 'C')
+      // Multiple cells on the same row count as ONE update operation:
+      store.updateCellValue(tabId, { id: 1, name: 'B', email: 'a@x' }, 'email', 'aa@x')
 
       const counts = store.getPendingChangesCount(tabId)
       expect(counts.updates).toBe(2)
     })
 
-    it('should count pending inserts', () => {
+    it('counts pending inserts', () => {
       const store = useEditStore.getState()
 
       store.addNewRow(tabId, { name: 'A' })
@@ -345,30 +402,29 @@ describe('useEditStore', () => {
       expect(counts.inserts).toBe(2)
     })
 
-    it('should count pending deletes', () => {
+    it('counts pending deletes', () => {
       const store = useEditStore.getState()
 
-      store.markRowForDeletion(tabId, 0, { id: 1 })
-      store.markRowForDeletion(tabId, 1, { id: 2 })
+      store.markRowForDeletion(tabId, { id: 1 })
+      store.markRowForDeletion(tabId, { id: 2 })
 
       const counts = store.getPendingChangesCount(tabId)
       expect(counts.deletes).toBe(2)
     })
 
-    it('should not count deleted rows as updates', () => {
+    it('does not count modified rows that are also marked for deletion', () => {
       const store = useEditStore.getState()
       const originalRow = { id: 1, name: 'John', email: 'john@example.com' }
 
-      // Modify and then delete the same row
-      store.updateCellValue(tabId, 0, 'name', 'Jane', originalRow)
-      store.markRowForDeletion(tabId, 0, originalRow)
+      store.updateCellValue(tabId, originalRow, 'name', 'Jane')
+      store.markRowForDeletion(tabId, originalRow)
 
       const counts = store.getPendingChangesCount(tabId)
-      expect(counts.updates).toBe(0) // Not counted as update since it's deleted
+      expect(counts.updates).toBe(0)
       expect(counts.deletes).toBe(1)
     })
 
-    it('should report hasPendingChanges correctly', () => {
+    it('reports hasPendingChanges correctly', () => {
       const store = useEditStore.getState()
 
       expect(store.hasPendingChanges(tabId)).toBe(false)
@@ -387,11 +443,11 @@ describe('useEditStore', () => {
       store.enterEditMode(tabId, createContext())
     })
 
-    it('should return null when no context', () => {
+    it('returns null when no context', () => {
       const store = useEditStore.getState()
       store.exitEditMode(tabId)
 
-      // Clear the context
+      // Manually clear the context (simulating internal state mutation)
       useEditStore.setState((state) => {
         const newTabEdits = new Map(state.tabEdits)
         const existing = newTabEdits.get(tabId)
@@ -405,18 +461,18 @@ describe('useEditStore', () => {
       expect(batch).toBeNull()
     })
 
-    it('should return null when no changes', () => {
+    it('returns null when there are no changes', () => {
       const store = useEditStore.getState()
 
       const batch = store.buildEditBatch(tabId, testColumns)
       expect(batch).toBeNull()
     })
 
-    it('should build update operations', () => {
+    it('builds an update operation', () => {
       const store = useEditStore.getState()
       const originalRow = { id: 1, name: 'John', email: 'john@example.com' }
 
-      store.updateCellValue(tabId, 0, 'name', 'Jane', originalRow)
+      store.updateCellValue(tabId, originalRow, 'name', 'Jane')
 
       const batch = store.buildEditBatch(tabId, testColumns)
 
@@ -433,11 +489,11 @@ describe('useEditStore', () => {
       expect(updateOp.changes[0].newValue).toBe('Jane')
     })
 
-    it('should build delete operations', () => {
+    it('builds a delete operation', () => {
       const store = useEditStore.getState()
       const originalRow = { id: 1, name: 'John', email: 'john@example.com' }
 
-      store.markRowForDeletion(tabId, 0, originalRow)
+      store.markRowForDeletion(tabId, originalRow)
 
       const batch = store.buildEditBatch(tabId, testColumns)
 
@@ -446,7 +502,7 @@ describe('useEditStore', () => {
       expect(batch!.operations[0].type).toBe('delete')
     })
 
-    it('should build insert operations', () => {
+    it('builds an insert operation', () => {
       const store = useEditStore.getState()
 
       store.addNewRow(tabId, { name: 'New User', email: 'new@example.com' })
@@ -461,12 +517,12 @@ describe('useEditStore', () => {
       expect(insertOp.values.name).toBe('New User')
     })
 
-    it('should skip update for deleted rows', () => {
+    it('skips the update for a row that is also marked for deletion', () => {
       const store = useEditStore.getState()
       const originalRow = { id: 1, name: 'John', email: 'john@example.com' }
 
-      store.updateCellValue(tabId, 0, 'name', 'Jane', originalRow)
-      store.markRowForDeletion(tabId, 0, originalRow)
+      store.updateCellValue(tabId, originalRow, 'name', 'Jane')
+      store.markRowForDeletion(tabId, originalRow)
 
       const batch = store.buildEditBatch(tabId, testColumns)
 
@@ -474,11 +530,11 @@ describe('useEditStore', () => {
       expect(batch!.operations[0].type).toBe('delete')
     })
 
-    it('should include primary key values in operations', () => {
+    it('includes the row primary key in update operations', () => {
       const store = useEditStore.getState()
       const originalRow = { id: 42, name: 'John', email: 'john@example.com' }
 
-      store.updateCellValue(tabId, 0, 'name', 'Jane', originalRow)
+      store.updateCellValue(tabId, originalRow, 'name', 'Jane')
 
       const batch = store.buildEditBatch(tabId, testColumns)
       const updateOp = batch!.operations[0] as {
@@ -490,6 +546,65 @@ describe('useEditStore', () => {
       expect(updateOp.primaryKeys[0].column).toBe('id')
       expect(updateOp.primaryKeys[0].value).toBe(42)
     })
+
+    it('includes all primary key columns for composite keys', () => {
+      const store = useEditStore.getState()
+      store.enterEditMode(
+        'composite-tab',
+        createContext({
+          table: 'memberships',
+          primaryKeyColumns: ['userId', 'orgId']
+        })
+      )
+      const originalRow = { userId: 7, orgId: 99, role: 'member' }
+
+      store.updateCellValue('composite-tab', originalRow, 'role', 'admin')
+
+      const batch = store.buildEditBatch('composite-tab', testColumns)
+      const updateOp = batch!.operations[0] as {
+        type: 'update'
+        primaryKeys: Array<{ column: string; value: unknown }>
+      }
+      const pkMap = Object.fromEntries(updateOp.primaryKeys.map((p) => [p.column, p.value]))
+      expect(pkMap).toEqual({ userId: 7, orgId: 99 })
+    })
+  })
+
+  describe('cell focus (transient UI state)', () => {
+    beforeEach(() => {
+      const store = useEditStore.getState()
+      store.enterEditMode(tabId, createContext())
+    })
+
+    it('tracks the currently editing cell by display position', () => {
+      const store = useEditStore.getState()
+
+      store.startCellEdit(tabId, 0, 'name')
+
+      const tabEdit = useEditStore.getState().tabEdits.get(tabId)
+      expect(tabEdit?.editingCell).toEqual({ rowIndex: 0, columnName: 'name' })
+    })
+
+    it('clears editing cell on cancel', () => {
+      const store = useEditStore.getState()
+
+      store.startCellEdit(tabId, 0, 'name')
+      store.cancelCellEdit(tabId)
+
+      const tabEdit = useEditStore.getState().tabEdits.get(tabId)
+      expect(tabEdit?.editingCell).toBeNull()
+    })
+
+    it('clears the editing cell after a value update', () => {
+      const store = useEditStore.getState()
+      const originalRow = { id: 1, name: 'John', email: 'john@example.com' }
+
+      store.startCellEdit(tabId, 0, 'name')
+      store.updateCellValue(tabId, originalRow, 'name', 'Jane')
+
+      const tabEdit = useEditStore.getState().tabEdits.get(tabId)
+      expect(tabEdit?.editingCell).toBeNull()
+    })
   })
 
   describe('clearPendingChanges', () => {
@@ -498,20 +613,21 @@ describe('useEditStore', () => {
       store.enterEditMode(tabId, createContext())
     })
 
-    it('should clear all pending changes while preserving edit mode', () => {
+    it('clears all pending changes while preserving edit mode', () => {
       const store = useEditStore.getState()
-      const originalRow = { id: 1, name: 'John', email: 'john@example.com' }
+      const rowA = { id: 1, name: 'John', email: 'john@example.com' }
+      const rowB = { id: 2, name: 'Bob' }
 
-      store.updateCellValue(tabId, 0, 'name', 'Jane', originalRow)
-      store.markRowForDeletion(tabId, 1, { id: 2, name: 'Bob' })
+      store.updateCellValue(tabId, rowA, 'name', 'Jane')
+      store.markRowForDeletion(tabId, rowB)
       store.addNewRow(tabId, { name: 'New' })
 
       store.clearPendingChanges(tabId)
 
-      expect(store.isInEditMode(tabId)).toBe(true) // Edit mode preserved
+      expect(store.isInEditMode(tabId)).toBe(true)
       expect(store.hasPendingChanges(tabId)).toBe(false)
-      expect(store.isCellModified(tabId, 0, 'name')).toBe(false)
-      expect(store.isRowMarkedForDeletion(tabId, 1)).toBe(false)
+      expect(store.isCellModified(tabId, rowA, 'name')).toBe(false)
+      expect(store.isRowMarkedForDeletion(tabId, rowB)).toBe(false)
       expect(store.getNewRows(tabId)).toHaveLength(0)
     })
   })

--- a/apps/desktop/src/renderer/src/stores/__tests__/edit-store.test.ts
+++ b/apps/desktop/src/renderer/src/stores/__tests__/edit-store.test.ts
@@ -630,5 +630,66 @@ describe('useEditStore', () => {
       expect(store.isRowMarkedForDeletion(tabId, rowB)).toBe(false)
       expect(store.getNewRows(tabId)).toHaveLength(0)
     })
+
+    it('clears the editing cell focus too', () => {
+      // Otherwise a cell that was mid-edit when results were replaced reappears as
+      // "in edit mode" at the same display index over fresh rows, and Enter commits
+      // an UPDATE the user never meant to make.
+      const store = useEditStore.getState()
+
+      store.startCellEdit(tabId, 0, 'name')
+      store.clearPendingChanges(tabId)
+
+      const tabEdit = useEditStore.getState().tabEdits.get(tabId)
+      expect(tabEdit?.editingCell).toBeNull()
+    })
+  })
+
+  describe('revertAllChanges', () => {
+    beforeEach(() => {
+      const store = useEditStore.getState()
+      store.enterEditMode(tabId, createContext())
+    })
+
+    it('clears the editing cell focus too', () => {
+      const store = useEditStore.getState()
+
+      store.startCellEdit(tabId, 0, 'name')
+      store.revertAllChanges(tabId)
+
+      const tabEdit = useEditStore.getState().tabEdits.get(tabId)
+      expect(tabEdit?.editingCell).toBeNull()
+    })
+  })
+
+  describe('bigint primary keys (no JSON.stringify throw)', () => {
+    beforeEach(() => {
+      const store = useEditStore.getState()
+      store.enterEditMode(tabId, createContext({ primaryKeyColumns: ['id'] }))
+    })
+
+    it('records an edit for a row whose PK value is a bigint without throwing', () => {
+      // pg returns bigint as string by default but pg-types can be configured to
+      // produce native BigInt. JSON.stringify throws on BigInt, and the throw used
+      // to happen inside a Zustand updater — leaving the store mid-mutation and
+      // killing every subsequent edit on the tab.
+      const store = useEditStore.getState()
+      const row = { id: 9007199254740993n, name: 'Big' }
+
+      expect(() => store.updateCellValue(tabId, row, 'name', 'Bigger')).not.toThrow()
+      expect(store.getModifiedCellValue(tabId, row, 'name')).toBe('Bigger')
+    })
+
+    it('treats two rows with different bigint PKs as independent', () => {
+      const store = useEditStore.getState()
+      const a = { id: 1n, name: 'A' }
+      const b = { id: 2n, name: 'B' }
+
+      store.updateCellValue(tabId, a, 'name', 'A-edit')
+      store.updateCellValue(tabId, b, 'name', 'B-edit')
+
+      expect(store.getModifiedCellValue(tabId, a, 'name')).toBe('A-edit')
+      expect(store.getModifiedCellValue(tabId, b, 'name')).toBe('B-edit')
+    })
   })
 })

--- a/apps/desktop/src/renderer/src/stores/__tests__/tab-lifecycle.test.ts
+++ b/apps/desktop/src/renderer/src/stores/__tests__/tab-lifecycle.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { useTabStore } from '../tab-store'
+
+vi.stubGlobal('crypto', {
+  randomUUID: () => 'test-uuid-' + Math.random().toString(36).slice(2)
+})
+
+// Stub window.api so closeTab can fire the cancel call.
+const cancelSpy = vi.fn().mockResolvedValue({ success: true, data: { cancelled: true } })
+
+vi.stubGlobal('window', {
+  api: {
+    db: {
+      cancelQuery: cancelSpy
+    }
+  }
+})
+
+describe('updateTabExecuting compare-and-swap by executionId', () => {
+  beforeEach(() => {
+    useTabStore.setState({ tabs: [], activeTabId: null })
+    cancelSpy.mockClear()
+  })
+
+  it('refuses to flip isExecuting when expectedExecutionId does not match the live one', () => {
+    const tabId = useTabStore.getState().createQueryTab(null, 'SELECT 1')
+    useTabStore.getState().updateTabExecuting(tabId, true, 'exec-A')
+
+    // A stale "finally" from execution B tries to clear the flag.
+    useTabStore.getState().updateTabExecuting(tabId, false, undefined, 'exec-B')
+
+    const tab = useTabStore.getState().getTab(tabId)
+    expect(tab && 'isExecuting' in tab && tab.isExecuting).toBe(true)
+    expect(tab && 'executionId' in tab && tab.executionId).toBe('exec-A')
+  })
+
+  it('flips isExecuting when expectedExecutionId matches', () => {
+    const tabId = useTabStore.getState().createQueryTab(null, 'SELECT 1')
+    useTabStore.getState().updateTabExecuting(tabId, true, 'exec-A')
+
+    useTabStore.getState().updateTabExecuting(tabId, false, undefined, 'exec-A')
+
+    const tab = useTabStore.getState().getTab(tabId)
+    expect(tab && 'isExecuting' in tab && tab.isExecuting).toBe(false)
+    expect(tab && 'executionId' in tab && tab.executionId).toBe(null)
+  })
+
+  it('still works without expectedExecutionId for backwards compatibility', () => {
+    const tabId = useTabStore.getState().createQueryTab(null, 'SELECT 1')
+    useTabStore.getState().updateTabExecuting(tabId, true, 'exec-A')
+
+    useTabStore.getState().updateTabExecuting(tabId, false)
+
+    const tab = useTabStore.getState().getTab(tabId)
+    expect(tab && 'isExecuting' in tab && tab.isExecuting).toBe(false)
+  })
+})
+
+describe('closeTab cancels in-flight queries', () => {
+  beforeEach(() => {
+    useTabStore.setState({ tabs: [], activeTabId: null })
+    cancelSpy.mockClear()
+  })
+
+  it('fires cancelQuery when closing a tab that is executing', () => {
+    const tabId = useTabStore.getState().createQueryTab(null, 'SELECT pg_sleep(60)')
+    useTabStore.getState().updateTabExecuting(tabId, true, 'long-running-exec')
+
+    useTabStore.getState().closeTab(tabId)
+
+    expect(cancelSpy).toHaveBeenCalledTimes(1)
+    expect(cancelSpy).toHaveBeenCalledWith('long-running-exec')
+  })
+
+  it('does not call cancelQuery when closing an idle tab', () => {
+    const tabId = useTabStore.getState().createQueryTab(null, 'SELECT 1')
+
+    useTabStore.getState().closeTab(tabId)
+
+    expect(cancelSpy).not.toHaveBeenCalled()
+  })
+
+  it('does not call cancelQuery when closeTab is a no-op (pinned tab)', () => {
+    const tabId = useTabStore.getState().createQueryTab(null, 'SELECT 1')
+    useTabStore.getState().pinTab(tabId)
+    useTabStore.getState().updateTabExecuting(tabId, true, 'exec-X')
+
+    useTabStore.getState().closeTab(tabId)
+
+    expect(cancelSpy).not.toHaveBeenCalled()
+    // Tab still present
+    expect(useTabStore.getState().getTab(tabId)).toBeDefined()
+  })
+})

--- a/apps/desktop/src/renderer/src/stores/__tests__/tab-lifecycle.test.ts
+++ b/apps/desktop/src/renderer/src/stores/__tests__/tab-lifecycle.test.ts
@@ -88,7 +88,51 @@ describe('closeTab cancels in-flight queries', () => {
     useTabStore.getState().closeTab(tabId)
 
     expect(cancelSpy).not.toHaveBeenCalled()
-    // Tab still present
     expect(useTabStore.getState().getTab(tabId)).toBeDefined()
+  })
+
+  it('closeAllTabs cancels every executing non-pinned tab', () => {
+    const a = useTabStore.getState().createQueryTab(null, 'SELECT 1')
+    const b = useTabStore.getState().createQueryTab(null, 'SELECT 2')
+    const idle = useTabStore.getState().createQueryTab(null, 'SELECT 3')
+    useTabStore.getState().updateTabExecuting(a, true, 'exec-a')
+    useTabStore.getState().updateTabExecuting(b, true, 'exec-b')
+
+    useTabStore.getState().closeAllTabs()
+
+    expect(cancelSpy).toHaveBeenCalledTimes(2)
+    expect(cancelSpy).toHaveBeenCalledWith('exec-a')
+    expect(cancelSpy).toHaveBeenCalledWith('exec-b')
+    expect(useTabStore.getState().getTab(idle)).toBeUndefined()
+  })
+
+  it('closeOtherTabs cancels other executing tabs but leaves the kept tab alone', () => {
+    const keep = useTabStore.getState().createQueryTab(null, 'SELECT keep')
+    const other = useTabStore.getState().createQueryTab(null, 'SELECT other')
+    useTabStore.getState().updateTabExecuting(keep, true, 'exec-keep')
+    useTabStore.getState().updateTabExecuting(other, true, 'exec-other')
+
+    useTabStore.getState().closeOtherTabs(keep)
+
+    expect(cancelSpy).toHaveBeenCalledTimes(1)
+    expect(cancelSpy).toHaveBeenCalledWith('exec-other')
+    expect(useTabStore.getState().getTab(keep)).toBeDefined()
+  })
+
+  it('closeTabsToRight cancels only the tabs to the right that are executing', () => {
+    const left = useTabStore.getState().createQueryTab(null, 'SELECT left')
+    const middle = useTabStore.getState().createQueryTab(null, 'SELECT middle')
+    const right = useTabStore.getState().createQueryTab(null, 'SELECT right')
+    useTabStore.getState().updateTabExecuting(left, true, 'exec-left')
+    useTabStore.getState().updateTabExecuting(middle, true, 'exec-middle')
+    useTabStore.getState().updateTabExecuting(right, true, 'exec-right')
+
+    useTabStore.getState().closeTabsToRight(middle)
+
+    expect(cancelSpy).toHaveBeenCalledTimes(1)
+    expect(cancelSpy).toHaveBeenCalledWith('exec-right')
+    expect(useTabStore.getState().getTab(left)).toBeDefined()
+    expect(useTabStore.getState().getTab(middle)).toBeDefined()
+    expect(useTabStore.getState().getTab(right)).toBeUndefined()
   })
 })

--- a/apps/desktop/src/renderer/src/stores/__tests__/tab-result-invalidation.test.ts
+++ b/apps/desktop/src/renderer/src/stores/__tests__/tab-result-invalidation.test.ts
@@ -78,15 +78,23 @@ describe('tab-store invalidates pending edits when results change', () => {
     expect(useEditStore.getState().hasPendingChanges(tabId)).toBe(false)
   })
 
-  it('updateTabResult preserves pending edits when called with the same null result (no-op)', () => {
-    // Setting result to null with no rows shouldn't drop edits a user is mid-flight on —
-    // but the simpler invariant is: any time the result identity changes, drop edits.
-    // To keep this simple and safe, we always drop. This test pins that contract.
+  it('updateTabResult does NOT drop pending edits when called with a null result', () => {
+    // A null result means "cancel/error blanked the panel", not "new rows arrived".
+    // The user's edits are still valid against whatever was previously displayed —
+    // wiping them on Stop would silently destroy in-flight work.
     const tabId = setupTabWithEdits()
 
-    useTabStore.getState().updateTabResult(tabId, null, 'some error')
+    useTabStore.getState().updateTabResult(tabId, null, 'Query cancelled by user')
 
-    expect(useEditStore.getState().hasPendingChanges(tabId)).toBe(false)
+    expect(useEditStore.getState().hasPendingChanges(tabId)).toBe(true)
+  })
+
+  it('updateTabMultiResult does NOT drop pending edits when called with a null multiResult', () => {
+    const tabId = setupTabWithEdits()
+
+    useTabStore.getState().updateTabMultiResult(tabId, null, 'Query cancelled by user')
+
+    expect(useEditStore.getState().hasPendingChanges(tabId)).toBe(true)
   })
 
   it('setActiveResultIndex drops pending edits because they were captured against the previous statement', () => {
@@ -138,7 +146,16 @@ describe('tab-store invalidates pending edits when results change', () => {
     expect(useEditStore.getState().hasPendingChanges(tab1)).toBe(true)
     expect(useEditStore.getState().hasPendingChanges(tab2)).toBe(true)
 
-    useTabStore.getState().updateTabResult(tab1, null, null)
+    useTabStore.getState().updateTabResult(
+      tab1,
+      {
+        columns: [{ name: 'id', dataType: 'integer' }],
+        rows: [{ id: 1 }],
+        rowCount: 1,
+        durationMs: 1
+      },
+      null
+    )
 
     expect(useEditStore.getState().hasPendingChanges(tab1)).toBe(false)
     expect(useEditStore.getState().hasPendingChanges(tab2)).toBe(true)

--- a/apps/desktop/src/renderer/src/stores/__tests__/tab-result-invalidation.test.ts
+++ b/apps/desktop/src/renderer/src/stores/__tests__/tab-result-invalidation.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { useTabStore } from '../tab-store'
+import { useEditStore } from '../edit-store'
+import type { EditContext } from '@data-peek/shared'
+
+vi.stubGlobal('crypto', {
+  randomUUID: () => 'test-uuid-' + Math.random().toString(36).slice(2)
+})
+
+const sampleContext: EditContext = {
+  schema: 'public',
+  table: 'users',
+  primaryKeyColumns: ['id'],
+  columns: [
+    { name: 'id', dataType: 'integer', isNullable: false, isPrimaryKey: true, ordinalPosition: 1 },
+    { name: 'name', dataType: 'varchar', isNullable: true, isPrimaryKey: false, ordinalPosition: 2 }
+  ]
+}
+
+describe('tab-store invalidates pending edits when results change', () => {
+  beforeEach(() => {
+    useTabStore.setState({ tabs: [], activeTabId: null })
+    useEditStore.setState({ tabEdits: new Map() })
+  })
+
+  function setupTabWithEdits(): string {
+    const tabId = useTabStore.getState().createQueryTab(null, 'SELECT * FROM users')
+    const edit = useEditStore.getState()
+    edit.enterEditMode(tabId, sampleContext)
+    edit.updateCellValue(tabId, { id: 1, name: 'Original' }, 'name', 'Modified')
+    edit.markRowForDeletion(tabId, { id: 2, name: 'Doomed' })
+    edit.addNewRow(tabId, { name: 'Brand New' })
+    return tabId
+  }
+
+  it('updateTabResult drops stale pending edits so they cannot commit against new rows', () => {
+    const tabId = setupTabWithEdits()
+    expect(useEditStore.getState().hasPendingChanges(tabId)).toBe(true)
+
+    useTabStore.getState().updateTabResult(
+      tabId,
+      {
+        columns: [{ name: 'id', dataType: 'integer' }],
+        rows: [{ id: 99 }],
+        rowCount: 1,
+        durationMs: 1
+      },
+      null
+    )
+
+    expect(useEditStore.getState().hasPendingChanges(tabId)).toBe(false)
+  })
+
+  it('updateTabMultiResult drops stale pending edits', () => {
+    const tabId = setupTabWithEdits()
+    expect(useEditStore.getState().hasPendingChanges(tabId)).toBe(true)
+
+    useTabStore.getState().updateTabMultiResult(
+      tabId,
+      {
+        statements: [
+          {
+            index: 0,
+            statement: 'SELECT * FROM users',
+            success: true,
+            fields: [{ name: 'id', dataType: 'integer' }],
+            rows: [{ id: 99 }],
+            rowCount: 1,
+            durationMs: 1
+          }
+        ],
+        totalDurationMs: 1,
+        statementCount: 1
+      },
+      null
+    )
+
+    expect(useEditStore.getState().hasPendingChanges(tabId)).toBe(false)
+  })
+
+  it('updateTabResult preserves pending edits when called with the same null result (no-op)', () => {
+    // Setting result to null with no rows shouldn't drop edits a user is mid-flight on —
+    // but the simpler invariant is: any time the result identity changes, drop edits.
+    // To keep this simple and safe, we always drop. This test pins that contract.
+    const tabId = setupTabWithEdits()
+
+    useTabStore.getState().updateTabResult(tabId, null, 'some error')
+
+    expect(useEditStore.getState().hasPendingChanges(tabId)).toBe(false)
+  })
+
+  it('setActiveResultIndex drops pending edits because they were captured against the previous statement', () => {
+    const tabId = setupTabWithEdits()
+
+    useTabStore.getState().updateTabMultiResult(
+      tabId,
+      {
+        statements: [
+          {
+            index: 0,
+            statement: 'SELECT * FROM users',
+            success: true,
+            fields: [{ name: 'id', dataType: 'integer' }],
+            rows: [{ id: 1 }],
+            rowCount: 1,
+            durationMs: 1
+          },
+          {
+            index: 1,
+            statement: 'SELECT * FROM orders',
+            success: true,
+            fields: [{ name: 'id', dataType: 'integer' }],
+            rows: [{ id: 100 }],
+            rowCount: 1,
+            durationMs: 1
+          }
+        ],
+        totalDurationMs: 2,
+        statementCount: 2
+      },
+      null
+    )
+
+    // Setting the result already cleared edits; re-add some so we can test setActiveResultIndex.
+    const edit = useEditStore.getState()
+    edit.enterEditMode(tabId, sampleContext)
+    edit.updateCellValue(tabId, { id: 1, name: 'Original' }, 'name', 'Modified')
+    expect(edit.hasPendingChanges(tabId)).toBe(true)
+
+    useTabStore.getState().setActiveResultIndex(tabId, 1)
+
+    expect(useEditStore.getState().hasPendingChanges(tabId)).toBe(false)
+  })
+
+  it('does not affect pending edits on other tabs', () => {
+    const tab1 = setupTabWithEdits()
+    const tab2 = setupTabWithEdits()
+    expect(useEditStore.getState().hasPendingChanges(tab1)).toBe(true)
+    expect(useEditStore.getState().hasPendingChanges(tab2)).toBe(true)
+
+    useTabStore.getState().updateTabResult(tab1, null, null)
+
+    expect(useEditStore.getState().hasPendingChanges(tab1)).toBe(false)
+    expect(useEditStore.getState().hasPendingChanges(tab2)).toBe(true)
+  })
+})

--- a/apps/desktop/src/renderer/src/stores/__tests__/tab-result-invalidation.test.ts
+++ b/apps/desktop/src/renderer/src/stores/__tests__/tab-result-invalidation.test.ts
@@ -60,9 +60,9 @@ describe('tab-store invalidates pending edits when results change', () => {
       {
         statements: [
           {
-            index: 0,
+            statementIndex: 0,
+            isDataReturning: true,
             statement: 'SELECT * FROM users',
-            success: true,
             fields: [{ name: 'id', dataType: 'integer' }],
             rows: [{ id: 99 }],
             rowCount: 1,
@@ -97,18 +97,18 @@ describe('tab-store invalidates pending edits when results change', () => {
       {
         statements: [
           {
-            index: 0,
+            statementIndex: 0,
+            isDataReturning: true,
             statement: 'SELECT * FROM users',
-            success: true,
             fields: [{ name: 'id', dataType: 'integer' }],
             rows: [{ id: 1 }],
             rowCount: 1,
             durationMs: 1
           },
           {
-            index: 1,
+            statementIndex: 1,
+            isDataReturning: true,
             statement: 'SELECT * FROM orders',
-            success: true,
             fields: [{ name: 'id', dataType: 'integer' }],
             rows: [{ id: 100 }],
             rowCount: 1,

--- a/apps/desktop/src/renderer/src/stores/__tests__/table-preview-pagination.test.ts
+++ b/apps/desktop/src/renderer/src/stores/__tests__/table-preview-pagination.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { useTabStore } from '../tab-store'
+import { useConnectionStore } from '../connection-store'
+
+vi.stubGlobal('crypto', {
+  randomUUID: () => 'test-uuid-' + Math.random().toString(36).slice(2)
+})
+vi.stubGlobal('window', { api: { db: { cancelQuery: vi.fn() } } })
+
+describe('updateTablePreviewPagination', () => {
+  beforeEach(() => {
+    useTabStore.setState({ tabs: [], activeTabId: null })
+    useConnectionStore.setState({
+      connections: [
+        {
+          id: 'conn-1',
+          name: 'Test',
+          dbType: 'postgresql',
+          host: 'localhost',
+          port: 5432,
+          database: 'test',
+          user: 'u',
+          password: 'p',
+          ssl: false,
+          isConnected: false,
+          isConnecting: false,
+          dstPort: 5432
+        }
+      ],
+      activeConnectionId: 'conn-1'
+    })
+  })
+
+  it('updates the page and pageSize without overwriting the user-rewritten SQL', () => {
+    // Repro: open a table preview; rewrite the editor SQL to query a different table;
+    // click "next page". Pagination state should advance, but the user's typed SQL
+    // must not be silently replaced with a SELECT against the original stored table.
+    const tabId = useTabStore
+      .getState()
+      .createTablePreviewTab('conn-1', 'public', 'admission_notes')
+
+    const userTypedSql = 'SELECT * FROM birth_histories WHERE x = 1'
+    useTabStore.getState().updateTabQuery(tabId, userTypedSql)
+
+    useTabStore.getState().updateTablePreviewPagination(tabId, 2, 100, null)
+
+    const tab = useTabStore.getState().getTab(tabId)
+    expect(tab?.type).toBe('table-preview')
+    if (tab?.type === 'table-preview') {
+      expect(tab.currentPage).toBe(2)
+      expect(tab.pageSize).toBe(100)
+      expect(tab.query).toBe(userTypedSql)
+    }
+  })
+
+  it('updates the query when a rebuiltQuery is supplied', () => {
+    const tabId = useTabStore
+      .getState()
+      .createTablePreviewTab('conn-1', 'public', 'admission_notes')
+
+    useTabStore
+      .getState()
+      .updateTablePreviewPagination(
+        tabId,
+        3,
+        50,
+        'SELECT * FROM "public"."admission_notes" LIMIT 50 OFFSET 100'
+      )
+
+    const tab = useTabStore.getState().getTab(tabId)
+    if (tab?.type === 'table-preview') {
+      expect(tab.currentPage).toBe(3)
+      expect(tab.pageSize).toBe(50)
+      expect(tab.query).toContain('LIMIT 50 OFFSET 100')
+      expect(tab.savedQuery).toContain('LIMIT 50 OFFSET 100')
+    }
+  })
+})

--- a/apps/desktop/src/renderer/src/stores/edit-store.ts
+++ b/apps/desktop/src/renderer/src/stores/edit-store.ts
@@ -121,14 +121,33 @@ function makeRowKey(
   pkColumns: readonly string[]
 ): string | null {
   if (pkColumns.length === 0) return null
-  const values: unknown[] = []
+  // Encode each PK value to a string explicitly. JSON.stringify throws on bigint
+  // (PostgreSQL returns bigint as string by default but pg-types overrides or
+  // mysql2 in BigInt mode can produce one); throwing here would happen inside a
+  // Zustand updater and leave the store mid-mutation.
+  const parts: string[] = []
   for (const col of pkColumns) {
     if (!(col in originalRow)) return null
     const value = originalRow[col]
     if (value === null || value === undefined) return null
-    values.push(value)
+    if (typeof value === 'bigint') {
+      parts.push(`b${value.toString()}`)
+    } else if (value instanceof Date) {
+      parts.push(`d${value.toISOString()}`)
+    } else if (typeof value === 'number' || typeof value === 'string' || typeof value === 'boolean') {
+      parts.push(`p${JSON.stringify(value)}`)
+    } else {
+      // Fallback for buffers, objects, etc — stringify defensively.
+      try {
+        parts.push(`p${JSON.stringify(value)}`)
+      } catch {
+        return null
+      }
+    }
   }
-  return JSON.stringify(values)
+  // \x1f (Unit Separator) cannot appear inside JSON-encoded strings, so it's a safe
+  // delimiter that won't collide with PK values that contain quotes or other punctuation.
+  return parts.join('\x1f')
 }
 
 function getRowKey(
@@ -459,6 +478,9 @@ export const useEditStore = create<EditStoreState>()((set, get) => ({
       const newTabEdits = new Map(state.tabEdits)
       newTabEdits.set(tabId, {
         ...existing,
+        // Drop the editing-cell focus too — leaving it set would make a cell at the
+        // same display position re-render as "in edit mode" against fresh data.
+        editingCell: null,
         modifiedCells: new Map(),
         deletedRowKeys: new Set(),
         originalRows: new Map(),
@@ -579,6 +601,9 @@ export const useEditStore = create<EditStoreState>()((set, get) => ({
       const newTabEdits = new Map(state.tabEdits)
       newTabEdits.set(tabId, {
         ...existing,
+        // Drop the editing-cell focus too — leaving it set would make a cell at the
+        // same display position re-render as "in edit mode" against fresh data.
+        editingCell: null,
         modifiedCells: new Map(),
         deletedRowKeys: new Set(),
         originalRows: new Map(),

--- a/apps/desktop/src/renderer/src/stores/edit-store.ts
+++ b/apps/desktop/src/renderer/src/stores/edit-store.ts
@@ -12,7 +12,12 @@ import type {
 } from '@data-peek/shared'
 
 /**
- * Edit mode state per tab
+ * Edit mode state per tab.
+ *
+ * Pending edits are keyed by the row's primary-key value(s), not by display position.
+ * This is the difference between an UPDATE landing on the row the user actually edited
+ * and an UPDATE landing on whatever happens to sit at that display index after the user
+ * sorts, paginates, or filters the table.
  */
 interface TabEditState {
   /** Whether edit mode is active for this tab */
@@ -21,16 +26,16 @@ interface TabEditState {
   context: EditContext | null
   /** Pending operations */
   operations: EditOperation[]
-  /** Currently editing cell */
+  /** Currently editing cell — display position, transient UI focus state */
   editingCell: { rowIndex: number; columnName: string } | null
-  /** Rows marked for deletion (by their index in the result set) */
-  deletedRowIndices: Set<number>
+  /** Rows marked for deletion, keyed by stable PK identity */
+  deletedRowKeys: Set<string>
   /** New rows being added (not yet in database) */
   newRows: Array<{ id: string; values: Record<string, unknown> }>
-  /** Original row data for modified rows (key: row index) */
-  originalRows: Map<number, Record<string, unknown>>
-  /** Modified cell values (key: `${rowIndex}:${columnName}`) */
-  modifiedCells: Map<string, unknown>
+  /** Original row snapshot per modified row, keyed by PK identity */
+  originalRows: Map<string, Record<string, unknown>>
+  /** Modified cell values, keyed by PK identity → column → new value */
+  modifiedCells: Map<string, Map<string, unknown>>
 }
 
 interface EditStoreState {
@@ -44,35 +49,42 @@ interface EditStoreState {
   isInEditMode: (tabId: string) => boolean
   getEditContext: (tabId: string) => EditContext | null
 
-  // Cell editing
+  // Cell editing — identified by the row's PK value(s) carried in originalRow
   startCellEdit: (tabId: string, rowIndex: number, columnName: string) => void
   cancelCellEdit: (tabId: string) => void
   updateCellValue: (
     tabId: string,
-    rowIndex: number,
+    originalRow: Record<string, unknown>,
     columnName: string,
-    value: unknown,
-    originalRow: Record<string, unknown>
+    value: unknown
   ) => void
-  getModifiedCellValue: (tabId: string, rowIndex: number, columnName: string) => unknown | undefined
-  isCellModified: (tabId: string, rowIndex: number, columnName: string) => boolean
+  getModifiedCellValue: (
+    tabId: string,
+    originalRow: Record<string, unknown>,
+    columnName: string
+  ) => unknown | undefined
+  isCellModified: (
+    tabId: string,
+    originalRow: Record<string, unknown>,
+    columnName: string
+  ) => boolean
 
   // Row operations
-  markRowForDeletion: (
-    tabId: string,
-    rowIndex: number,
-    originalRow: Record<string, unknown>
-  ) => void
-  unmarkRowForDeletion: (tabId: string, rowIndex: number) => void
-  isRowMarkedForDeletion: (tabId: string, rowIndex: number) => boolean
+  markRowForDeletion: (tabId: string, originalRow: Record<string, unknown>) => void
+  unmarkRowForDeletion: (tabId: string, originalRow: Record<string, unknown>) => void
+  isRowMarkedForDeletion: (tabId: string, originalRow: Record<string, unknown>) => boolean
   addNewRow: (tabId: string, defaultValues: Record<string, unknown>) => string
   updateNewRowValue: (tabId: string, rowId: string, columnName: string, value: unknown) => void
   removeNewRow: (tabId: string, rowId: string) => void
   getNewRows: (tabId: string) => Array<{ id: string; values: Record<string, unknown> }>
 
   // Revert operations
-  revertCellChange: (tabId: string, rowIndex: number, columnName: string) => void
-  revertRowChanges: (tabId: string, rowIndex: number) => void
+  revertCellChange: (
+    tabId: string,
+    originalRow: Record<string, unknown>,
+    columnName: string
+  ) => void
+  revertRowChanges: (tabId: string, originalRow: Record<string, unknown>) => void
   revertAllChanges: (tabId: string) => void
 
   // Build operations for commit
@@ -90,11 +102,43 @@ function getInitialTabEditState(): TabEditState {
     context: null,
     operations: [],
     editingCell: null,
-    deletedRowIndices: new Set(),
+    deletedRowKeys: new Set(),
     newRows: [],
     originalRows: new Map(),
     modifiedCells: new Map()
   }
+}
+
+/**
+ * Build a stable identity string from a row's primary key values.
+ *
+ * Returns `null` when the row cannot be identified — missing PK columns or null PK
+ * values. Callers must treat null as "edit not allowed for this row" rather than
+ * silently inventing a key, otherwise UPDATE/DELETE could land on the wrong row.
+ */
+function makeRowKey(
+  originalRow: Record<string, unknown>,
+  pkColumns: readonly string[]
+): string | null {
+  if (pkColumns.length === 0) return null
+  const values: unknown[] = []
+  for (const col of pkColumns) {
+    if (!(col in originalRow)) return null
+    const value = originalRow[col]
+    if (value === null || value === undefined) return null
+    values.push(value)
+  }
+  return JSON.stringify(values)
+}
+
+function getRowKey(
+  state: EditStoreState,
+  tabId: string,
+  originalRow: Record<string, unknown>
+): string | null {
+  const ctx = state.tabEdits.get(tabId)?.context
+  if (!ctx) return null
+  return makeRowKey(originalRow, ctx.primaryKeyColumns)
 }
 
 export const useEditStore = create<EditStoreState>()((set, get) => ({
@@ -162,35 +206,49 @@ export const useEditStore = create<EditStoreState>()((set, get) => ({
     })
   },
 
-  updateCellValue: (tabId, rowIndex, columnName, value, originalRow) => {
+  updateCellValue: (tabId, originalRow, columnName, value) => {
     set((state) => {
-      const newTabEdits = new Map(state.tabEdits)
-      const existing = newTabEdits.get(tabId) ?? getInitialTabEditState()
+      const existing = state.tabEdits.get(tabId)
+      if (!existing?.context) return state
+
+      const rowKey = makeRowKey(originalRow, existing.context.primaryKeyColumns)
+      // Reject edits we can't safely identify — better to drop the keystroke than
+      // build an UPDATE with no usable WHERE clause.
+      if (rowKey === null) {
+        // Still clear any active cell-edit focus so the UI doesn't get stuck.
+        if (existing.editingCell === null) return state
+        const newTabEdits = new Map(state.tabEdits)
+        newTabEdits.set(tabId, { ...existing, editingCell: null })
+        return { tabEdits: newTabEdits }
+      }
 
       const newModifiedCells = new Map(existing.modifiedCells)
       const newOriginalRows = new Map(existing.originalRows)
+      const rowCells = new Map(newModifiedCells.get(rowKey) ?? [])
 
-      const cellKey = `${rowIndex}:${columnName}`
       const originalValue = originalRow[columnName]
+      const isReverted = value === originalValue || (value === '' && originalValue === null)
 
-      // If value is same as original, remove the modification
-      if (value === originalValue || (value === '' && originalValue === null)) {
-        newModifiedCells.delete(cellKey)
-        // Clean up originalRows if no more modified cells for this row
-        const hasOtherModifications = Array.from(newModifiedCells.keys()).some((key) =>
-          key.startsWith(`${rowIndex}:`)
-        )
-        if (!hasOtherModifications) {
-          newOriginalRows.delete(rowIndex)
+      if (isReverted) {
+        rowCells.delete(columnName)
+        if (rowCells.size === 0) {
+          newModifiedCells.delete(rowKey)
+          // Drop the snapshot too if there's no other reason to hold it.
+          if (!existing.deletedRowKeys.has(rowKey)) {
+            newOriginalRows.delete(rowKey)
+          }
+        } else {
+          newModifiedCells.set(rowKey, rowCells)
         }
       } else {
-        newModifiedCells.set(cellKey, value)
-        // Store original row if not already stored
-        if (!newOriginalRows.has(rowIndex)) {
-          newOriginalRows.set(rowIndex, originalRow)
+        rowCells.set(columnName, value)
+        newModifiedCells.set(rowKey, rowCells)
+        if (!newOriginalRows.has(rowKey)) {
+          newOriginalRows.set(rowKey, originalRow)
         }
       }
 
+      const newTabEdits = new Map(state.tabEdits)
       newTabEdits.set(tabId, {
         ...existing,
         modifiedCells: newModifiedCells,
@@ -201,59 +259,84 @@ export const useEditStore = create<EditStoreState>()((set, get) => ({
     })
   },
 
-  getModifiedCellValue: (tabId, rowIndex, columnName) => {
-    const tabEdit = get().tabEdits.get(tabId)
+  getModifiedCellValue: (tabId, originalRow, columnName) => {
+    const state = get()
+    const tabEdit = state.tabEdits.get(tabId)
     if (!tabEdit) return undefined
-    return tabEdit.modifiedCells.get(`${rowIndex}:${columnName}`)
+    const rowKey = getRowKey(state, tabId, originalRow)
+    if (rowKey === null) return undefined
+    return tabEdit.modifiedCells.get(rowKey)?.get(columnName)
   },
 
-  isCellModified: (tabId, rowIndex, columnName) => {
-    const tabEdit = get().tabEdits.get(tabId)
+  isCellModified: (tabId, originalRow, columnName) => {
+    const state = get()
+    const tabEdit = state.tabEdits.get(tabId)
     if (!tabEdit) return false
-    return tabEdit.modifiedCells.has(`${rowIndex}:${columnName}`)
+    const rowKey = getRowKey(state, tabId, originalRow)
+    if (rowKey === null) return false
+    return tabEdit.modifiedCells.get(rowKey)?.has(columnName) ?? false
   },
 
-  markRowForDeletion: (tabId, rowIndex, originalRow) => {
+  markRowForDeletion: (tabId, originalRow) => {
     set((state) => {
-      const newTabEdits = new Map(state.tabEdits)
-      const existing = newTabEdits.get(tabId) ?? getInitialTabEditState()
+      const existing = state.tabEdits.get(tabId)
+      if (!existing?.context) return state
 
-      const newDeletedIndices = new Set(existing.deletedRowIndices)
-      newDeletedIndices.add(rowIndex)
+      const rowKey = makeRowKey(originalRow, existing.context.primaryKeyColumns)
+      if (rowKey === null) return state
+
+      const newDeletedKeys = new Set(existing.deletedRowKeys)
+      newDeletedKeys.add(rowKey)
 
       const newOriginalRows = new Map(existing.originalRows)
-      if (!newOriginalRows.has(rowIndex)) {
-        newOriginalRows.set(rowIndex, originalRow)
+      if (!newOriginalRows.has(rowKey)) {
+        newOriginalRows.set(rowKey, originalRow)
       }
 
+      const newTabEdits = new Map(state.tabEdits)
       newTabEdits.set(tabId, {
         ...existing,
-        deletedRowIndices: newDeletedIndices,
+        deletedRowKeys: newDeletedKeys,
         originalRows: newOriginalRows
       })
       return { tabEdits: newTabEdits }
     })
   },
 
-  unmarkRowForDeletion: (tabId, rowIndex) => {
+  unmarkRowForDeletion: (tabId, originalRow) => {
     set((state) => {
+      const existing = state.tabEdits.get(tabId)
+      if (!existing?.context) return state
+
+      const rowKey = makeRowKey(originalRow, existing.context.primaryKeyColumns)
+      if (rowKey === null || !existing.deletedRowKeys.has(rowKey)) return state
+
+      const newDeletedKeys = new Set(existing.deletedRowKeys)
+      newDeletedKeys.delete(rowKey)
+
+      // If there are no edits on this row either, drop the snapshot.
+      const newOriginalRows = new Map(existing.originalRows)
+      if (!existing.modifiedCells.has(rowKey)) {
+        newOriginalRows.delete(rowKey)
+      }
+
       const newTabEdits = new Map(state.tabEdits)
-      const existing = newTabEdits.get(tabId)
-      if (!existing) return state
-
-      const newDeletedIndices = new Set(existing.deletedRowIndices)
-      newDeletedIndices.delete(rowIndex)
-
       newTabEdits.set(tabId, {
         ...existing,
-        deletedRowIndices: newDeletedIndices
+        deletedRowKeys: newDeletedKeys,
+        originalRows: newOriginalRows
       })
       return { tabEdits: newTabEdits }
     })
   },
 
-  isRowMarkedForDeletion: (tabId, rowIndex) => {
-    return get().tabEdits.get(tabId)?.deletedRowIndices.has(rowIndex) ?? false
+  isRowMarkedForDeletion: (tabId, originalRow) => {
+    const state = get()
+    const tabEdit = state.tabEdits.get(tabId)
+    if (!tabEdit) return false
+    const rowKey = getRowKey(state, tabId, originalRow)
+    if (rowKey === null) return false
+    return tabEdit.deletedRowKeys.has(rowKey)
   },
 
   addNewRow: (tabId, defaultValues) => {
@@ -304,24 +387,33 @@ export const useEditStore = create<EditStoreState>()((set, get) => ({
     return get().tabEdits.get(tabId)?.newRows ?? []
   },
 
-  revertCellChange: (tabId, rowIndex, columnName) => {
+  revertCellChange: (tabId, originalRow, columnName) => {
     set((state) => {
-      const newTabEdits = new Map(state.tabEdits)
-      const existing = newTabEdits.get(tabId)
-      if (!existing) return state
+      const existing = state.tabEdits.get(tabId)
+      if (!existing?.context) return state
+
+      const rowKey = makeRowKey(originalRow, existing.context.primaryKeyColumns)
+      if (rowKey === null) return state
+
+      const rowCells = existing.modifiedCells.get(rowKey)
+      if (!rowCells || !rowCells.has(columnName)) return state
+
+      const newRowCells = new Map(rowCells)
+      newRowCells.delete(columnName)
 
       const newModifiedCells = new Map(existing.modifiedCells)
-      newModifiedCells.delete(`${rowIndex}:${columnName}`)
-
-      // Clean up originalRows if no more modifications for this row
-      const hasOtherModifications = Array.from(newModifiedCells.keys()).some((key) =>
-        key.startsWith(`${rowIndex}:`)
-      )
       const newOriginalRows = new Map(existing.originalRows)
-      if (!hasOtherModifications && !existing.deletedRowIndices.has(rowIndex)) {
-        newOriginalRows.delete(rowIndex)
+
+      if (newRowCells.size === 0) {
+        newModifiedCells.delete(rowKey)
+        if (!existing.deletedRowKeys.has(rowKey)) {
+          newOriginalRows.delete(rowKey)
+        }
+      } else {
+        newModifiedCells.set(rowKey, newRowCells)
       }
 
+      const newTabEdits = new Map(state.tabEdits)
       newTabEdits.set(tabId, {
         ...existing,
         modifiedCells: newModifiedCells,
@@ -331,32 +423,28 @@ export const useEditStore = create<EditStoreState>()((set, get) => ({
     })
   },
 
-  revertRowChanges: (tabId, rowIndex) => {
+  revertRowChanges: (tabId, originalRow) => {
     set((state) => {
-      const newTabEdits = new Map(state.tabEdits)
-      const existing = newTabEdits.get(tabId)
-      if (!existing) return state
+      const existing = state.tabEdits.get(tabId)
+      if (!existing?.context) return state
 
-      // Remove all cell modifications for this row
+      const rowKey = makeRowKey(originalRow, existing.context.primaryKeyColumns)
+      if (rowKey === null) return state
+
       const newModifiedCells = new Map(existing.modifiedCells)
-      for (const key of newModifiedCells.keys()) {
-        if (key.startsWith(`${rowIndex}:`)) {
-          newModifiedCells.delete(key)
-        }
-      }
+      newModifiedCells.delete(rowKey)
 
-      // Unmark from deletion
-      const newDeletedIndices = new Set(existing.deletedRowIndices)
-      newDeletedIndices.delete(rowIndex)
+      const newDeletedKeys = new Set(existing.deletedRowKeys)
+      newDeletedKeys.delete(rowKey)
 
-      // Remove from originalRows
       const newOriginalRows = new Map(existing.originalRows)
-      newOriginalRows.delete(rowIndex)
+      newOriginalRows.delete(rowKey)
 
+      const newTabEdits = new Map(state.tabEdits)
       newTabEdits.set(tabId, {
         ...existing,
         modifiedCells: newModifiedCells,
-        deletedRowIndices: newDeletedIndices,
+        deletedRowKeys: newDeletedKeys,
         originalRows: newOriginalRows
       })
       return { tabEdits: newTabEdits }
@@ -365,14 +453,14 @@ export const useEditStore = create<EditStoreState>()((set, get) => ({
 
   revertAllChanges: (tabId) => {
     set((state) => {
-      const newTabEdits = new Map(state.tabEdits)
-      const existing = newTabEdits.get(tabId)
+      const existing = state.tabEdits.get(tabId)
       if (!existing) return state
 
+      const newTabEdits = new Map(state.tabEdits)
       newTabEdits.set(tabId, {
         ...existing,
         modifiedCells: new Map(),
-        deletedRowIndices: new Set(),
+        deletedRowKeys: new Set(),
         originalRows: new Map(),
         newRows: [],
         operations: []
@@ -383,29 +471,19 @@ export const useEditStore = create<EditStoreState>()((set, get) => ({
 
   buildEditBatch: (tabId, columns) => {
     const tabEdit = get().tabEdits.get(tabId)
-    if (!tabEdit || !tabEdit.context) return null
+    if (!tabEdit?.context) return null
 
     const operations: EditOperation[] = []
-    const { context, modifiedCells, originalRows, deletedRowIndices, newRows } = tabEdit
+    const { context, modifiedCells, originalRows, deletedRowKeys, newRows } = tabEdit
 
-    // Build UPDATE operations from modified cells
-    const modifiedRowIndices = new Set<number>()
-    for (const key of modifiedCells.keys()) {
-      const [rowIndexStr] = key.split(':')
-      modifiedRowIndices.add(parseInt(rowIndexStr))
-    }
-
-    for (const rowIndex of modifiedRowIndices) {
-      // Skip if row is marked for deletion
-      if (deletedRowIndices.has(rowIndex)) continue
-
-      const originalRow = originalRows.get(rowIndex)
+    // UPDATEs
+    for (const [rowKey, cells] of modifiedCells.entries()) {
+      if (deletedRowKeys.has(rowKey)) continue
+      const originalRow = originalRows.get(rowKey)
       if (!originalRow) continue
 
       const changes: CellChange[] = []
-      for (const [key, newValue] of modifiedCells.entries()) {
-        if (!key.startsWith(`${rowIndex}:`)) continue
-        const columnName = key.split(':')[1]
+      for (const [columnName, newValue] of cells.entries()) {
         const colInfo = columns.find((c) => c.name === columnName)
         changes.push({
           column: columnName,
@@ -414,32 +492,30 @@ export const useEditStore = create<EditStoreState>()((set, get) => ({
           dataType: colInfo?.dataType ?? 'text'
         })
       }
+      if (changes.length === 0) continue
 
-      if (changes.length > 0) {
-        // Build primary key values
-        const primaryKeys: PrimaryKeyValue[] = context.primaryKeyColumns.map((pkCol) => {
-          const colInfo = columns.find((c) => c.name === pkCol)
-          return {
-            column: pkCol,
-            value: originalRow[pkCol],
-            dataType: colInfo?.dataType ?? 'text'
-          }
-        })
-
-        const update: RowUpdate = {
-          type: 'update',
-          id: crypto.randomUUID(),
-          primaryKeys,
-          changes,
-          originalRow
+      const primaryKeys: PrimaryKeyValue[] = context.primaryKeyColumns.map((pkCol) => {
+        const colInfo = columns.find((c) => c.name === pkCol)
+        return {
+          column: pkCol,
+          value: originalRow[pkCol],
+          dataType: colInfo?.dataType ?? 'text'
         }
-        operations.push(update)
+      })
+
+      const update: RowUpdate = {
+        type: 'update',
+        id: crypto.randomUUID(),
+        primaryKeys,
+        changes,
+        originalRow
       }
+      operations.push(update)
     }
 
-    // Build DELETE operations
-    for (const rowIndex of deletedRowIndices) {
-      const originalRow = originalRows.get(rowIndex)
+    // DELETEs
+    for (const rowKey of deletedRowKeys) {
+      const originalRow = originalRows.get(rowKey)
       if (!originalRow) continue
 
       const primaryKeys: PrimaryKeyValue[] = context.primaryKeyColumns.map((pkCol) => {
@@ -451,52 +527,42 @@ export const useEditStore = create<EditStoreState>()((set, get) => ({
         }
       })
 
-      const deleteOp: RowDelete = {
+      operations.push({
         type: 'delete',
         id: crypto.randomUUID(),
         primaryKeys,
         originalRow
-      }
-      operations.push(deleteOp)
+      } satisfies RowDelete)
     }
 
-    // Build INSERT operations
+    // INSERTs
     for (const newRow of newRows) {
-      const insert: RowInsert = {
+      operations.push({
         type: 'insert',
         id: newRow.id,
         values: newRow.values,
         columns: columns.map((c) => ({ name: c.name, dataType: c.dataType }))
-      }
-      operations.push(insert)
+      } satisfies RowInsert)
     }
 
     if (operations.length === 0) return null
 
-    return {
-      context,
-      operations
-    }
+    return { context, operations }
   },
 
   getPendingChangesCount: (tabId) => {
     const tabEdit = get().tabEdits.get(tabId)
     if (!tabEdit) return { updates: 0, inserts: 0, deletes: 0 }
 
-    // Count unique modified rows (excluding deleted ones)
-    const modifiedRowIndices = new Set<number>()
-    for (const key of tabEdit.modifiedCells.keys()) {
-      const [rowIndexStr] = key.split(':')
-      const rowIndex = parseInt(rowIndexStr)
-      if (!tabEdit.deletedRowIndices.has(rowIndex)) {
-        modifiedRowIndices.add(rowIndex)
-      }
+    let updates = 0
+    for (const rowKey of tabEdit.modifiedCells.keys()) {
+      if (!tabEdit.deletedRowKeys.has(rowKey)) updates++
     }
 
     return {
-      updates: modifiedRowIndices.size,
+      updates,
       inserts: tabEdit.newRows.length,
-      deletes: tabEdit.deletedRowIndices.size
+      deletes: tabEdit.deletedRowKeys.size
     }
   },
 
@@ -507,14 +573,14 @@ export const useEditStore = create<EditStoreState>()((set, get) => ({
 
   clearPendingChanges: (tabId) => {
     set((state) => {
-      const newTabEdits = new Map(state.tabEdits)
-      const existing = newTabEdits.get(tabId)
+      const existing = state.tabEdits.get(tabId)
       if (!existing) return state
 
+      const newTabEdits = new Map(state.tabEdits)
       newTabEdits.set(tabId, {
         ...existing,
         modifiedCells: new Map(),
-        deletedRowIndices: new Set(),
+        deletedRowKeys: new Set(),
         originalRows: new Map(),
         newRows: [],
         operations: []

--- a/apps/desktop/src/renderer/src/stores/tab-store.ts
+++ b/apps/desktop/src/renderer/src/stores/tab-store.ts
@@ -201,7 +201,12 @@ interface TabState {
     error: string | null
   ) => void
   setActiveResultIndex: (tabId: string, index: number) => void
-  updateTabExecuting: (tabId: string, isExecuting: boolean, executionId?: string | null) => void
+  updateTabExecuting: (
+    tabId: string,
+    isExecuting: boolean,
+    executionId?: string | null,
+    expectedExecutionId?: string | null
+  ) => void
   markTabSaved: (tabId: string) => void
 
   // Pagination per tab
@@ -633,6 +638,15 @@ export const useTabStore = create<TabState>()(
         const tab = get().tabs.find((t) => t.id === tabId)
         if (!tab || tab.isPinned) return
 
+        // If the tab has a query in flight, ask main to cancel it before we drop the tab.
+        // Without this the pg pool client keeps streaming results that nothing reads,
+        // and with POOL_MAX=5 a few abandoned tabs starve the pool for new connections.
+        if (isExecutableTab(tab) && tab.isExecuting && tab.executionId) {
+          void window.api.db.cancelQuery(tab.executionId).catch(() => {
+            // Cancellation is best-effort — main will time out the orphan query eventually.
+          })
+        }
+
         set((state) => {
           const newTabs = state.tabs.filter((t) => t.id !== tabId)
           let newActiveId = state.activeTabId
@@ -755,10 +769,15 @@ export const useTabStore = create<TabState>()(
         }))
       },
 
-      updateTabExecuting: (tabId, isExecuting, executionId?: string | null) => {
+      updateTabExecuting: (tabId, isExecuting, executionId?, expectedExecutionId?) => {
         set((state) => {
           const tabs = mapTab(state.tabs, tabId, (t) => {
             if (!isExecutableTab(t)) return t
+            // Compare-and-swap: a stale "finally" from execution A must not flip the
+            // flag on execution B that started after A was cancelled or thrown.
+            if (expectedExecutionId !== undefined && t.executionId !== expectedExecutionId) {
+              return t
+            }
             const newExecutionId =
               executionId !== undefined ? executionId : isExecuting ? t.executionId : null
             if (t.isExecuting === isExecuting && t.executionId === newExecutionId) return t

--- a/apps/desktop/src/renderer/src/stores/tab-store.ts
+++ b/apps/desktop/src/renderer/src/stores/tab-store.ts
@@ -10,6 +10,7 @@ import {
 } from '@/lib/sql-helpers'
 import { useConnectionStore } from './connection-store'
 import { useSettingsStore } from './settings-store'
+import { useEditStore } from './edit-store'
 
 /**
  * Extended QueryResult with multi-statement support
@@ -692,6 +693,10 @@ export const useTabStore = create<TabState>()(
       },
 
       updateTabResult: (tabId, result, error) => {
+        // Pending inline edits are captured against the *previous* result rows. Once the
+        // result changes, those snapshots no longer correspond to anything onscreen and
+        // committing them would target rows the user never saw — drop them defensively.
+        useEditStore.getState().clearPendingChanges(tabId)
         set((state) => ({
           tabs: state.tabs.map((t) => {
             if (t.id !== tabId) return t
@@ -703,6 +708,7 @@ export const useTabStore = create<TabState>()(
       },
 
       updateTabMultiResult: (tabId, multiResult, error) => {
+        useEditStore.getState().clearPendingChanges(tabId)
         set((state) => ({
           tabs: state.tabs.map((t) => {
             if (t.id !== tabId) return t
@@ -732,6 +738,10 @@ export const useTabStore = create<TabState>()(
       },
 
       setActiveResultIndex: (tabId, index) => {
+        // Pending edits are captured against the previously active statement; switching to
+        // a different statement (potentially a different table) would otherwise let those
+        // edits commit with the wrong context.
+        useEditStore.getState().clearPendingChanges(tabId)
         set((state) => ({
           tabs: state.tabs.map((t) =>
             t.id === tabId

--- a/apps/desktop/src/renderer/src/stores/tab-store.ts
+++ b/apps/desktop/src/renderer/src/stores/tab-store.ts
@@ -140,6 +140,20 @@ export function isExecutableTab(tab: Tab): tab is ExecutableTab {
   return tab.type === 'query' || tab.type === 'table-preview'
 }
 
+// Fire best-effort cancel for any executable tab that's currently running a query.
+// Used by every tab-close path so the bulk-close variants (close all / close others /
+// close right) don't orphan pg pool clients — POOL_MAX is 5, a handful of abandoned
+// long-running tabs is enough to starve new connections.
+function cancelInFlightQueries(tabs: Tab[]): void {
+  for (const tab of tabs) {
+    if (isExecutableTab(tab) && tab.isExecuting && tab.executionId) {
+      void window.api.db.cancelQuery(tab.executionId).catch(() => {
+        // Cancellation is best-effort — main will time out the orphan eventually.
+      })
+    }
+  }
+}
+
 function mapTab(tabs: Tab[], id: string, updater: (t: Tab) => Tab): Tab[] {
   const idx = tabs.findIndex((t) => t.id === id)
   if (idx === -1) return tabs
@@ -214,7 +228,7 @@ interface TabState {
   setTabPageSize: (tabId: string, size: number) => void
 
   // Server-side pagination for table previews
-  setTablePreviewTotalCount: (tabId: string, count: number) => void
+  setTablePreviewTotalCount: (tabId: string, count: number | null) => void
   updateTablePreviewPagination: (
     tabId: string,
     page: number,
@@ -643,14 +657,7 @@ export const useTabStore = create<TabState>()(
         const tab = get().tabs.find((t) => t.id === tabId)
         if (!tab || tab.isPinned) return
 
-        // If the tab has a query in flight, ask main to cancel it before we drop the tab.
-        // Without this the pg pool client keeps streaming results that nothing reads,
-        // and with POOL_MAX=5 a few abandoned tabs starve the pool for new connections.
-        if (isExecutableTab(tab) && tab.isExecuting && tab.executionId) {
-          void window.api.db.cancelQuery(tab.executionId).catch(() => {
-            // Cancellation is best-effort — main will time out the orphan query eventually.
-          })
-        }
+        cancelInFlightQueries([tab])
 
         set((state) => {
           const newTabs = state.tabs.filter((t) => t.id !== tabId)
@@ -667,8 +674,11 @@ export const useTabStore = create<TabState>()(
       },
 
       closeAllTabs: () => {
-        set((state) => {
-          // Keep pinned tabs
+        const state = get()
+        const removed = state.tabs.filter((t) => !t.isPinned)
+        cancelInFlightQueries(removed)
+
+        set(() => {
           const pinnedTabs = state.tabs.filter((t) => t.isPinned)
           return {
             tabs: pinnedTabs,
@@ -678,8 +688,11 @@ export const useTabStore = create<TabState>()(
       },
 
       closeOtherTabs: (tabId) => {
-        set((state) => {
-          // Keep the specified tab and all pinned tabs
+        const state = get()
+        const removed = state.tabs.filter((t) => t.id !== tabId && !t.isPinned)
+        cancelInFlightQueries(removed)
+
+        set(() => {
           const keptTabs = state.tabs.filter((t) => t.id === tabId || t.isPinned)
           return {
             tabs: keptTabs,
@@ -689,10 +702,14 @@ export const useTabStore = create<TabState>()(
       },
 
       closeTabsToRight: (tabId) => {
-        set((state) => {
-          const tabIndex = state.tabs.findIndex((t) => t.id === tabId)
-          if (tabIndex === -1) return state
+        const state = get()
+        const tabIndex = state.tabs.findIndex((t) => t.id === tabId)
+        if (tabIndex === -1) return
 
+        const removed = state.tabs.filter((t, i) => i > tabIndex && !t.isPinned)
+        cancelInFlightQueries(removed)
+
+        set(() => {
           const keptTabs = state.tabs.filter((t, i) => i <= tabIndex || t.isPinned)
           return {
             tabs: keptTabs,
@@ -715,7 +732,11 @@ export const useTabStore = create<TabState>()(
         // Pending inline edits are captured against the *previous* result rows. Once the
         // result changes, those snapshots no longer correspond to anything onscreen and
         // committing them would target rows the user never saw — drop them defensively.
-        useEditStore.getState().clearPendingChanges(tabId)
+        // Skip when the result is being blanked by a cancellation (`null` result + error
+        // text): the user's edits are still valid against what's currently displayed.
+        if (result !== null) {
+          useEditStore.getState().clearPendingChanges(tabId)
+        }
         set((state) => ({
           tabs: state.tabs.map((t) => {
             if (t.id !== tabId) return t
@@ -727,7 +748,11 @@ export const useTabStore = create<TabState>()(
       },
 
       updateTabMultiResult: (tabId, multiResult, error) => {
-        useEditStore.getState().clearPendingChanges(tabId)
+        // Same rule as updateTabResult: a null result is a cancel/error blank, not a
+        // new result set, so don't wipe the user's pending edits.
+        if (multiResult !== null) {
+          useEditStore.getState().clearPendingChanges(tabId)
+        }
         set((state) => ({
           tabs: state.tabs.map((t) => {
             if (t.id !== tabId) return t

--- a/apps/desktop/src/renderer/src/stores/tab-store.ts
+++ b/apps/desktop/src/renderer/src/stores/tab-store.ts
@@ -215,7 +215,12 @@ interface TabState {
 
   // Server-side pagination for table previews
   setTablePreviewTotalCount: (tabId: string, count: number) => void
-  updateTablePreviewPagination: (tabId: string, page: number, pageSize: number) => void
+  updateTablePreviewPagination: (
+    tabId: string,
+    page: number,
+    pageSize: number,
+    rebuiltQuery: string | null
+  ) => void
 
   // Pinning
   pinTab: (tabId: string) => void
@@ -828,27 +833,25 @@ export const useTabStore = create<TabState>()(
         })
       },
 
-      updateTablePreviewPagination: (tabId, page, pageSize) => {
-        const tab = get().tabs.find((t) => t.id === tabId)
-        if (!tab || tab.type !== 'table-preview') return
-
-        // Get connection to determine database type
-        const connection = useConnectionStore
-          .getState()
-          .connections.find((c) => c.id === tab.connectionId)
-        const dbType = connection?.dbType
-
-        // Build new query with updated pagination
-        const offset = (page - 1) * pageSize
-        const sqlTableRef = buildQualifiedTableRef(tab.schemaName, tab.tableName, dbType)
-        const query = buildSelectQuery(sqlTableRef, dbType, { limit: pageSize, offset })
-
+      updateTablePreviewPagination: (tabId, page, pageSize, rebuiltQuery) => {
+        // The renderer decides whether the executed SQL still maps to the stored
+        // table and supplies a rebuiltQuery only when it's safe to overwrite. If
+        // null, we update pagination state without touching the user's typed SQL —
+        // pagination falls back to client-side over the existing result set.
         set((state) => ({
-          tabs: state.tabs.map((t) =>
-            t.id === tabId && t.type === 'table-preview'
-              ? { ...t, currentPage: page, pageSize, query, savedQuery: query }
-              : t
-          )
+          tabs: state.tabs.map((t) => {
+            if (t.id !== tabId || t.type !== 'table-preview') return t
+            if (rebuiltQuery !== null) {
+              return {
+                ...t,
+                currentPage: page,
+                pageSize,
+                query: rebuiltQuery,
+                savedQuery: rebuiltQuery
+              }
+            }
+            return { ...t, currentPage: page, pageSize }
+          })
         }))
       },
 


### PR DESCRIPTION
## Summary

Follow-up to v0.21.7 — addresses the eight P0 findings from the post-release codebase audit. Each fix is its own commit; the audit findings notes are in the commit messages.

The recurring theme across these bugs is **stored metadata being trusted as the source of truth for follow-up actions even after user state diverged**. Same root cause as the resolveEditSourceTable fix that shipped in v0.21.7, surfacing in four more places.

### Cluster A — edit-store row identity
- **fix(edit): key pending edits by row primary key, not display position** (15cd5d7)

  Inline edits were keyed by TanStack `row.index`, which is the post-sort, post-pagination, post-filter slice position. Sorting after editing, paginating, switching active result-set, or re-executing a query all let pending edits drift onto unrelated rows — at best a 0-row no-op UPDATE, at worst a wrong-row clobber. Edits are now keyed by the row's primary-key value(s); rows without a usable PK identity (missing or null PK columns) are rejected rather than guessed. tab-store clears pending edits whenever the result set is replaced or the active statement changes.

  +22 new edit-store tests covering composite PKs, null-PK rejection, identity stability across sort/page, plus a tab-store integration test for the result-invalidation contract.

### Cluster B — query lifecycle
- **fix(query): guard query lifecycle against stale executions and orphaned cancels** (301afbd)

  Three races on the query path:
  - Late responses overwriting newer queries — handlers now snapshot executionId in a closure and bail before any tab state write if it no longer matches.
  - `updateTabExecuting` blindly clearing the flag — accepts an optional `expectedExecutionId` for compare-and-swap; the finally in `handleRunQuery` passes the captured id.
  - Closing a tab during an in-flight query orphaned the pool client (POOL_MAX=5 → five abandoned tabs starve new connections). `closeTab` now fires a best-effort `cancelQuery` first.

  +9 lifecycle tests for the CAS contract and cancel-on-close.

### Cluster C — table-preview executed-SQL source of truth
- **fix(table-preview): trust executed SQL over stored table for follow-up queries** (a8bc8a3)

  Same class as the bug fixed in v0.21.7, in three more places:
  - The COUNT-for-pagination query (showed wrong-table totals).
  - `updateTablePreviewPagination`'s SQL rebuild (silently overwrote the user's typed SQL on every page change).
  - `buildQueryWithFilters`' "Apply to Query" branch (rebuilt against stored table, dropping the user's SQL).

  Adds a `sqlMatchesStoredTable` helper in `editable-select.ts`; each call site gates on it, falling back to client-side pagination / leaving the user's SQL alone when the SQL has diverged from the stored table.

### Cluster D — schema cache correctness + dogpile
- **fix(schema-cache): invalidate on DDL and coalesce concurrent fetches** (273f59e)

  - DDL handlers (CREATE/ALTER/DROP TABLE) didn't invalidate the schema cache, so with the 24-hour TTL, edit-context column lookup, FK drilldowns, and Table Designer all read pre-DDL columns. Each successful DDL handler now calls `invalidateSchemaCache`.
  - Concurrent `db:schemas` calls dogpiled the database (each tab triggered its own full pg_catalog scan). Adds `getOrFetchCachedSchema` which coalesces in-flight fetches per connection key. `invalidateSchemaCache` also drops any pending fetch so the next read after DDL refetches against the new state.

## Out of scope (deferred to follow-up)

- **Cluster E** — persisted tab + deleted/rebound connection silently runs queries on the wrong DB. Needs a UX call (warn? require explicit re-pick?), so leaving for a separate change.
- **Multi-statement cancel preservation** — `queryMultiple` discards completed statements when the user clicks Stop on a later statement. Lower severity; deferred.
- **Playwright e2e harness** — the right time to add it is alongside Cluster A so the regression net is in place. Would be a separate PR.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 528 passed (was 506; +22 new tests)
- [ ] Manual: open table preview, rewrite SQL to different table, paginate → user's SQL is preserved, count is from current rows
- [ ] Manual: edit a cell, sort the table, edit a different cell at "row 0", commit → two independent UPDATEs, not one row clobbered
- [ ] Manual: run long query, click Stop, immediately Run again → no "Query cancelled" overwriting new result
- [ ] Manual: close tab mid-query → no orphan pool client (verify via `pg_stat_activity`)
- [ ] Manual: ALTER TABLE in Table Designer → next FK drilldown / column stats reads fresh schema

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stale query results/cancels from overwriting newer executions
  * Ensured schema cache is invalidated after DDL so schema views update immediately
  * Fixed row deletion/restore and edit-state clearing when results change or tabs switch

* **New Features**
  * Concurrent schema fetches coalesce into a single request for better performance
  * Edit tracking now uses stable primary-key identity for more reliable saves/reverts
  * Table-preview pagination/refined SQL rebuilding for predictable behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->