### PR TITLE
feat(cross-tab): @name references — foundations (parser + resolver + tests)

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/cross-tab-name-validation.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/cross-tab-name-validation.test.ts
@@ -76,6 +76,17 @@ describe('validateRefName', () => {
       expect(isReservedRefName('SELECT')).toBe(true)
       expect(isReservedRefName('users')).toBe(false)
     })
+
+    it('rejects the broader shared SQL keyword set (table / into / set / over)', () => {
+      // Not in the local RESERVED_REF_NAMES list but caught by the shared
+      // isSQLKeyword check. Bug fix from PR #184 review — these would
+      // otherwise pass validation and only fail at resolve time.
+      for (const kw of ['table', 'into', 'set', 'over', 'using', 'references']) {
+        const r = validateRefName(kw)
+        expect(r.ok).toBe(false)
+        if (!r.ok) expect(r.error.kind).toBe('reserved_word')
+      }
+    })
   })
 
   describe('uniqueness', () => {

--- a/apps/desktop/src/renderer/src/lib/__tests__/cross-tab-name-validation.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/cross-tab-name-validation.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest'
+import {
+  validateRefName,
+  isReservedRefName
+} from '../cross-tab-name-validation'
+import { REF_NAME_MAX_LENGTH } from '../cross-tab-types'
+
+describe('validateRefName', () => {
+  describe('shape', () => {
+    it('accepts a basic lowercase identifier', () => {
+      const r = validateRefName('active_users')
+      expect(r.ok).toBe(true)
+      if (r.ok) expect(r.normalized).toBe('active_users')
+    })
+
+    it('lowercases the input (silently normalizes mixed case)', () => {
+      const r = validateRefName('ActiveUsers')
+      expect(r.ok).toBe(true)
+      if (r.ok) expect(r.normalized).toBe('activeusers')
+    })
+
+    it('normalizes pure-uppercase to lowercase', () => {
+      const r = validateRefName('USERS')
+      expect(r.ok).toBe(true)
+      if (r.ok) expect(r.normalized).toBe('users')
+    })
+
+    it('rejects empty after trim', () => {
+      const r = validateRefName('   ')
+      expect(r.ok).toBe(false)
+      if (!r.ok) expect(r.error.kind).toBe('empty')
+    })
+
+    it('rejects too long', () => {
+      const long = 'a' + 'x'.repeat(REF_NAME_MAX_LENGTH)
+      const r = validateRefName(long)
+      expect(r.ok).toBe(false)
+      if (!r.ok) expect(r.error.kind).toBe('too_long')
+    })
+
+    it('rejects starting with a digit', () => {
+      const r = validateRefName('1users')
+      expect(r.ok).toBe(false)
+    })
+
+    it('rejects with hyphens', () => {
+      const r = validateRefName('active-users')
+      expect(r.ok).toBe(false)
+    })
+
+    it('rejects with spaces', () => {
+      const r = validateRefName('active users')
+      expect(r.ok).toBe(false)
+    })
+
+    it('accepts digits + underscores after first letter', () => {
+      const r = validateRefName('users_v2')
+      expect(r.ok).toBe(true)
+    })
+  })
+
+  describe('reserved words', () => {
+    it('rejects SELECT', () => {
+      const r = validateRefName('select')
+      expect(r.ok).toBe(false)
+      if (!r.ok) expect(r.error.kind).toBe('reserved_word')
+    })
+
+    it('rejects WITH', () => {
+      const r = validateRefName('with')
+      expect(r.ok).toBe(false)
+      if (!r.ok) expect(r.error.kind).toBe('reserved_word')
+    })
+
+    it('isReservedRefName helper works case-insensitively', () => {
+      expect(isReservedRefName('SELECT')).toBe(true)
+      expect(isReservedRefName('users')).toBe(false)
+    })
+  })
+
+  describe('uniqueness', () => {
+    it('rejects a duplicate name on another tab', () => {
+      const taken = new Map([['active_users', 'tab-1']])
+      const r = validateRefName('active_users', {
+        takenNames: taken,
+        ownTabId: 'tab-2'
+      })
+      expect(r.ok).toBe(false)
+      if (!r.ok && r.error.kind === 'duplicate') {
+        expect(r.error.conflictingTabId).toBe('tab-1')
+      } else {
+        throw new Error('expected duplicate error')
+      }
+    })
+
+    it('allows keeping the same name on the same tab', () => {
+      const taken = new Map([['active_users', 'tab-1']])
+      const r = validateRefName('active_users', {
+        takenNames: taken,
+        ownTabId: 'tab-1'
+      })
+      expect(r.ok).toBe(true)
+    })
+
+    it('allows a name not in the taken set', () => {
+      const taken = new Map([['active_users', 'tab-1']])
+      const r = validateRefName('new_users', { takenNames: taken })
+      expect(r.ok).toBe(true)
+    })
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/__tests__/cross-tab-parser.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/cross-tab-parser.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest'
+import { parseTabReferences } from '../cross-tab-parser'
+
+describe('parseTabReferences', () => {
+  it('finds a basic reference', () => {
+    const r = parseTabReferences('SELECT * FROM @active_users')
+    expect(r.references).toHaveLength(1)
+    expect(r.references[0].name).toBe('active_users')
+    expect(r.references[0].raw).toBe('@active_users')
+    expect(r.referencedNames).toEqual(new Set(['active_users']))
+  })
+
+  it('finds multiple distinct references', () => {
+    const r = parseTabReferences(
+      'SELECT * FROM @active_users JOIN @recent_purchases USING(user_id)'
+    )
+    expect(r.references).toHaveLength(2)
+    expect(r.referencedNames).toEqual(new Set(['active_users', 'recent_purchases']))
+  })
+
+  it('deduplicates the same name in referencedNames', () => {
+    const r = parseTabReferences(
+      'SELECT * FROM @active_users a, @active_users b WHERE a.id < b.id'
+    )
+    expect(r.references).toHaveLength(2)
+    expect(r.referencedNames.size).toBe(1)
+  })
+
+  it('records correct start/end positions', () => {
+    const sql = 'SELECT * FROM @active_users LIMIT 1'
+    const r = parseTabReferences(sql)
+    const ref = r.references[0]
+    expect(sql.slice(ref.start, ref.end)).toBe('@active_users')
+  })
+
+  describe('ignores references inside strings', () => {
+    it('single-quoted string', () => {
+      const r = parseTabReferences("SELECT '@hidden' FROM users")
+      expect(r.references).toHaveLength(0)
+    })
+
+    it('doubled-quote escape', () => {
+      const r = parseTabReferences("SELECT 'it''s @gone' FROM users")
+      expect(r.references).toHaveLength(0)
+    })
+
+    it('double-quoted identifier', () => {
+      const r = parseTabReferences('SELECT "col@name" FROM users')
+      expect(r.references).toHaveLength(0)
+    })
+
+    it('dollar-quoted body', () => {
+      const r = parseTabReferences("SELECT $body$ @ignored $body$ FROM x")
+      expect(r.references).toHaveLength(0)
+    })
+
+    it('mixed: real ref + ref inside string', () => {
+      const r = parseTabReferences("SELECT '@x' FROM @real_tab")
+      expect(r.references).toHaveLength(1)
+      expect(r.references[0].name).toBe('real_tab')
+    })
+  })
+
+  describe('ignores references inside comments', () => {
+    it('line comment', () => {
+      const r = parseTabReferences('SELECT 1 -- @ignored\nFROM x')
+      expect(r.references).toHaveLength(0)
+    })
+
+    it('block comment', () => {
+      const r = parseTabReferences('SELECT /* @ignored */ 1 FROM x')
+      expect(r.references).toHaveLength(0)
+    })
+
+    it('nested block comment', () => {
+      const r = parseTabReferences('SELECT /* /* @ignored */ */ 1 FROM x')
+      expect(r.references).toHaveLength(0)
+    })
+
+    it('real ref after a block comment', () => {
+      const r = parseTabReferences('SELECT /* @x */ * FROM @real')
+      expect(r.references).toHaveLength(1)
+      expect(r.references[0].name).toBe('real')
+    })
+  })
+
+  describe('email-like sequences', () => {
+    it('alice@example.com is not a reference', () => {
+      const r = parseTabReferences("SELECT 'alice@example.com'")
+      expect(r.references).toHaveLength(0)
+    })
+
+    it('unquoted alice@example only consumes valid lowercase ident', () => {
+      // The `@` here is preceded by `e` (word continuation), so not a ref.
+      const r = parseTabReferences('SELECT alice@example FROM x')
+      expect(r.references).toHaveLength(0)
+    })
+
+    it('@ at start of input is fine', () => {
+      const r = parseTabReferences('@foo')
+      expect(r.references).toHaveLength(1)
+      expect(r.references[0].name).toBe('foo')
+    })
+  })
+
+  describe('boundaries', () => {
+    it('@ followed by invalid char is not consumed', () => {
+      const r = parseTabReferences('SELECT @ FROM x')
+      expect(r.references).toHaveLength(0)
+    })
+
+    it('@ followed by digit is not consumed (must start with letter)', () => {
+      const r = parseTabReferences('SELECT @1foo FROM x')
+      expect(r.references).toHaveLength(0)
+    })
+
+    it('@FOO uppercase is not consumed (must be lowercase)', () => {
+      const r = parseTabReferences('SELECT @FOO FROM x')
+      expect(r.references).toHaveLength(0)
+    })
+
+    it('lone @ at end of input', () => {
+      const r = parseTabReferences('SELECT * FROM x WHERE c = @')
+      expect(r.references).toHaveLength(0)
+    })
+
+    it('reference followed by punctuation', () => {
+      const r = parseTabReferences('SELECT * FROM @t WHERE id IN (SELECT id FROM @other);')
+      expect(r.references.map((x) => x.name)).toEqual(['t', 'other'])
+    })
+
+    it('reference followed by underscore continues the name', () => {
+      const r = parseTabReferences('SELECT * FROM @my_long_name__id')
+      expect(r.references).toHaveLength(1)
+      expect(r.references[0].name).toBe('my_long_name__id')
+    })
+  })
+
+  it('no references → empty result', () => {
+    const r = parseTabReferences('SELECT * FROM users')
+    expect(r.references).toHaveLength(0)
+    expect(r.referencedNames.size).toBe(0)
+  })
+
+  it('empty input → empty result', () => {
+    const r = parseTabReferences('')
+    expect(r.references).toHaveLength(0)
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/__tests__/cross-tab-parser.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/cross-tab-parser.test.ts
@@ -1,9 +1,13 @@
 import { describe, it, expect } from 'vitest'
 import { parseTabReferences } from '../cross-tab-parser'
 
+const pg = (sql: string) => parseTabReferences(sql, { dialect: 'postgresql' })
+const my = (sql: string) => parseTabReferences(sql, { dialect: 'mysql' })
+const ms = (sql: string) => parseTabReferences(sql, { dialect: 'mssql' })
+
 describe('parseTabReferences', () => {
   it('finds a basic reference', () => {
-    const r = parseTabReferences('SELECT * FROM @active_users')
+    const r = pg('SELECT * FROM @active_users')
     expect(r.references).toHaveLength(1)
     expect(r.references[0].name).toBe('active_users')
     expect(r.references[0].raw).toBe('@active_users')
@@ -11,139 +15,233 @@ describe('parseTabReferences', () => {
   })
 
   it('finds multiple distinct references', () => {
-    const r = parseTabReferences(
-      'SELECT * FROM @active_users JOIN @recent_purchases USING(user_id)'
-    )
+    const r = pg('SELECT * FROM @active_users JOIN @recent_purchases USING(user_id)')
     expect(r.references).toHaveLength(2)
     expect(r.referencedNames).toEqual(new Set(['active_users', 'recent_purchases']))
   })
 
   it('deduplicates the same name in referencedNames', () => {
-    const r = parseTabReferences(
-      'SELECT * FROM @active_users a, @active_users b WHERE a.id < b.id'
-    )
+    const r = pg('SELECT * FROM @active_users a, @active_users b WHERE a.id < b.id')
     expect(r.references).toHaveLength(2)
     expect(r.referencedNames.size).toBe(1)
   })
 
   it('records correct start/end positions', () => {
     const sql = 'SELECT * FROM @active_users LIMIT 1'
-    const r = parseTabReferences(sql)
+    const r = pg(sql)
     const ref = r.references[0]
     expect(sql.slice(ref.start, ref.end)).toBe('@active_users')
   })
 
   describe('ignores references inside strings', () => {
     it('single-quoted string', () => {
-      const r = parseTabReferences("SELECT '@hidden' FROM users")
-      expect(r.references).toHaveLength(0)
+      expect(pg("SELECT '@hidden' FROM users").references).toHaveLength(0)
     })
 
     it('doubled-quote escape', () => {
-      const r = parseTabReferences("SELECT 'it''s @gone' FROM users")
+      expect(pg("SELECT 'it''s @gone' FROM users").references).toHaveLength(0)
+    })
+
+    it('MySQL backslash escape keeps the string open', () => {
+      // Bug fix: `\'` inside a single-quoted string is an escape in MySQL
+      // default mode; the string continues, the `@bar` is hidden inside it.
+      const r = my("SELECT 'foo\\'@bar' FROM t")
+      expect(r.references).toHaveLength(0)
+    })
+
+    it('PG E-string backslash escape keeps the string open', () => {
+      const r = pg("SELECT E'foo\\'@bar' FROM t")
       expect(r.references).toHaveLength(0)
     })
 
     it('double-quoted identifier', () => {
-      const r = parseTabReferences('SELECT "col@name" FROM users')
+      expect(pg('SELECT "col@name" FROM users').references).toHaveLength(0)
+    })
+
+    it('MySQL backtick-quoted identifier hides @-tokens inside', () => {
+      const r = my('SELECT `@col` FROM t')
       expect(r.references).toHaveLength(0)
     })
 
-    it('dollar-quoted body', () => {
-      const r = parseTabReferences("SELECT $body$ @ignored $body$ FROM x")
+    it('MySQL doubled-backtick escape inside backtick identifier', () => {
+      const r = my('SELECT `a``@b` FROM t')
       expect(r.references).toHaveLength(0)
+    })
+
+    it('MSSQL bracket-quoted identifier hides @-tokens inside', () => {
+      const r = ms('SELECT [@col] FROM dbo.t')
+      expect(r.references).toHaveLength(0)
+    })
+
+    it('MSSQL `]]` escapes a literal `]` inside brackets', () => {
+      const r = ms('SELECT [a]]@b] FROM dbo.t')
+      expect(r.references).toHaveLength(0)
+    })
+
+    it('dollar-quoted body (PG)', () => {
+      expect(pg('SELECT $body$ @ignored $body$ FROM x').references).toHaveLength(0)
+    })
+
+    it('empty dollar-tag `$$ ... $$` (PG)', () => {
+      expect(pg('SELECT $$ @ignored $$ FROM x').references).toHaveLength(0)
+    })
+
+    it('`$1$ ... $1$` is NOT a dollar-quote (PG positional placeholder)', () => {
+      // Bug fix: dollar-quote tags can't start with a digit. `$1$` is the
+      // positional placeholder $1 followed by $. The `@hidden` inside is
+      // a real reference.
+      const r = pg('SELECT * FROM @users WHERE id = $1 AND tag = $1$ @hidden $1$')
+      const names = r.references.map((x) => x.name).sort()
+      expect(names).toEqual(['hidden', 'users'])
     })
 
     it('mixed: real ref + ref inside string', () => {
-      const r = parseTabReferences("SELECT '@x' FROM @real_tab")
+      const r = pg("SELECT '@x' FROM @real_tab")
       expect(r.references).toHaveLength(1)
       expect(r.references[0].name).toBe('real_tab')
     })
   })
 
   describe('ignores references inside comments', () => {
-    it('line comment', () => {
-      const r = parseTabReferences('SELECT 1 -- @ignored\nFROM x')
-      expect(r.references).toHaveLength(0)
+    it('line comment terminated by \\n', () => {
+      expect(pg('SELECT 1 -- @ignored\nFROM x').references).toHaveLength(0)
+    })
+
+    it('lone \\r terminates a line comment (bug fix)', () => {
+      // Old-Mac line endings: previously consumed the rest of the file.
+      const r = pg('SELECT 1 -- @hidden\r@visible FROM x')
+      expect(r.references.map((x) => x.name)).toEqual(['visible'])
     })
 
     it('block comment', () => {
-      const r = parseTabReferences('SELECT /* @ignored */ 1 FROM x')
-      expect(r.references).toHaveLength(0)
+      expect(pg('SELECT /* @ignored */ 1 FROM x').references).toHaveLength(0)
     })
 
-    it('nested block comment', () => {
-      const r = parseTabReferences('SELECT /* /* @ignored */ */ 1 FROM x')
-      expect(r.references).toHaveLength(0)
+    it('nested block comment (PG only)', () => {
+      expect(pg('SELECT /* /* @ignored */ */ 1 FROM x').references).toHaveLength(0)
+    })
+
+    it('MySQL block comments do NOT nest', () => {
+      // Bug fix: in MySQL the first `*/` closes the outermost comment, so
+      // `@exposed` is outside any comment.
+      const r = my('SELECT /* outer /* inner */ @exposed */ 1 FROM x')
+      expect(r.references.map((x) => x.name)).toEqual(['exposed'])
+    })
+
+    it('MSSQL block comments do NOT nest', () => {
+      const r = ms('SELECT /* outer /* inner */ @exposed */ 1 FROM x')
+      expect(r.references.map((x) => x.name)).toEqual(['exposed'])
     })
 
     it('real ref after a block comment', () => {
-      const r = parseTabReferences('SELECT /* @x */ * FROM @real')
+      const r = pg('SELECT /* @x */ * FROM @real')
       expect(r.references).toHaveLength(1)
       expect(r.references[0].name).toBe('real')
     })
   })
 
-  describe('email-like sequences', () => {
-    it('alice@example.com is not a reference', () => {
-      const r = parseTabReferences("SELECT 'alice@example.com'")
-      expect(r.references).toHaveLength(0)
+  describe('system variables and word boundaries', () => {
+    it('@@version (MySQL/MSSQL system var) is NOT captured', () => {
+      // Bug fix: previously `@@version` captured `@version` as a ref.
+      expect(my('SELECT @@version').references).toHaveLength(0)
+      expect(ms('SELECT @@version').references).toHaveLength(0)
+      expect(pg('SELECT @@version').references).toHaveLength(0)
     })
 
-    it('unquoted alice@example only consumes valid lowercase ident', () => {
-      // The `@` here is preceded by `e` (word continuation), so not a ref.
-      const r = parseTabReferences('SELECT alice@example FROM x')
-      expect(r.references).toHaveLength(0)
+    it('@@rowcount and @@identity (MSSQL)', () => {
+      expect(ms('SELECT @@rowcount, @@identity').references).toHaveLength(0)
+    })
+
+    it('alice@example.com is not a reference', () => {
+      expect(pg("SELECT 'alice@example.com'").references).toHaveLength(0)
+    })
+
+    it('unquoted alice@example does not produce a ref', () => {
+      expect(pg('SELECT alice@example FROM x').references).toHaveLength(0)
     })
 
     it('@ at start of input is fine', () => {
-      const r = parseTabReferences('@foo')
+      const r = pg('@foo')
       expect(r.references).toHaveLength(1)
       expect(r.references[0].name).toBe('foo')
     })
   })
 
-  describe('boundaries', () => {
+  describe('reference boundaries', () => {
     it('@ followed by invalid char is not consumed', () => {
-      const r = parseTabReferences('SELECT @ FROM x')
-      expect(r.references).toHaveLength(0)
+      expect(pg('SELECT @ FROM x').references).toHaveLength(0)
     })
 
     it('@ followed by digit is not consumed (must start with letter)', () => {
-      const r = parseTabReferences('SELECT @1foo FROM x')
-      expect(r.references).toHaveLength(0)
+      expect(pg('SELECT @1foo FROM x').references).toHaveLength(0)
     })
 
     it('@FOO uppercase is not consumed (must be lowercase)', () => {
-      const r = parseTabReferences('SELECT @FOO FROM x')
-      expect(r.references).toHaveLength(0)
+      expect(pg('SELECT @FOO FROM x').references).toHaveLength(0)
+    })
+
+    it('@fooBar does NOT partial-parse to @foo (bug fix)', () => {
+      // Previously: regex `^[a-z][a-z0-9_]*` matched just `foo`, leaving
+      // `Bar` floating. Now the negative lookahead rejects the match.
+      expect(pg('SELECT * FROM @fooBar').references).toHaveLength(0)
+    })
+
+    it('@foo-bar parses as @foo followed by `-bar` (SQL operator)', () => {
+      // Hyphen is a SQL token separator (`SELECT @foo - 1`), so it's a
+      // valid termination for a ref. Word characters (letters/digits/_)
+      // would invalidate the match via the negative lookahead, but the
+      // hyphen breaks the identifier cleanly.
+      const r = pg('SELECT * FROM @foo-bar')
+      expect(r.references).toHaveLength(1)
+      expect(r.references[0].name).toBe('foo')
     })
 
     it('lone @ at end of input', () => {
-      const r = parseTabReferences('SELECT * FROM x WHERE c = @')
-      expect(r.references).toHaveLength(0)
+      expect(pg('SELECT * FROM x WHERE c = @').references).toHaveLength(0)
     })
 
     it('reference followed by punctuation', () => {
-      const r = parseTabReferences('SELECT * FROM @t WHERE id IN (SELECT id FROM @other);')
+      const r = pg('SELECT * FROM @t WHERE id IN (SELECT id FROM @other);')
       expect(r.references.map((x) => x.name)).toEqual(['t', 'other'])
     })
 
     it('reference followed by underscore continues the name', () => {
-      const r = parseTabReferences('SELECT * FROM @my_long_name__id')
+      const r = pg('SELECT * FROM @my_long_name__id')
       expect(r.references).toHaveLength(1)
       expect(r.references[0].name).toBe('my_long_name__id')
     })
   })
 
+  describe('knownNames filter (MySQL/MSSQL @var coexistence)', () => {
+    it('without knownNames, every @name token is emitted', () => {
+      const r = my('SET @count = 5; SELECT @count, @users FROM x')
+      const names = new Set(r.references.map((x) => x.name))
+      expect(names.has('count')).toBe(true)
+      expect(names.has('users')).toBe(true)
+    })
+
+    it('with knownNames, only matching names are emitted', () => {
+      const r = parseTabReferences(
+        'SET @count = 5; SELECT @count, @users FROM x',
+        { dialect: 'mysql', knownNames: new Set(['users']) }
+      )
+      expect(r.references.map((x) => x.name)).toEqual(['users'])
+    })
+
+    it('with empty knownNames set, nothing is emitted', () => {
+      const r = parseTabReferences('SELECT @count, @users FROM x', {
+        dialect: 'mysql',
+        knownNames: new Set()
+      })
+      expect(r.references).toHaveLength(0)
+    })
+  })
+
   it('no references → empty result', () => {
-    const r = parseTabReferences('SELECT * FROM users')
-    expect(r.references).toHaveLength(0)
-    expect(r.referencedNames.size).toBe(0)
+    expect(pg('SELECT * FROM users').references).toHaveLength(0)
   })
 
   it('empty input → empty result', () => {
-    const r = parseTabReferences('')
-    expect(r.references).toHaveLength(0)
+    expect(pg('').references).toHaveLength(0)
   })
 })

--- a/apps/desktop/src/renderer/src/lib/__tests__/cross-tab-resolver.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/cross-tab-resolver.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { resolveReferences, type ResolvableTab } from '../cross-tab-resolver'
 import { parseTabReferences } from '../cross-tab-parser'
+import type { DatabaseType } from '@data-peek/shared'
 
 const successTab = (
   name: string,
@@ -24,15 +25,18 @@ const emptyTab = (name: string): ResolvableTab => ({
   result: { kind: 'none' }
 })
 
-const makeLookup = (tabs: ResolvableTab[]) =>
-  (name: string) => tabs.find((t) => t.name === name) ?? null
+const makeLookup = (tabs: ResolvableTab[]) => (name: string) =>
+  tabs.find((t) => t.name === name) ?? null
+
+function parse(sql: string, dialect: DatabaseType = 'postgresql') {
+  return parseTabReferences(sql, { dialect })
+}
 
 describe('resolveReferences', () => {
   describe('happy paths', () => {
     it('no references → source unchanged', () => {
       const sql = 'SELECT * FROM users'
-      const parsed = parseTabReferences(sql)
-      const r = resolveReferences(sql, parsed, {
+      const r = resolveReferences(sql, parse(sql), {
         lookup: () => null,
         currentTabId: 'main',
         dialect: 'postgresql'
@@ -46,8 +50,7 @@ describe('resolveReferences', () => {
 
     it('one reference → CTE prepended with WITH and identifier substitution', () => {
       const sql = 'SELECT * FROM @active_users'
-      const parsed = parseTabReferences(sql)
-      const r = resolveReferences(sql, parsed, {
+      const r = resolveReferences(sql, parse(sql), {
         lookup: makeLookup([
           successTab(
             'active_users',
@@ -69,7 +72,6 @@ describe('resolveReferences', () => {
       expect(r.result.finalSql).toContain('WITH')
       expect(r.result.finalSql).toContain('active_users')
       expect(r.result.finalSql).toContain('VALUES')
-      // Identifier substitution removed the @
       expect(r.result.finalSql).toContain('SELECT * FROM active_users')
       expect(r.result.finalSql).not.toContain('@active_users')
       expect(r.result.rowsInlined).toBe(2)
@@ -77,8 +79,7 @@ describe('resolveReferences', () => {
 
     it('emits PG type casts on the first VALUES tuple', () => {
       const sql = 'SELECT * FROM @t'
-      const parsed = parseTabReferences(sql)
-      const r = resolveReferences(sql, parsed, {
+      const r = resolveReferences(sql, parse(sql), {
         lookup: makeLookup([
           successTab(
             't',
@@ -97,15 +98,13 @@ describe('resolveReferences', () => {
       })
       expect(r.ok).toBe(true)
       if (!r.ok) return
-      // First tuple should carry ::integer and ::text casts.
       expect(r.result.prependedCtes[0]).toMatch(/::integer/)
       expect(r.result.prependedCtes[0]).toMatch(/::text/)
     })
 
     it('multiple distinct references → multiple CTEs in alphabetical order', () => {
       const sql = 'SELECT * FROM @users JOIN @orders USING(user_id)'
-      const parsed = parseTabReferences(sql)
-      const r = resolveReferences(sql, parsed, {
+      const r = resolveReferences(sql, parse(sql), {
         lookup: makeLookup([
           successTab('users', [{ user_id: 1 }], [{ name: 'user_id', dataType: 'integer' }]),
           successTab(
@@ -122,7 +121,6 @@ describe('resolveReferences', () => {
       })
       expect(r.ok).toBe(true)
       if (!r.ok) return
-      // Alphabetical: orders before users.
       const ordersIdx = r.result.finalSql.indexOf('orders(')
       const usersIdx = r.result.finalSql.indexOf('users(')
       expect(ordersIdx).toBeGreaterThan(0)
@@ -131,8 +129,7 @@ describe('resolveReferences', () => {
 
     it('repeated references emit only one CTE', () => {
       const sql = 'SELECT * FROM @t a JOIN @t b ON a.id < b.id'
-      const parsed = parseTabReferences(sql)
-      const r = resolveReferences(sql, parsed, {
+      const r = resolveReferences(sql, parse(sql), {
         lookup: makeLookup([
           successTab('t', [{ id: 1 }, { id: 2 }], [{ name: 'id', dataType: 'integer' }])
         ]),
@@ -142,15 +139,13 @@ describe('resolveReferences', () => {
       expect(r.ok).toBe(true)
       if (!r.ok) return
       expect(r.result.prependedCtes).toHaveLength(1)
-      // Both references substituted in the final SQL.
       expect(r.result.finalSql.indexOf('t a')).toBeGreaterThan(0)
       expect(r.result.finalSql.indexOf('t b')).toBeGreaterThan(0)
     })
 
-    it('empty result emits a defensible WHERE FALSE CTE', () => {
+    it('empty result emits a defensible WHERE FALSE CTE (PG)', () => {
       const sql = 'SELECT * FROM @empty'
-      const parsed = parseTabReferences(sql)
-      const r = resolveReferences(sql, parsed, {
+      const r = resolveReferences(sql, parse(sql), {
         lookup: makeLookup([
           successTab('empty', [], [{ name: 'id', dataType: 'integer' }])
         ]),
@@ -165,8 +160,7 @@ describe('resolveReferences', () => {
 
     it('merges into an existing WITH clause when present', () => {
       const sql = 'WITH high AS (SELECT 1) SELECT * FROM @users, high'
-      const parsed = parseTabReferences(sql)
-      const r = resolveReferences(sql, parsed, {
+      const r = resolveReferences(sql, parse(sql), {
         lookup: makeLookup([
           successTab('users', [{ id: 1 }], [{ name: 'id', dataType: 'integer' }])
         ]),
@@ -175,20 +169,222 @@ describe('resolveReferences', () => {
       })
       expect(r.ok).toBe(true)
       if (!r.ok) return
-      // The merged WITH should appear once at the start; users CTE comes
-      // before the user's `high` CTE.
       const final = r.result.finalSql
       expect(final.indexOf('WITH')).toBe(0)
       expect(final.indexOf('users(')).toBeLessThan(final.indexOf('high AS'))
     })
   })
 
+  describe('dialect-specific CTE shapes', () => {
+    it('MySQL emits VALUES ROW(...) tuples', () => {
+      const sql = 'SELECT * FROM @t'
+      const r = resolveReferences(sql, parse(sql, 'mysql'), {
+        lookup: makeLookup([
+          successTab(
+            't',
+            [
+              { id: 1, name: 'a' },
+              { id: 2, name: 'b' }
+            ],
+            [
+              { name: 'id', dataType: 'integer' },
+              { name: 'name', dataType: 'varchar' }
+            ]
+          )
+        ]),
+        currentTabId: 'main',
+        dialect: 'mysql'
+      })
+      expect(r.ok).toBe(true)
+      if (!r.ok) return
+      expect(r.result.prependedCtes[0]).toMatch(/VALUES\s+ROW\(/)
+      // Should NOT carry PG-style :: casts.
+      expect(r.result.prependedCtes[0]).not.toMatch(/::integer/)
+    })
+
+    it('MSSQL wraps VALUES in SELECT * FROM derived table', () => {
+      const sql = 'SELECT * FROM @t'
+      const r = resolveReferences(sql, parse(sql, 'mssql'), {
+        lookup: makeLookup([
+          successTab(
+            't',
+            [{ id: 1 }, { id: 2 }],
+            [{ name: 'id', dataType: 'int' }]
+          )
+        ]),
+        currentTabId: 'main',
+        dialect: 'mssql'
+      })
+      expect(r.ok).toBe(true)
+      if (!r.ok) return
+      const cte = r.result.prependedCtes[0]
+      expect(cte).toMatch(/SELECT \* FROM \(VALUES/)
+      expect(cte).toMatch(/\) AS _\(/)
+    })
+
+    it('MSSQL empty CTE uses WHERE 1 = 0 (no FALSE literal)', () => {
+      const sql = 'SELECT * FROM @empty'
+      const r = resolveReferences(sql, parse(sql, 'mssql'), {
+        lookup: makeLookup([successTab('empty', [], [{ name: 'id', dataType: 'int' }])]),
+        currentTabId: 'main',
+        dialect: 'mssql'
+      })
+      expect(r.ok).toBe(true)
+      if (!r.ok) return
+      expect(r.result.prependedCtes[0]).toMatch(/WHERE 1 = 0/)
+      expect(r.result.prependedCtes[0]).not.toMatch(/FALSE/)
+    })
+
+    it('MySQL empty CTE uses WHERE FALSE inside a SELECT subquery', () => {
+      const sql = 'SELECT * FROM @empty'
+      const r = resolveReferences(sql, parse(sql, 'mysql'), {
+        lookup: makeLookup([
+          successTab('empty', [], [{ name: 'id', dataType: 'integer' }])
+        ]),
+        currentTabId: 'main',
+        dialect: 'mysql'
+      })
+      expect(r.ok).toBe(true)
+      if (!r.ok) return
+      expect(r.result.prependedCtes[0]).toMatch(/WHERE FALSE/)
+    })
+
+    it('mysql identifier quoting uses backticks', () => {
+      const sql = 'SELECT * FROM @select_data'
+      const r = resolveReferences(sql, parse(sql, 'mysql'), {
+        lookup: makeLookup([
+          successTab(
+            'select_data',
+            [{ order: 1 }],
+            [{ name: 'order', dataType: 'integer' }]
+          )
+        ]),
+        currentTabId: 'main',
+        dialect: 'mysql'
+      })
+      expect(r.ok).toBe(true)
+      if (!r.ok) return
+      expect(r.result.prependedCtes[0]).toContain('`order`')
+    })
+  })
+
+  describe('WITH RECURSIVE handling', () => {
+    it('preserves RECURSIVE modifier when merging', () => {
+      const sql =
+        'WITH RECURSIVE chain(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM chain WHERE n < 10) SELECT * FROM @users, chain'
+      const r = resolveReferences(sql, parse(sql), {
+        lookup: makeLookup([
+          successTab('users', [{ id: 1 }], [{ name: 'id', dataType: 'integer' }])
+        ]),
+        currentTabId: 'main',
+        dialect: 'postgresql'
+      })
+      expect(r.ok).toBe(true)
+      if (!r.ok) return
+      const final = r.result.finalSql
+      // Should still start with WITH RECURSIVE, ours injected between
+      // RECURSIVE and the user's chain CTE.
+      expect(final).toMatch(/^WITH\s+RECURSIVE\b/)
+      const ourIdx = final.indexOf('users(')
+      const userIdx = final.indexOf('chain(n)')
+      expect(ourIdx).toBeGreaterThan(0)
+      expect(ourIdx).toBeLessThan(userIdx)
+    })
+
+    it('skips leading block comment when detecting WITH', () => {
+      const sql = '/* hint */ WITH user_cte AS (SELECT 1) SELECT * FROM @users, user_cte'
+      const r = resolveReferences(sql, parse(sql), {
+        lookup: makeLookup([
+          successTab('users', [{ id: 1 }], [{ name: 'id', dataType: 'integer' }])
+        ]),
+        currentTabId: 'main',
+        dialect: 'postgresql'
+      })
+      expect(r.ok).toBe(true)
+      if (!r.ok) return
+      const final = r.result.finalSql
+      // Exactly one WITH keyword should appear at the top level.
+      const matches = final.match(/\bWITH\b/g) ?? []
+      expect(matches.length).toBe(1)
+    })
+  })
+
+  describe('NaN / Infinity handling (PG)', () => {
+    it('does not double-cast NaN against an integer column', () => {
+      const sql = 'SELECT * FROM @t'
+      const r = resolveReferences(sql, parse(sql), {
+        lookup: makeLookup([
+          successTab('t', [{ x: NaN }, { x: 1 }], [{ name: 'x', dataType: 'integer' }])
+        ]),
+        currentTabId: 'main',
+        dialect: 'postgresql'
+      })
+      expect(r.ok).toBe(true)
+      if (!r.ok) return
+      // The cell should be `'NaN'::float` from escapeSQLValue with NO
+      // additional `::integer` appended.
+      expect(r.result.prependedCtes[0]).toMatch(/'NaN'::float/)
+      expect(r.result.prependedCtes[0]).not.toMatch(/'NaN'::float::integer/)
+    })
+
+    it('does not double-cast Infinity', () => {
+      const sql = 'SELECT * FROM @t'
+      const r = resolveReferences(sql, parse(sql), {
+        lookup: makeLookup([
+          successTab(
+            't',
+            [{ x: Number.POSITIVE_INFINITY }],
+            [{ name: 'x', dataType: 'integer' }]
+          )
+        ]),
+        currentTabId: 'main',
+        dialect: 'postgresql'
+      })
+      expect(r.ok).toBe(true)
+      if (!r.ok) return
+      expect(r.result.prependedCtes[0]).not.toMatch(/'Infinity'::float::integer/)
+    })
+
+    it('first-tuple NULL uses CAST(NULL AS type)', () => {
+      const sql = 'SELECT * FROM @t'
+      const r = resolveReferences(sql, parse(sql), {
+        lookup: makeLookup([
+          successTab(
+            't',
+            [{ id: null }, { id: 1 }],
+            [{ name: 'id', dataType: 'integer' }]
+          )
+        ]),
+        currentTabId: 'main',
+        dialect: 'postgresql'
+      })
+      expect(r.ok).toBe(true)
+      if (!r.ok) return
+      expect(r.result.prependedCtes[0]).toMatch(/CAST\(NULL AS integer\)/)
+    })
+  })
+
   describe('errors', () => {
     it('unknown reference', () => {
       const sql = 'SELECT * FROM @xyz'
-      const parsed = parseTabReferences(sql)
-      const r = resolveReferences(sql, parsed, {
+      const r = resolveReferences(sql, parse(sql), {
         lookup: () => null,
+        currentTabId: 'main',
+        dialect: 'postgresql'
+      })
+      expect(r.ok).toBe(false)
+      if (r.ok) return
+      expect(r.error.kind).toBe('unknown_reference')
+    })
+
+    it('refuses ref name that collides with a SQL keyword', () => {
+      // `table` is in the shared isSQLKeyword set, so even if a tab is
+      // registered with that name, the resolver refuses upfront.
+      const sql = 'SELECT * FROM @table'
+      const r = resolveReferences(sql, parse(sql), {
+        lookup: makeLookup([
+          successTab('table', [{ id: 1 }], [{ name: 'id', dataType: 'integer' }])
+        ]),
         currentTabId: 'main',
         dialect: 'postgresql'
       })
@@ -199,8 +395,7 @@ describe('resolveReferences', () => {
 
     it('referenced tab has no result yet', () => {
       const sql = 'SELECT * FROM @pending'
-      const parsed = parseTabReferences(sql)
-      const r = resolveReferences(sql, parsed, {
+      const r = resolveReferences(sql, parse(sql), {
         lookup: makeLookup([emptyTab('pending')]),
         currentTabId: 'main',
         dialect: 'postgresql'
@@ -212,8 +407,7 @@ describe('resolveReferences', () => {
 
     it('referenced tab errored on its last run', () => {
       const sql = 'SELECT * FROM @broken'
-      const parsed = parseTabReferences(sql)
-      const r = resolveReferences(sql, parsed, {
+      const r = resolveReferences(sql, parse(sql), {
         lookup: makeLookup([errorTab('broken', 'syntax error at or near "frm"')]),
         currentTabId: 'main',
         dialect: 'postgresql'
@@ -221,15 +415,11 @@ describe('resolveReferences', () => {
       expect(r.ok).toBe(false)
       if (r.ok) return
       expect(r.error.kind).toBe('errored_result')
-      if (r.error.kind === 'errored_result') {
-        expect(r.error.error).toContain('syntax error')
-      }
     })
 
-    it('self-reference flagged as circular', () => {
+    it('self-reference flagged as circular with single-name chain', () => {
       const sql = 'SELECT * FROM @me'
-      const parsed = parseTabReferences(sql)
-      const r = resolveReferences(sql, parsed, {
+      const r = resolveReferences(sql, parse(sql), {
         lookup: () => ({
           tabId: 'main',
           name: 'me',
@@ -241,13 +431,15 @@ describe('resolveReferences', () => {
       expect(r.ok).toBe(false)
       if (r.ok) return
       expect(r.error.kind).toBe('circular')
+      if (r.error.kind === 'circular') {
+        expect(r.error.chain).toEqual(['me'])
+      }
     })
 
     it('row cap exceeded', () => {
       const rows = Array.from({ length: 11 }, (_, i) => ({ id: i }))
       const sql = 'SELECT * FROM @big'
-      const parsed = parseTabReferences(sql)
-      const r = resolveReferences(sql, parsed, {
+      const r = resolveReferences(sql, parse(sql), {
         lookup: makeLookup([successTab('big', rows, [{ name: 'id', dataType: 'integer' }])]),
         currentTabId: 'main',
         dialect: 'postgresql',
@@ -265,8 +457,7 @@ describe('resolveReferences', () => {
       }))
       const rows = [Object.fromEntries(fields.map((f) => [f.name, 'x']))]
       const sql = 'SELECT * FROM @wide'
-      const parsed = parseTabReferences(sql)
-      const r = resolveReferences(sql, parsed, {
+      const r = resolveReferences(sql, parse(sql), {
         lookup: makeLookup([successTab('wide', rows, fields)]),
         currentTabId: 'main',
         dialect: 'postgresql',
@@ -277,49 +468,49 @@ describe('resolveReferences', () => {
       expect(r.error.kind).toBe('too_many_columns')
     })
 
-    it('byte cap exceeded', () => {
-      // Use a tiny cap so even a small inlined value blows past it.
-      const sql = 'SELECT * FROM @t'
-      const parsed = parseTabReferences(sql)
-      const r = resolveReferences(sql, parsed, {
+    it('byte cap exceeded — error reports running total, not the triggering CTE alone', () => {
+      // Two CTEs that individually fit under 150 bytes but together exceed
+      // it. Resolver should report the cumulative bytes at the point of
+      // failure, not just the triggering CTE's own size.
+      const sql = 'SELECT * FROM @alpha, @beta'
+      const r = resolveReferences(sql, parse(sql), {
         lookup: makeLookup([
           successTab(
-            't',
-            [{ note: 'x'.repeat(100) }],
+            'alpha',
+            [{ note: 'x'.repeat(60) }],
+            [{ name: 'note', dataType: 'text' }]
+          ),
+          successTab(
+            'beta',
+            [{ note: 'y'.repeat(60) }],
             [{ name: 'note', dataType: 'text' }]
           )
         ]),
         currentTabId: 'main',
         dialect: 'postgresql',
-        caps: { maxBytesTotal: 10 }
+        caps: { maxBytesTotal: 150 }
       })
       expect(r.ok).toBe(false)
       if (r.ok) return
       expect(r.error.kind).toBe('too_large')
+      if (r.error.kind === 'too_large') {
+        expect(r.error.bytes).toBeGreaterThan(0)
+        expect(r.error.bytes).toBeGreaterThanOrEqual(r.error.cap.bytes)
+      }
     })
-  })
 
-  describe('dialect handling', () => {
-    it('mysql identifier quoting uses backticks', () => {
-      const sql = 'SELECT * FROM @select_data'
-      // `select_data` doesn't need quoting, but if a field name needs it
-      // we want backticks for mysql. Use a column named 'order' which is a
-      // reserved word.
-      const parsed = parseTabReferences(sql)
-      const r = resolveReferences(sql, parsed, {
+    it('duplicate CTE name — user already declared a CTE with our name', () => {
+      const sql = 'WITH users AS (SELECT 1) SELECT * FROM @users, users'
+      const r = resolveReferences(sql, parse(sql), {
         lookup: makeLookup([
-          successTab(
-            'select_data',
-            [{ order: 1 }],
-            [{ name: 'order', dataType: 'integer' }]
-          )
+          successTab('users', [{ id: 1 }], [{ name: 'id', dataType: 'integer' }])
         ]),
         currentTabId: 'main',
-        dialect: 'mysql'
+        dialect: 'postgresql'
       })
-      expect(r.ok).toBe(true)
-      if (!r.ok) return
-      expect(r.result.prependedCtes[0]).toContain('`order`')
+      expect(r.ok).toBe(false)
+      if (r.ok) return
+      expect(r.error.kind).toBe('duplicate_cte_name')
     })
   })
 })

--- a/apps/desktop/src/renderer/src/lib/__tests__/cross-tab-resolver.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/cross-tab-resolver.test.ts
@@ -1,0 +1,325 @@
+import { describe, it, expect } from 'vitest'
+import { resolveReferences, type ResolvableTab } from '../cross-tab-resolver'
+import { parseTabReferences } from '../cross-tab-parser'
+
+const successTab = (
+  name: string,
+  rows: Array<Record<string, unknown>>,
+  fields: Array<{ name: string; dataType: string }>
+): ResolvableTab => ({
+  tabId: `tab-${name}`,
+  name,
+  result: { kind: 'success', rows, fields }
+})
+
+const errorTab = (name: string, message: string): ResolvableTab => ({
+  tabId: `tab-${name}`,
+  name,
+  result: { kind: 'error', message }
+})
+
+const emptyTab = (name: string): ResolvableTab => ({
+  tabId: `tab-${name}`,
+  name,
+  result: { kind: 'none' }
+})
+
+const makeLookup = (tabs: ResolvableTab[]) =>
+  (name: string) => tabs.find((t) => t.name === name) ?? null
+
+describe('resolveReferences', () => {
+  describe('happy paths', () => {
+    it('no references → source unchanged', () => {
+      const sql = 'SELECT * FROM users'
+      const parsed = parseTabReferences(sql)
+      const r = resolveReferences(sql, parsed, {
+        lookup: () => null,
+        currentTabId: 'main',
+        dialect: 'postgresql'
+      })
+      expect(r.ok).toBe(true)
+      if (r.ok) {
+        expect(r.result.finalSql).toBe(sql)
+        expect(r.result.prependedCtes).toHaveLength(0)
+      }
+    })
+
+    it('one reference → CTE prepended with WITH and identifier substitution', () => {
+      const sql = 'SELECT * FROM @active_users'
+      const parsed = parseTabReferences(sql)
+      const r = resolveReferences(sql, parsed, {
+        lookup: makeLookup([
+          successTab(
+            'active_users',
+            [
+              { id: 1, email: 'a@x.com' },
+              { id: 2, email: 'b@x.com' }
+            ],
+            [
+              { name: 'id', dataType: 'integer' },
+              { name: 'email', dataType: 'text' }
+            ]
+          )
+        ]),
+        currentTabId: 'main',
+        dialect: 'postgresql'
+      })
+      expect(r.ok).toBe(true)
+      if (!r.ok) return
+      expect(r.result.finalSql).toContain('WITH')
+      expect(r.result.finalSql).toContain('active_users')
+      expect(r.result.finalSql).toContain('VALUES')
+      // Identifier substitution removed the @
+      expect(r.result.finalSql).toContain('SELECT * FROM active_users')
+      expect(r.result.finalSql).not.toContain('@active_users')
+      expect(r.result.rowsInlined).toBe(2)
+    })
+
+    it('emits PG type casts on the first VALUES tuple', () => {
+      const sql = 'SELECT * FROM @t'
+      const parsed = parseTabReferences(sql)
+      const r = resolveReferences(sql, parsed, {
+        lookup: makeLookup([
+          successTab(
+            't',
+            [
+              { id: 1, name: 'a' },
+              { id: 2, name: 'b' }
+            ],
+            [
+              { name: 'id', dataType: 'integer' },
+              { name: 'name', dataType: 'text' }
+            ]
+          )
+        ]),
+        currentTabId: 'main',
+        dialect: 'postgresql'
+      })
+      expect(r.ok).toBe(true)
+      if (!r.ok) return
+      // First tuple should carry ::integer and ::text casts.
+      expect(r.result.prependedCtes[0]).toMatch(/::integer/)
+      expect(r.result.prependedCtes[0]).toMatch(/::text/)
+    })
+
+    it('multiple distinct references → multiple CTEs in alphabetical order', () => {
+      const sql = 'SELECT * FROM @users JOIN @orders USING(user_id)'
+      const parsed = parseTabReferences(sql)
+      const r = resolveReferences(sql, parsed, {
+        lookup: makeLookup([
+          successTab('users', [{ user_id: 1 }], [{ name: 'user_id', dataType: 'integer' }]),
+          successTab(
+            'orders',
+            [{ user_id: 1, amount: 99 }],
+            [
+              { name: 'user_id', dataType: 'integer' },
+              { name: 'amount', dataType: 'numeric' }
+            ]
+          )
+        ]),
+        currentTabId: 'main',
+        dialect: 'postgresql'
+      })
+      expect(r.ok).toBe(true)
+      if (!r.ok) return
+      // Alphabetical: orders before users.
+      const ordersIdx = r.result.finalSql.indexOf('orders(')
+      const usersIdx = r.result.finalSql.indexOf('users(')
+      expect(ordersIdx).toBeGreaterThan(0)
+      expect(ordersIdx).toBeLessThan(usersIdx)
+    })
+
+    it('repeated references emit only one CTE', () => {
+      const sql = 'SELECT * FROM @t a JOIN @t b ON a.id < b.id'
+      const parsed = parseTabReferences(sql)
+      const r = resolveReferences(sql, parsed, {
+        lookup: makeLookup([
+          successTab('t', [{ id: 1 }, { id: 2 }], [{ name: 'id', dataType: 'integer' }])
+        ]),
+        currentTabId: 'main',
+        dialect: 'postgresql'
+      })
+      expect(r.ok).toBe(true)
+      if (!r.ok) return
+      expect(r.result.prependedCtes).toHaveLength(1)
+      // Both references substituted in the final SQL.
+      expect(r.result.finalSql.indexOf('t a')).toBeGreaterThan(0)
+      expect(r.result.finalSql.indexOf('t b')).toBeGreaterThan(0)
+    })
+
+    it('empty result emits a defensible WHERE FALSE CTE', () => {
+      const sql = 'SELECT * FROM @empty'
+      const parsed = parseTabReferences(sql)
+      const r = resolveReferences(sql, parsed, {
+        lookup: makeLookup([
+          successTab('empty', [], [{ name: 'id', dataType: 'integer' }])
+        ]),
+        currentTabId: 'main',
+        dialect: 'postgresql'
+      })
+      expect(r.ok).toBe(true)
+      if (!r.ok) return
+      expect(r.result.prependedCtes[0]).toMatch(/WHERE FALSE/)
+      expect(r.result.rowsInlined).toBe(0)
+    })
+
+    it('merges into an existing WITH clause when present', () => {
+      const sql = 'WITH high AS (SELECT 1) SELECT * FROM @users, high'
+      const parsed = parseTabReferences(sql)
+      const r = resolveReferences(sql, parsed, {
+        lookup: makeLookup([
+          successTab('users', [{ id: 1 }], [{ name: 'id', dataType: 'integer' }])
+        ]),
+        currentTabId: 'main',
+        dialect: 'postgresql'
+      })
+      expect(r.ok).toBe(true)
+      if (!r.ok) return
+      // The merged WITH should appear once at the start; users CTE comes
+      // before the user's `high` CTE.
+      const final = r.result.finalSql
+      expect(final.indexOf('WITH')).toBe(0)
+      expect(final.indexOf('users(')).toBeLessThan(final.indexOf('high AS'))
+    })
+  })
+
+  describe('errors', () => {
+    it('unknown reference', () => {
+      const sql = 'SELECT * FROM @xyz'
+      const parsed = parseTabReferences(sql)
+      const r = resolveReferences(sql, parsed, {
+        lookup: () => null,
+        currentTabId: 'main',
+        dialect: 'postgresql'
+      })
+      expect(r.ok).toBe(false)
+      if (r.ok) return
+      expect(r.error.kind).toBe('unknown_reference')
+    })
+
+    it('referenced tab has no result yet', () => {
+      const sql = 'SELECT * FROM @pending'
+      const parsed = parseTabReferences(sql)
+      const r = resolveReferences(sql, parsed, {
+        lookup: makeLookup([emptyTab('pending')]),
+        currentTabId: 'main',
+        dialect: 'postgresql'
+      })
+      expect(r.ok).toBe(false)
+      if (r.ok) return
+      expect(r.error.kind).toBe('no_result')
+    })
+
+    it('referenced tab errored on its last run', () => {
+      const sql = 'SELECT * FROM @broken'
+      const parsed = parseTabReferences(sql)
+      const r = resolveReferences(sql, parsed, {
+        lookup: makeLookup([errorTab('broken', 'syntax error at or near "frm"')]),
+        currentTabId: 'main',
+        dialect: 'postgresql'
+      })
+      expect(r.ok).toBe(false)
+      if (r.ok) return
+      expect(r.error.kind).toBe('errored_result')
+      if (r.error.kind === 'errored_result') {
+        expect(r.error.error).toContain('syntax error')
+      }
+    })
+
+    it('self-reference flagged as circular', () => {
+      const sql = 'SELECT * FROM @me'
+      const parsed = parseTabReferences(sql)
+      const r = resolveReferences(sql, parsed, {
+        lookup: () => ({
+          tabId: 'main',
+          name: 'me',
+          result: { kind: 'success', rows: [], fields: [] }
+        }),
+        currentTabId: 'main',
+        dialect: 'postgresql'
+      })
+      expect(r.ok).toBe(false)
+      if (r.ok) return
+      expect(r.error.kind).toBe('circular')
+    })
+
+    it('row cap exceeded', () => {
+      const rows = Array.from({ length: 11 }, (_, i) => ({ id: i }))
+      const sql = 'SELECT * FROM @big'
+      const parsed = parseTabReferences(sql)
+      const r = resolveReferences(sql, parsed, {
+        lookup: makeLookup([successTab('big', rows, [{ name: 'id', dataType: 'integer' }])]),
+        currentTabId: 'main',
+        dialect: 'postgresql',
+        caps: { maxRowsPerRef: 10 }
+      })
+      expect(r.ok).toBe(false)
+      if (r.ok) return
+      expect(r.error.kind).toBe('too_large')
+    })
+
+    it('column cap exceeded', () => {
+      const fields = Array.from({ length: 5 }, (_, i) => ({
+        name: `c${i}`,
+        dataType: 'text'
+      }))
+      const rows = [Object.fromEntries(fields.map((f) => [f.name, 'x']))]
+      const sql = 'SELECT * FROM @wide'
+      const parsed = parseTabReferences(sql)
+      const r = resolveReferences(sql, parsed, {
+        lookup: makeLookup([successTab('wide', rows, fields)]),
+        currentTabId: 'main',
+        dialect: 'postgresql',
+        caps: { maxColumnsPerRef: 3 }
+      })
+      expect(r.ok).toBe(false)
+      if (r.ok) return
+      expect(r.error.kind).toBe('too_many_columns')
+    })
+
+    it('byte cap exceeded', () => {
+      // Use a tiny cap so even a small inlined value blows past it.
+      const sql = 'SELECT * FROM @t'
+      const parsed = parseTabReferences(sql)
+      const r = resolveReferences(sql, parsed, {
+        lookup: makeLookup([
+          successTab(
+            't',
+            [{ note: 'x'.repeat(100) }],
+            [{ name: 'note', dataType: 'text' }]
+          )
+        ]),
+        currentTabId: 'main',
+        dialect: 'postgresql',
+        caps: { maxBytesTotal: 10 }
+      })
+      expect(r.ok).toBe(false)
+      if (r.ok) return
+      expect(r.error.kind).toBe('too_large')
+    })
+  })
+
+  describe('dialect handling', () => {
+    it('mysql identifier quoting uses backticks', () => {
+      const sql = 'SELECT * FROM @select_data'
+      // `select_data` doesn't need quoting, but if a field name needs it
+      // we want backticks for mysql. Use a column named 'order' which is a
+      // reserved word.
+      const parsed = parseTabReferences(sql)
+      const r = resolveReferences(sql, parsed, {
+        lookup: makeLookup([
+          successTab(
+            'select_data',
+            [{ order: 1 }],
+            [{ name: 'order', dataType: 'integer' }]
+          )
+        ]),
+        currentTabId: 'main',
+        dialect: 'mysql'
+      })
+      expect(r.ok).toBe(true)
+      if (!r.ok) return
+      expect(r.result.prependedCtes[0]).toContain('`order`')
+    })
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/cross-tab-name-validation.ts
+++ b/apps/desktop/src/renderer/src/lib/cross-tab-name-validation.ts
@@ -1,0 +1,160 @@
+/**
+ * Reference-name validation for cross-tab queries.
+ *
+ * Three layers of rules, in order:
+ *   1. Shape — pattern, length, normalization (lowercase, trim).
+ *   2. Reserved words — SQL keywords that would lead to ambiguous CTEs or
+ *      flag-out parsing inside the user's query.
+ *   3. Uniqueness — duplicates within the same connection are rejected so
+ *      `@active_users` is unambiguous.
+ *
+ * Validation runs both at input time (Tab → "Name this tab as @…") and at
+ * parse time (the resolver double-checks before generating CTEs).
+ */
+
+import {
+  REF_NAME_MAX_LENGTH,
+  REF_NAME_PATTERN,
+  type RefNameValidationResult
+} from './cross-tab-types'
+
+/**
+ * SQL keywords we refuse to allow as tab names. A name like `@select` would
+ * make the resulting CTE `WITH select(...)` which parses but is awful to
+ * read; worse, names like `@from` could collide visually with parser state
+ * in the future autocomplete pass.
+ */
+const RESERVED_REF_NAMES = new Set([
+  'select',
+  'from',
+  'where',
+  'join',
+  'inner',
+  'left',
+  'right',
+  'full',
+  'outer',
+  'cross',
+  'natural',
+  'on',
+  'using',
+  'group',
+  'order',
+  'by',
+  'having',
+  'limit',
+  'offset',
+  'fetch',
+  'with',
+  'as',
+  'and',
+  'or',
+  'not',
+  'null',
+  'true',
+  'false',
+  'distinct',
+  'all',
+  'union',
+  'intersect',
+  'except',
+  'case',
+  'when',
+  'then',
+  'else',
+  'end',
+  'in',
+  'between',
+  'like',
+  'ilike',
+  'is',
+  'exists',
+  'any',
+  'some',
+  'values',
+  'returning',
+  'insert',
+  'update',
+  'delete',
+  'create',
+  'drop',
+  'alter',
+  'truncate',
+  'grant',
+  'revoke',
+  'begin',
+  'commit',
+  'rollback'
+])
+
+/**
+ * Validate that the given string is a usable reference name, optionally
+ * also checking for uniqueness across a set of already-taken names on the
+ * same connection.
+ *
+ * `takenNames` should map `name → tabId`. If the candidate is in the map
+ * with a tabId different from `ownTabId`, the validation fails with
+ * `duplicate`. Passing the same `ownTabId` lets a tab keep its name on
+ * re-validate (e.g., when the user blurs the rename input without
+ * changing the value).
+ */
+export function validateRefName(
+  candidate: string,
+  options: {
+    takenNames?: Map<string, string>
+    ownTabId?: string
+  } = {}
+): RefNameValidationResult {
+  // Normalize: trim + lowercase. The lowercase requirement keeps the CTE
+  // generation deterministic and avoids case-mismatched identifier quoting
+  // issues across PG/MySQL.
+  const normalized = candidate.trim().toLowerCase()
+
+  if (normalized.length === 0) {
+    return { ok: false, error: { kind: 'empty' } }
+  }
+  if (normalized.length > REF_NAME_MAX_LENGTH) {
+    return {
+      ok: false,
+      error: {
+        kind: 'too_long',
+        length: normalized.length,
+        max: REF_NAME_MAX_LENGTH
+      }
+    }
+  }
+  if (!REF_NAME_PATTERN.test(normalized)) {
+    return {
+      ok: false,
+      error: {
+        kind: 'invalid_chars',
+        detail:
+          'Use lowercase letters, digits, underscores. Must start with a letter.'
+      }
+    }
+  }
+  if (RESERVED_REF_NAMES.has(normalized)) {
+    return {
+      ok: false,
+      error: { kind: 'reserved_word', word: normalized }
+    }
+  }
+
+  const { takenNames, ownTabId } = options
+  if (takenNames) {
+    const conflicting = takenNames.get(normalized)
+    if (conflicting && conflicting !== ownTabId) {
+      return {
+        ok: false,
+        error: { kind: 'duplicate', conflictingTabId: conflicting }
+      }
+    }
+  }
+
+  return { ok: true, normalized }
+}
+
+/** Returns true iff the word is in the SQL reserved-words set. Exported for tests. */
+export function isReservedRefName(word: string): boolean {
+  return RESERVED_REF_NAMES.has(word.toLowerCase())
+}

--- a/apps/desktop/src/renderer/src/lib/cross-tab-name-validation.ts
+++ b/apps/desktop/src/renderer/src/lib/cross-tab-name-validation.ts
@@ -12,6 +12,7 @@
  * parse time (the resolver double-checks before generating CTEs).
  */
 
+import { isSQLKeyword } from '@data-peek/shared'
 import {
   REF_NAME_MAX_LENGTH,
   REF_NAME_PATTERN,
@@ -133,7 +134,12 @@ export function validateRefName(
       }
     }
   }
-  if (RESERVED_REF_NAMES.has(normalized)) {
+  if (RESERVED_REF_NAMES.has(normalized) || isSQLKeyword(normalized)) {
+    // Local list catches common keywords with a clear message; the shared
+    // isSQLKeyword catches the long tail (table, into, set, recursive,
+    // references, using, over, etc.) that the resolver would otherwise
+    // reject at run time with `unknown_reference`. Surface them here so
+    // the rename UI catches the bad name on input.
     return {
       ok: false,
       error: { kind: 'reserved_word', word: normalized }

--- a/apps/desktop/src/renderer/src/lib/cross-tab-parser.ts
+++ b/apps/desktop/src/renderer/src/lib/cross-tab-parser.ts
@@ -2,45 +2,139 @@
  * Cross-Tab Query parser.
  *
  * Scans a SQL string for `@name` reference tokens, ignoring matches inside:
- *   - single-quoted string literals (with doubled-quote escapes)
+ *   - single-quoted string literals (with `''` standard escape AND `\'`
+ *     backslash escape — the latter is on by default in MySQL and inside
+ *     Postgres `E'...'` strings)
  *   - double-quoted identifiers (`"foo@bar"`)
- *   - line comments (`-- …`)
- *   - block comments (`/* … *‍/`, with nesting for Postgres)
- *   - dollar-quoted strings (`$tag$ … $tag$`)
- *   - email-like sequences (`foo@bar.com`) — `@` preceded by a non-whitespace
- *     non-operator character is treated as a literal `@`, not a ref boundary
+ *   - MySQL backtick-quoted identifiers (`` `@col` ``)
+ *   - MSSQL bracket-quoted identifiers (`[@col]`, with `]]` escape)
+ *   - line comments (terminated by `\n` or `\r`)
+ *   - block comments (`/* ... *‍/`, nested only in Postgres)
+ *   - Postgres dollar-quoted bodies (`$tag$ ... $tag$`, tag must start
+ *     with a letter or underscore — `$1$` is NOT a dollar quote)
+ *   - email-like sequences (`foo@bar.com`)
+ *   - `@@var` system-variable prefixes (MySQL / MSSQL)
  *
- * The output is the list of TabReference instances + a deduplicated name
- * set. The resolver consumes both — names for lookup, references for
- * source-position-aware error messages.
+ * The parser is dialect-aware. Dialect-only behaviour:
+ *   - `mysql`: backtick identifiers, backslash escape in strings, no nested
+ *     block comments, no dollar-quoted strings
+ *   - `mssql`: bracket identifiers, backslash NOT an escape, no nested
+ *     block comments, no dollar-quoted strings
+ *   - `postgresql`: nested block comments, dollar-quoted strings, backslash
+ *     escape only inside `E'...'` strings
+ *   - `sqlite`: backtick identifiers, no dollar quotes, no nested comments
  *
- * This is intentionally a hand-written single-pass scanner. The full SQL
- * tokenizer in `editable-select.ts` is overkill for this lookup and would
- * require us to thread dialect-specific quoting all the way through.
+ * MySQL/MSSQL `@var` collision: in those dialects `@name` is also user-
+ * defined-variable syntax. The parser's default is to still emit every
+ * `@name` token (the resolver decides what's a real reference). Callers
+ * that want to suppress unknown `@var` lookups in those dialects can pass
+ * `knownNames` — when present, only `@name` tokens whose name is in the
+ * set are emitted as references. The integration layer plumbs the set of
+ * registered tab names through for MySQL/MSSQL.
  */
 
+import type { DatabaseType } from '@data-peek/shared'
 import { REF_NAME_PATTERN, type TabReference, type ParsedSql } from './cross-tab-types'
+
+export interface ParseOptions {
+  dialect: DatabaseType
+  /**
+   * When provided, only `@name` tokens whose name is in the set are emitted
+   * as references. Unrecognised `@name` tokens are silently dropped.
+   *
+   * Useful in MySQL / MSSQL where `@name` is also user-defined-variable
+   * syntax: pass the set of currently registered tab names and the parser
+   * won't capture every `@offset` / `@count` in the user's procedure SQL
+   * as an unknown reference.
+   */
+  knownNames?: ReadonlySet<string>
+}
 
 /**
  * Strict regex for the part *after* the `@`. Same shape as REF_NAME_PATTERN
  * but used directly against the scanner cursor (no normalization needed —
  * the match must already be a valid name shape to be consumed as a ref).
+ *
+ * The negative lookahead at the end rejects partial matches: `@fooBar`
+ * doesn't silently parse as `@foo`. The whole identifier must be a valid
+ * lowercase name, ending at a non-word-character boundary.
  */
-const REF_BODY_RE = /^[a-z][a-z0-9_]*/
+const REF_BODY_RE = /^[a-z][a-z0-9_]*(?![A-Za-z0-9_])/
 
 /**
  * Characters that, when immediately preceding `@`, indicate the `@` is part
- * of a word (email, identifier) — not a reference boundary. Whitespace,
- * common operators, parens, commas, equality — all "word boundary" — make
- * the `@` a real ref marker.
+ * of a word (email, identifier, `@@` system var). Whitespace, common
+ * operators, parens, commas, equality — all "word boundary" — make the `@`
+ * a real ref marker.
+ *
+ * The `@` itself is in the set: that handles the `@@version` case — when
+ * scanning the second `@` of `@@`, its predecessor is `@`, so it's treated
+ * as a word continuation and not as a ref boundary.
  */
 function isWordContinuation(prev: string | undefined): boolean {
   if (!prev) return false
-  // Letters, digits, underscore, dot, dollar, backslash — all "in a word".
-  return /[A-Za-z0-9_.$\\]/.test(prev)
+  return /[A-Za-z0-9_.$\\@]/.test(prev)
 }
 
-export function parseTabReferences(sql: string): ParsedSql {
+interface DialectConfig {
+  /** MySQL + SQLite use backticks for quoted identifiers. */
+  backtickIdents: boolean
+  /** MSSQL uses `[...]` for quoted identifiers (with `]]` escape). */
+  bracketIdents: boolean
+  /** PG nests block comments; MySQL and MSSQL don't. */
+  nestedBlockComments: boolean
+  /** PG-only: `$tag$ ... $tag$`. */
+  dollarQuotedStrings: boolean
+  /**
+   * Backslash-escape inside single-quoted strings. MySQL: default ON
+   * (unless NO_BACKSLASH_ESCAPES is set; we assume default). MSSQL: never.
+   * Postgres: only inside `E'...'` strings — handled separately below.
+   */
+  backslashEscape: boolean
+}
+
+function configFor(dialect: DatabaseType): DialectConfig {
+  switch (dialect) {
+    case 'mysql':
+      return {
+        backtickIdents: true,
+        bracketIdents: false,
+        nestedBlockComments: false,
+        dollarQuotedStrings: false,
+        backslashEscape: true
+      }
+    case 'mssql':
+      return {
+        backtickIdents: false,
+        bracketIdents: true,
+        nestedBlockComments: false,
+        dollarQuotedStrings: false,
+        backslashEscape: false
+      }
+    case 'sqlite':
+      return {
+        backtickIdents: true,
+        bracketIdents: true,
+        nestedBlockComments: false,
+        dollarQuotedStrings: false,
+        backslashEscape: false
+      }
+    case 'postgresql':
+    default:
+      return {
+        backtickIdents: false,
+        bracketIdents: false,
+        nestedBlockComments: true,
+        dollarQuotedStrings: true,
+        backslashEscape: false
+      }
+  }
+}
+
+export function parseTabReferences(sql: string, options: ParseOptions): ParsedSql {
+  const cfg = configFor(options.dialect)
+  const known = options.knownNames
+
   const references: TabReference[] = []
   const referencedNames = new Set<string>()
 
@@ -48,7 +142,10 @@ export function parseTabReferences(sql: string): ParsedSql {
   const n = sql.length
 
   let inSingle = false
+  let singleAllowsBackslash = false
   let inDouble = false
+  let inBacktick = false
+  let inBracket = false
   let inLine = false
   let blockDepth = 0
   let dollarTag: string | null = null
@@ -58,7 +155,9 @@ export function parseTabReferences(sql: string): ParsedSql {
     const nx = sql[i + 1]
 
     if (inLine) {
-      if (c === '\n') inLine = false
+      // Both \n and \r terminate line comments — old-Mac CR-only files and
+      // some generated SQL otherwise consume the rest as a comment.
+      if (c === '\n' || c === '\r') inLine = false
       i++
       continue
     }
@@ -68,7 +167,7 @@ export function parseTabReferences(sql: string): ParsedSql {
         i += 2
         continue
       }
-      if (c === '/' && nx === '*') {
+      if (cfg.nestedBlockComments && c === '/' && nx === '*') {
         blockDepth++
         i += 2
         continue
@@ -90,7 +189,15 @@ export function parseTabReferences(sql: string): ParsedSql {
         i += 2
         continue
       }
-      if (c === "'") inSingle = false
+      const allowBackslash = singleAllowsBackslash || cfg.backslashEscape
+      if (allowBackslash && c === '\\' && i + 1 < n) {
+        i += 2
+        continue
+      }
+      if (c === "'") {
+        inSingle = false
+        singleAllowsBackslash = false
+      }
       i++
       continue
     }
@@ -103,8 +210,25 @@ export function parseTabReferences(sql: string): ParsedSql {
       i++
       continue
     }
+    if (inBacktick) {
+      if (c === '`' && sql[i + 1] === '`') {
+        i += 2
+        continue
+      }
+      if (c === '`') inBacktick = false
+      i++
+      continue
+    }
+    if (inBracket) {
+      if (c === ']' && sql[i + 1] === ']') {
+        i += 2
+        continue
+      }
+      if (c === ']') inBracket = false
+      i++
+      continue
+    }
 
-    // Comment starts
     if (c === '-' && nx === '-') {
       inLine = true
       i += 2
@@ -116,10 +240,27 @@ export function parseTabReferences(sql: string): ParsedSql {
       continue
     }
 
-    // Dollar-quoted string start
-    if (c === '$') {
+    // Postgres E'...' string — backslash escape applies inside.
+    if (
+      cfg.dollarQuotedStrings &&
+      (c === 'E' || c === 'e') &&
+      nx === "'" &&
+      !isWordContinuation(i > 0 ? sql[i - 1] : undefined)
+    ) {
+      inSingle = true
+      singleAllowsBackslash = true
+      i += 2
+      continue
+    }
+
+    // PG dollar-quoted body. Tag must start with letter or underscore
+    // (`$1$` is positional-parameter syntax, not a dollar-quote open).
+    if (cfg.dollarQuotedStrings && c === '$') {
       let j = i + 1
-      while (j < n && /[A-Za-z0-9_]/.test(sql[j])) j++
+      if (j < n && /[A-Za-z_]/.test(sql[j])) {
+        j++
+        while (j < n && /[A-Za-z0-9_]/.test(sql[j])) j++
+      }
       if (sql[j] === '$') {
         dollarTag = sql.slice(i, j + 1)
         i = j + 1
@@ -129,6 +270,7 @@ export function parseTabReferences(sql: string): ParsedSql {
 
     if (c === "'") {
       inSingle = true
+      singleAllowsBackslash = false
       i++
       continue
     }
@@ -137,13 +279,20 @@ export function parseTabReferences(sql: string): ParsedSql {
       i++
       continue
     }
+    if (cfg.backtickIdents && c === '`') {
+      inBacktick = true
+      i++
+      continue
+    }
+    if (cfg.bracketIdents && c === '[') {
+      inBracket = true
+      i++
+      continue
+    }
 
-    // The interesting case.
     if (c === '@') {
       const prev = i > 0 ? sql[i - 1] : undefined
       if (isWordContinuation(prev)) {
-        // foo@bar style — not a reference. Skip the @, the next iteration
-        // will continue scanning normally.
         i++
         continue
       }
@@ -154,6 +303,14 @@ export function parseTabReferences(sql: string): ParsedSql {
         continue
       }
       const name = match[0]
+      // When the caller supplies a known-names set, suppress refs not in
+      // it. Lets MySQL/MSSQL users keep `@count` / `@offset` user-vars
+      // without spurious unknown_reference errors on every parameterised
+      // query.
+      if (known && !known.has(name)) {
+        i += 1 + name.length
+        continue
+      }
       const start = i
       const end = i + 1 + name.length
       references.push({

--- a/apps/desktop/src/renderer/src/lib/cross-tab-parser.ts
+++ b/apps/desktop/src/renderer/src/lib/cross-tab-parser.ts
@@ -1,0 +1,180 @@
+/**
+ * Cross-Tab Query parser.
+ *
+ * Scans a SQL string for `@name` reference tokens, ignoring matches inside:
+ *   - single-quoted string literals (with doubled-quote escapes)
+ *   - double-quoted identifiers (`"foo@bar"`)
+ *   - line comments (`-- …`)
+ *   - block comments (`/* … *‍/`, with nesting for Postgres)
+ *   - dollar-quoted strings (`$tag$ … $tag$`)
+ *   - email-like sequences (`foo@bar.com`) — `@` preceded by a non-whitespace
+ *     non-operator character is treated as a literal `@`, not a ref boundary
+ *
+ * The output is the list of TabReference instances + a deduplicated name
+ * set. The resolver consumes both — names for lookup, references for
+ * source-position-aware error messages.
+ *
+ * This is intentionally a hand-written single-pass scanner. The full SQL
+ * tokenizer in `editable-select.ts` is overkill for this lookup and would
+ * require us to thread dialect-specific quoting all the way through.
+ */
+
+import { REF_NAME_PATTERN, type TabReference, type ParsedSql } from './cross-tab-types'
+
+/**
+ * Strict regex for the part *after* the `@`. Same shape as REF_NAME_PATTERN
+ * but used directly against the scanner cursor (no normalization needed —
+ * the match must already be a valid name shape to be consumed as a ref).
+ */
+const REF_BODY_RE = /^[a-z][a-z0-9_]*/
+
+/**
+ * Characters that, when immediately preceding `@`, indicate the `@` is part
+ * of a word (email, identifier) — not a reference boundary. Whitespace,
+ * common operators, parens, commas, equality — all "word boundary" — make
+ * the `@` a real ref marker.
+ */
+function isWordContinuation(prev: string | undefined): boolean {
+  if (!prev) return false
+  // Letters, digits, underscore, dot, dollar, backslash — all "in a word".
+  return /[A-Za-z0-9_.$\\]/.test(prev)
+}
+
+export function parseTabReferences(sql: string): ParsedSql {
+  const references: TabReference[] = []
+  const referencedNames = new Set<string>()
+
+  let i = 0
+  const n = sql.length
+
+  let inSingle = false
+  let inDouble = false
+  let inLine = false
+  let blockDepth = 0
+  let dollarTag: string | null = null
+
+  while (i < n) {
+    const c = sql[i]
+    const nx = sql[i + 1]
+
+    if (inLine) {
+      if (c === '\n') inLine = false
+      i++
+      continue
+    }
+    if (blockDepth > 0) {
+      if (c === '*' && nx === '/') {
+        blockDepth--
+        i += 2
+        continue
+      }
+      if (c === '/' && nx === '*') {
+        blockDepth++
+        i += 2
+        continue
+      }
+      i++
+      continue
+    }
+    if (dollarTag) {
+      if (sql.startsWith(dollarTag, i)) {
+        i += dollarTag.length
+        dollarTag = null
+        continue
+      }
+      i++
+      continue
+    }
+    if (inSingle) {
+      if (c === "'" && sql[i + 1] === "'") {
+        i += 2
+        continue
+      }
+      if (c === "'") inSingle = false
+      i++
+      continue
+    }
+    if (inDouble) {
+      if (c === '"' && sql[i + 1] === '"') {
+        i += 2
+        continue
+      }
+      if (c === '"') inDouble = false
+      i++
+      continue
+    }
+
+    // Comment starts
+    if (c === '-' && nx === '-') {
+      inLine = true
+      i += 2
+      continue
+    }
+    if (c === '/' && nx === '*') {
+      blockDepth = 1
+      i += 2
+      continue
+    }
+
+    // Dollar-quoted string start
+    if (c === '$') {
+      let j = i + 1
+      while (j < n && /[A-Za-z0-9_]/.test(sql[j])) j++
+      if (sql[j] === '$') {
+        dollarTag = sql.slice(i, j + 1)
+        i = j + 1
+        continue
+      }
+    }
+
+    if (c === "'") {
+      inSingle = true
+      i++
+      continue
+    }
+    if (c === '"') {
+      inDouble = true
+      i++
+      continue
+    }
+
+    // The interesting case.
+    if (c === '@') {
+      const prev = i > 0 ? sql[i - 1] : undefined
+      if (isWordContinuation(prev)) {
+        // foo@bar style — not a reference. Skip the @, the next iteration
+        // will continue scanning normally.
+        i++
+        continue
+      }
+      const rest = sql.slice(i + 1)
+      const match = rest.match(REF_BODY_RE)
+      if (!match) {
+        i++
+        continue
+      }
+      const name = match[0]
+      const start = i
+      const end = i + 1 + name.length
+      references.push({
+        raw: '@' + name,
+        start,
+        end,
+        name,
+        status: 'unknown'
+      })
+      referencedNames.add(name)
+      i = end
+      continue
+    }
+
+    i++
+  }
+
+  return { references, referencedNames }
+}
+
+/** True iff the candidate looks like a valid ref name. Exported for the resolver. */
+export function isValidRefNameShape(name: string): boolean {
+  return REF_NAME_PATTERN.test(name)
+}

--- a/apps/desktop/src/renderer/src/lib/cross-tab-resolver.ts
+++ b/apps/desktop/src/renderer/src/lib/cross-tab-resolver.ts
@@ -2,20 +2,41 @@
  * Cross-Tab Query resolver.
  *
  * Given a ParsedSql + a way to look up "name → tab result", produce:
- *   - A final SQL string with each `@name` substituted for the bare
- *     identifier `name` (no `@`).
+ *   - A final SQL string with each `@name` substituted for a properly
+ *     quoted identifier (no `@`).
  *   - A list of CTEs (one per unique reference) prepended in order.
  *
- * The resolver is dialect-aware via the SQLDialect type from
- * @data-peek/shared. Identifier quoting and value serialisation go through
- * the same helpers the edit-store uses, so bigints, dates, JSON, byteas all
- * serialise correctly.
+ * The resolver is dialect-aware. The shape of the inlined CTE varies:
  *
- * Errors are returned (not thrown) — callers want to surface them in the
- * UI with the offending reference name, not in a try/catch.
+ *   - Postgres: `name(cols) AS (VALUES (v1::t1, v2::t2), (v3, v4))`.
+ *     First tuple carries explicit type casts so the optimizer doesn't
+ *     default everything to `text`. Empty results emit a `WHERE FALSE`
+ *     defence over a synthesized all-NULL row.
+ *
+ *   - MySQL: `name(cols) AS (VALUES ROW(v1, v2), ROW(v3, v4))`. MySQL
+ *     8.0.19+ requires the explicit `ROW(...)` constructor; a bare
+ *     `VALUES (...)` body is rejected.
+ *
+ *   - MSSQL: `name(cols) AS (SELECT * FROM (VALUES (v1, v2)) AS _(cols))`.
+ *     T-SQL requires a `SELECT` body for a CTE; a bare `VALUES` clause
+ *     must be wrapped in a derived table. The empty-CTE branch uses
+ *     `WHERE 1 = 0` (T-SQL has no `FALSE` literal).
+ *
+ *   - SQLite: same shape as Postgres (no type casts emitted — SQLite's
+ *     dynamic typing makes them unnecessary and `::type` syntax invalid).
+ *
+ * NaN/Infinity guard: `escapeSQLValue` from `@data-peek/shared` already
+ * appends `::float` casts to non-finite numerics. The resolver detects
+ * that and skips its own `::<column-type>` wrap, otherwise we'd end up
+ * with `'NaN'::float::integer` which PG rejects at execution time.
  */
 
-import { escapeSQLIdentifier, escapeSQLValue, type SQLDialect } from '@data-peek/shared'
+import {
+  escapeSQLIdentifier,
+  escapeSQLValue,
+  isSQLKeyword,
+  type SQLDialect
+} from '@data-peek/shared'
 import type {
   ParsedSql,
   ResolveCaps,
@@ -33,9 +54,7 @@ import { DEFAULT_RESOLVE_CAPS } from './cross-tab-types'
 export interface ResolvableTab {
   tabId: string
   name: string
-  /** Display label — used in error chains for circularity. */
   title?: string
-  /** Last execution outcome. */
   result:
     | {
         kind: 'success'
@@ -57,11 +76,6 @@ export interface ResolveContext {
   caps?: Partial<ResolveCaps>
 }
 
-/**
- * Resolve a parsed SQL into a runnable string. References are inlined as
- * `VALUES`-backed CTEs in alphabetical order (stable across runs so diffs
- * of the generated SQL are clean).
- */
 export function resolveReferences(
   source: string,
   parsed: ParsedSql,
@@ -84,8 +98,6 @@ export function resolveReferences(
     }
   }
 
-  // Validate + collect per-name plans. Resolve in alphabetical order so the
-  // emitted SQL is stable.
   const namesSorted = Array.from(parsed.referencedNames).sort()
   const plans: Array<{
     name: string
@@ -95,15 +107,25 @@ export function resolveReferences(
   }> = []
 
   for (const name of namesSorted) {
+    // Refuse to inline as a CTE if the name collides with a reserved SQL
+    // keyword. escapeSQLIdentifier would quote the CTE-position identifier,
+    // but the substitution site in the user's SQL is the bare name —
+    // `WITH "table" (...) ... FROM table` is invalid. Reject early so the
+    // user renames.
+    if (isSQLKeyword(name)) {
+      return { ok: false, error: { kind: 'unknown_reference', name } }
+    }
+
     const tab = ctx.lookup(name)
     if (!tab) {
       return { ok: false, error: { kind: 'unknown_reference', name } }
     }
 
-    // Self-reference is the simplest "circular" case and worth surfacing
-    // with a clean error before we get into more elaborate chain detection.
+    // Self-reference. The resolver only inlines the result (not the SQL)
+    // so transitive A→B→A cycles don't actually loop at runtime, but a
+    // tab referencing itself is always a mistake.
     if (tab.tabId === ctx.currentTabId) {
-      return { ok: false, error: { kind: 'circular', chain: [name, name] } }
+      return { ok: false, error: { kind: 'circular', chain: [name] } }
     }
 
     if (tab.result.kind === 'none') {
@@ -160,7 +182,9 @@ export function resolveReferences(
           kind: 'too_large',
           name: plan.name,
           rows: plan.rows.length,
-          bytes,
+          // Report the running total — gives the user a true picture of
+          // how close they are to the cap, not just this CTE's slice.
+          bytes: totalBytes,
           cap: { rows: caps.maxRowsPerRef, bytes: caps.maxBytesTotal }
         }
       }
@@ -174,20 +198,29 @@ export function resolveReferences(
     })
   }
 
-  // Substitute `@name` with `name` in the source, walking the references
-  // back-to-front so positions stay valid.
+  // Substitute `@name` with a properly quoted identifier in the source,
+  // walking the references back-to-front so positions stay valid. Quoting
+  // through escapeSQLIdentifier handles any name that happens to need it
+  // (capitals / mixed case / future relaxation of the reserved-word
+  // check above).
   const sortedRefs = [...parsed.references].sort((a, b) => b.start - a.start)
   let rewritten = source
   for (const ref of sortedRefs) {
-    rewritten = rewritten.slice(0, ref.start) + ref.name + rewritten.slice(ref.end)
+    rewritten =
+      rewritten.slice(0, ref.start) +
+      escapeSQLIdentifier(ref.name, ctx.dialect) +
+      rewritten.slice(ref.end)
   }
 
-  const finalSql = mergeIntoWith(ctes, rewritten)
+  const merged = mergeIntoWith(ctes, rewritten, plans.map((p) => p.name))
+  if (!merged.ok) {
+    return { ok: false, error: merged.error }
+  }
 
   return {
     ok: true,
     result: {
-      finalSql,
+      finalSql: merged.sql,
       prependedCtes: ctes,
       bytesAdded: totalBytes,
       rowsInlined: plans.reduce((acc, p) => acc + p.rows.length, 0),
@@ -196,11 +229,6 @@ export function resolveReferences(
   }
 }
 
-/**
- * Build one CTE for the given name + rows + fields. Uses VALUES with
- * type casts on the first tuple to anchor the column types — Postgres
- * needs this to avoid `text`-typing everything.
- */
 function buildCte(
   name: string,
   rows: ReadonlyArray<Record<string, unknown>>,
@@ -208,73 +236,163 @@ function buildCte(
   dialect: SQLDialect
 ): string {
   const cteIdent = escapeSQLIdentifier(name, dialect)
-  const colList = fields.map((f) => escapeSQLIdentifier(f.name, dialect)).join(', ')
+  const quotedCols = fields.map((f) => escapeSQLIdentifier(f.name, dialect))
+  const colList = quotedCols.join(', ')
 
   if (rows.length === 0) {
-    // Empty CTE: emit `WHERE FALSE` over the column list. VALUES requires
-    // at least one tuple, so synthesize an all-NULL one and exclude it.
-    const allNull = fields.map(() => 'NULL').join(', ')
+    return buildEmptyCte(cteIdent, colList, dialect, fields.length)
+  }
+
+  const tuples = rows.map((row, r) => buildTuple(row, fields, dialect, r === 0))
+  return formatCte(cteIdent, colList, tuples, dialect)
+}
+
+function buildEmptyCte(
+  cteIdent: string,
+  colList: string,
+  dialect: SQLDialect,
+  columnCount: number
+): string {
+  // VALUES requires at least one tuple in every dialect, so we synthesize
+  // an all-NULL row and exclude it via WHERE FALSE / WHERE 1 = 0.
+  const nullsList = new Array(columnCount).fill('NULL').join(', ')
+
+  if (dialect === 'mssql') {
     return [
       `${cteIdent}(${colList}) AS (`,
-      `  SELECT * FROM (VALUES (${allNull})) AS _(${colList}) WHERE FALSE`,
+      `  SELECT * FROM (VALUES (${nullsList})) AS _(${colList}) WHERE 1 = 0`,
       `)`
     ].join('\n')
   }
+  if (dialect === 'mysql') {
+    // MySQL's `VALUES ROW(...)` is awkward inside a guarded empty CTE.
+    // Use a SELECT subquery instead — universally accepted.
+    return [
+      `${cteIdent}(${colList}) AS (`,
+      `  SELECT * FROM (SELECT ${nullsList}) AS _(${colList}) WHERE FALSE`,
+      `)`
+    ].join('\n')
+  }
+  // PG / SQLite: bare VALUES in the derived-table wrapper, WHERE FALSE.
+  return [
+    `${cteIdent}(${colList}) AS (`,
+    `  SELECT * FROM (VALUES (${nullsList})) AS _(${colList}) WHERE FALSE`,
+    `)`
+  ].join('\n')
+}
 
-  const tupleStrings: string[] = []
-  for (let r = 0; r < rows.length; r++) {
-    const row = rows[r]
-    const cells = fields.map((f) => {
-      const v = row[f.name]
-      const lit = escapeSQLValue(v, f.dataType, dialect)
-      // Type-cast only on the first tuple — anchors column types for PG.
-      // Subsequent rows don't need it.
-      if (r === 0 && dialect === 'postgresql' && v !== null && v !== undefined) {
-        return `${lit}::${normalizeTypeForCast(f.dataType)}`
-      }
-      // The first tuple's NULLs still need cast info or PG infers 'text'.
-      if (r === 0 && dialect === 'postgresql' && (v === null || v === undefined)) {
+function buildTuple(
+  row: Record<string, unknown>,
+  fields: ReadonlyArray<{ name: string; dataType: string }>,
+  dialect: SQLDialect,
+  isFirstTuple: boolean
+): string {
+  const cells = fields.map((f) => {
+    const v = row[f.name]
+    const lit = escapeSQLValue(v, f.dataType, dialect)
+
+    if (isFirstTuple && dialect === 'postgresql') {
+      // Skip the wrapper cast when the literal already has one (NaN /
+      // Infinity → `'NaN'::float`, jsonb → `'…'::jsonb`). Adding our cast
+      // on top produces `'NaN'::float::integer` which PG rejects.
+      if (lit === 'NULL') {
         return `CAST(NULL AS ${normalizeTypeForCast(f.dataType)})`
       }
-      return lit
-    })
-    tupleStrings.push(`  (${cells.join(', ')})`)
-  }
+      if (!literalAlreadyHasCast(lit)) {
+        return `${lit}::${normalizeTypeForCast(f.dataType)}`
+      }
+    }
+    return lit
+  })
+  return `  (${cells.join(', ')})`
+}
 
+function formatCte(
+  cteIdent: string,
+  colList: string,
+  tuples: string[],
+  dialect: SQLDialect
+): string {
+  if (dialect === 'mysql') {
+    // MySQL 8.0.19+ requires `VALUES ROW(...)` — the bare `(v1, v2)`
+    // tuples from buildTuple get reshaped to `ROW(v1, v2)`.
+    const rowTuples = tuples.map((t) => t.replace(/^\s*\(/, '  ROW('))
+    return [
+      `${cteIdent}(${colList}) AS (`,
+      `  VALUES`,
+      rowTuples.join(',\n'),
+      `)`
+    ].join('\n')
+  }
+  if (dialect === 'mssql') {
+    return [
+      `${cteIdent}(${colList}) AS (`,
+      `  SELECT * FROM (VALUES`,
+      tuples.join(',\n'),
+      `  ) AS _(${colList})`,
+      `)`
+    ].join('\n')
+  }
+  // Postgres / SQLite.
   return [
     `${cteIdent}(${colList}) AS (`,
     `  VALUES`,
-    tupleStrings.join(',\n'),
+    tuples.join(',\n'),
     `)`
   ].join('\n')
 }
 
 /**
- * Merge generated CTEs into the source SQL. If the source already begins
- * with a top-level WITH, we splice the new CTEs in between `WITH` and the
- * user's first CTE. Otherwise we prepend a fresh WITH clause.
+ * Merge generated CTEs into the source SQL. Handles:
+ *   - Plain SQL with no leading WITH → prepend a fresh WITH clause.
+ *   - SQL leading with `WITH <user_ctes>` → splice ours ahead of the
+ *     user's so they can reference ours.
+ *   - SQL leading with `WITH RECURSIVE <user_ctes>` → keep the modifier
+ *     and splice ours ahead. The RECURSIVE modifier applies to the
+ *     whole CTE list per PG; non-recursive CTEs are legal inside a
+ *     `WITH RECURSIVE` list.
+ *   - Leading line/block comments → skipped during detection so a
+ *     comment before WITH doesn't cause us to emit two WITH keywords.
  *
- * The detection is intentionally simple — look at the first non-whitespace,
- * non-comment token. Sufficient for the common cases. A user with truly
- * gnarly leading WITH RECURSIVE / WITH a AS MATERIALIZED can still write
- * around it; the resolver will fall through to prepend.
+ * Returns `duplicate_cte_name` when one of our generated names collides
+ * with a CTE name already in the user's WITH clause.
  */
-function mergeIntoWith(ctes: string[], sql: string): string {
-  if (ctes.length === 0) return sql
+function mergeIntoWith(
+  ctes: string[],
+  sql: string,
+  generatedNames: string[]
+): { ok: true; sql: string } | { ok: false; error: ResolveErrorKind } {
+  if (ctes.length === 0) return { ok: true, sql }
 
-  const leadingWith = startsWithBareWith(sql)
-  if (leadingWith.matches) {
-    const before = sql.slice(0, leadingWith.afterWithIndex)
-    const after = sql.slice(leadingWith.afterWithIndex)
-    return `${before}\n${ctes.join(',\n')},${after}`
+  const headInfo = analyzeLeadingWith(sql)
+  if (headInfo.matches) {
+    const userNames = extractCteNames(sql, headInfo.userCtesStartIndex)
+    for (const ours of generatedNames) {
+      if (userNames.has(ours.toLowerCase())) {
+        return { ok: false, error: { kind: 'duplicate_cte_name', name: ours } }
+      }
+    }
+    const before = sql.slice(0, headInfo.userCtesStartIndex)
+    const after = sql.slice(headInfo.userCtesStartIndex)
+    return { ok: true, sql: `${before}\n${ctes.join(',\n')},${after}` }
   }
-  return `WITH\n${ctes.join(',\n')}\n${sql.trimStart()}`
+  return { ok: true, sql: `WITH\n${ctes.join(',\n')}\n${sql.trimStart()}` }
 }
 
-function startsWithBareWith(sql: string): { matches: boolean; afterWithIndex: number } {
+interface LeadingWithInfo {
+  matches: boolean
+  /** Position where the user's CTE list begins (after WITH or WITH RECURSIVE). */
+  userCtesStartIndex: number
+}
+
+/**
+ * Scan past whitespace, line comments, and block comments to find a
+ * leading `WITH` (optionally followed by `RECURSIVE`).
+ */
+function analyzeLeadingWith(sql: string): LeadingWithInfo {
   let i = 0
   const n = sql.length
-  // Skip whitespace + simple line comments at the top.
+
   while (i < n) {
     const c = sql[i]
     if (c === ' ' || c === '\t' || c === '\n' || c === '\r') {
@@ -282,46 +400,178 @@ function startsWithBareWith(sql: string): { matches: boolean; afterWithIndex: nu
       continue
     }
     if (c === '-' && sql[i + 1] === '-') {
-      while (i < n && sql[i] !== '\n') i++
+      while (i < n && sql[i] !== '\n' && sql[i] !== '\r') i++
+      continue
+    }
+    if (c === '/' && sql[i + 1] === '*') {
+      i += 2
+      while (i < n && !(sql[i] === '*' && sql[i + 1] === '/')) i++
+      if (i < n) i += 2
       continue
     }
     break
   }
-  // Peek the keyword WITH (case-insensitive) followed by whitespace.
+
   const head = sql.slice(i, i + 4).toUpperCase()
-  if (head === 'WITH' && /\s/.test(sql[i + 4] ?? '')) {
-    return { matches: true, afterWithIndex: i + 4 }
+  if (head !== 'WITH' || !/\s/.test(sql[i + 4] ?? '')) {
+    return { matches: false, userCtesStartIndex: -1 }
   }
-  return { matches: false, afterWithIndex: -1 }
+  let j = i + 4
+  while (j < n && /\s/.test(sql[j])) j++
+
+  const recHead = sql.slice(j, j + 9).toUpperCase()
+  if (recHead === 'RECURSIVE' && /\s/.test(sql[j + 9] ?? '')) {
+    j += 9
+    while (j < n && /\s/.test(sql[j])) j++
+  }
+  return { matches: true, userCtesStartIndex: j }
+}
+
+/**
+ * Extract the names of CTEs declared at the top level of a WITH clause
+ * starting at `from`. Returns lowercase identifiers.
+ *
+ * Cheap and approximate: at parenthesis depth 0, any identifier-shaped
+ * token followed by whitespace + `AS` (case-insensitive) is a CTE name.
+ * Handles string/comment state so SQL like `WITH x AS (SELECT '@foo AS')`
+ * doesn't falsely produce `foo` as a name.
+ */
+function extractCteNames(sql: string, from: number): Set<string> {
+  const names = new Set<string>()
+  let i = from
+  const n = sql.length
+  let inSingle = false
+  let inDouble = false
+  let inLine = false
+  let blockDepth = 0
+  let depth = 0
+
+  while (i < n) {
+    const c = sql[i]
+    const nx = sql[i + 1]
+    if (inLine) {
+      if (c === '\n' || c === '\r') inLine = false
+      i++
+      continue
+    }
+    if (blockDepth > 0) {
+      if (c === '*' && nx === '/') {
+        blockDepth--
+        i += 2
+        continue
+      }
+      i++
+      continue
+    }
+    if (inSingle) {
+      if (c === "'" && sql[i + 1] === "'") {
+        i += 2
+        continue
+      }
+      if (c === "'") inSingle = false
+      i++
+      continue
+    }
+    if (inDouble) {
+      if (c === '"' && sql[i + 1] === '"') {
+        i += 2
+        continue
+      }
+      if (c === '"') inDouble = false
+      i++
+      continue
+    }
+    if (c === '-' && nx === '-') {
+      inLine = true
+      i += 2
+      continue
+    }
+    if (c === '/' && nx === '*') {
+      blockDepth = 1
+      i += 2
+      continue
+    }
+    if (c === "'") {
+      inSingle = true
+      i++
+      continue
+    }
+    if (c === '"') {
+      inDouble = true
+      i++
+      continue
+    }
+    if (c === '(') {
+      depth++
+      i++
+      continue
+    }
+    if (c === ')') {
+      depth--
+      i++
+      continue
+    }
+    if (depth === 0 && /[A-Za-z_]/.test(c)) {
+      let j = i + 1
+      while (j < n && /[A-Za-z0-9_]/.test(sql[j])) j++
+      const ident = sql.slice(i, j)
+      let k = j
+      while (k < n && /\s/.test(sql[k])) k++
+      const next = sql.slice(k, k + 2).toUpperCase()
+      if (next === 'AS' && /[\s(]/.test(sql[k + 2] ?? '')) {
+        names.add(ident.toLowerCase())
+      }
+      i = j
+      continue
+    }
+    i++
+  }
+  return names
+}
+
+function literalAlreadyHasCast(lit: string): boolean {
+  return /::[\w[\]"`. ]+\s*$/.test(lit.trim())
 }
 
 /**
  * Strip parens/precision from a type string so it's a clean cast target.
  * `character varying(255)` → `character varying`, `numeric(10,2)` →
- * `numeric`. Common dialect-y noise like trailing `[]` arrays is kept.
+ * `numeric`. Trailing `[]` arrays are kept intact.
  */
 function normalizeTypeForCast(dataType: string): string {
   const trimmed = dataType.trim()
-  // Strip parenthesised precision/scale — but keep `int4[]` etc intact.
   const noParen = trimmed.replace(/\([^)]*\)/g, '')
   return noParen.trim() || 'text'
 }
 
+/**
+ * Cheap UTF-8 byte length without pulling Buffer (renderer-safe). Handles
+ * surrogate pairs correctly — the original implementation unconditionally
+ * incremented `i` after a high surrogate, under-counting bytes on lone
+ * high surrogates and skipping the following (unrelated) code unit.
+ */
 function byteLengthUtf8(s: string): number {
-  // Cheap UTF-8 byte length without pulling Buffer (renderer-safe).
   let bytes = 0
   for (let i = 0; i < s.length; i++) {
     const code = s.charCodeAt(i)
     if (code < 0x80) bytes += 1
     else if (code < 0x800) bytes += 2
     else if (code >= 0xd800 && code <= 0xdbff) {
-      // High surrogate of a pair — counts 4 with its low surrogate.
-      bytes += 4
-      i++
-    } else bytes += 3
+      const next = s.charCodeAt(i + 1)
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        bytes += 4
+        i++
+      } else {
+        // Lone high surrogate — U+FFFD replacement is 3 bytes.
+        bytes += 3
+      }
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      bytes += 3
+    } else {
+      bytes += 3
+    }
   }
   return bytes
 }
 
-/** Re-export TabReference for callers building reference summaries. */
 export type { TabReference }

--- a/apps/desktop/src/renderer/src/lib/cross-tab-resolver.ts
+++ b/apps/desktop/src/renderer/src/lib/cross-tab-resolver.ts
@@ -1,0 +1,327 @@
+/**
+ * Cross-Tab Query resolver.
+ *
+ * Given a ParsedSql + a way to look up "name → tab result", produce:
+ *   - A final SQL string with each `@name` substituted for the bare
+ *     identifier `name` (no `@`).
+ *   - A list of CTEs (one per unique reference) prepended in order.
+ *
+ * The resolver is dialect-aware via the SQLDialect type from
+ * @data-peek/shared. Identifier quoting and value serialisation go through
+ * the same helpers the edit-store uses, so bigints, dates, JSON, byteas all
+ * serialise correctly.
+ *
+ * Errors are returned (not thrown) — callers want to surface them in the
+ * UI with the offending reference name, not in a try/catch.
+ */
+
+import { escapeSQLIdentifier, escapeSQLValue, type SQLDialect } from '@data-peek/shared'
+import type {
+  ParsedSql,
+  ResolveCaps,
+  ResolveErrorKind,
+  ResolveResult,
+  TabReference
+} from './cross-tab-types'
+import { DEFAULT_RESOLVE_CAPS } from './cross-tab-types'
+
+/**
+ * A tab's result as the resolver sees it. We only need the shape, not the
+ * full QueryResult — keeps this module unit-testable without dragging the
+ * tab store in.
+ */
+export interface ResolvableTab {
+  tabId: string
+  name: string
+  /** Display label — used in error chains for circularity. */
+  title?: string
+  /** Last execution outcome. */
+  result:
+    | {
+        kind: 'success'
+        rows: ReadonlyArray<Record<string, unknown>>
+        fields: ReadonlyArray<{ name: string; dataType: string }>
+      }
+    | { kind: 'error'; message: string }
+    | { kind: 'none' }
+}
+
+export interface ResolveContext {
+  /** Lookup a tab by reference name. Returns null when unknown. */
+  lookup: (name: string) => ResolvableTab | null
+  /** The tab issuing the SQL — referenced to detect self-reference. */
+  currentTabId: string
+  /** Database dialect — drives identifier quoting + value serialisation. */
+  dialect: SQLDialect
+  /** Caps; merged onto DEFAULT_RESOLVE_CAPS when partial. */
+  caps?: Partial<ResolveCaps>
+}
+
+/**
+ * Resolve a parsed SQL into a runnable string. References are inlined as
+ * `VALUES`-backed CTEs in alphabetical order (stable across runs so diffs
+ * of the generated SQL are clean).
+ */
+export function resolveReferences(
+  source: string,
+  parsed: ParsedSql,
+  ctx: ResolveContext
+):
+  | { ok: true; result: ResolveResult }
+  | { ok: false; error: ResolveErrorKind } {
+  const caps: ResolveCaps = { ...DEFAULT_RESOLVE_CAPS, ...(ctx.caps ?? {}) }
+
+  if (parsed.references.length === 0) {
+    return {
+      ok: true,
+      result: {
+        finalSql: source,
+        prependedCtes: [],
+        bytesAdded: 0,
+        rowsInlined: 0,
+        references: []
+      }
+    }
+  }
+
+  // Validate + collect per-name plans. Resolve in alphabetical order so the
+  // emitted SQL is stable.
+  const namesSorted = Array.from(parsed.referencedNames).sort()
+  const plans: Array<{
+    name: string
+    tab: ResolvableTab
+    rows: ReadonlyArray<Record<string, unknown>>
+    fields: ReadonlyArray<{ name: string; dataType: string }>
+  }> = []
+
+  for (const name of namesSorted) {
+    const tab = ctx.lookup(name)
+    if (!tab) {
+      return { ok: false, error: { kind: 'unknown_reference', name } }
+    }
+
+    // Self-reference is the simplest "circular" case and worth surfacing
+    // with a clean error before we get into more elaborate chain detection.
+    if (tab.tabId === ctx.currentTabId) {
+      return { ok: false, error: { kind: 'circular', chain: [name, name] } }
+    }
+
+    if (tab.result.kind === 'none') {
+      return { ok: false, error: { kind: 'no_result', name } }
+    }
+    if (tab.result.kind === 'error') {
+      return {
+        ok: false,
+        error: { kind: 'errored_result', name, error: tab.result.message }
+      }
+    }
+
+    const { rows, fields } = tab.result
+    if (fields.length > caps.maxColumnsPerRef) {
+      return {
+        ok: false,
+        error: {
+          kind: 'too_many_columns',
+          name,
+          columns: fields.length,
+          cap: caps.maxColumnsPerRef
+        }
+      }
+    }
+    if (rows.length > caps.maxRowsPerRef) {
+      return {
+        ok: false,
+        error: {
+          kind: 'too_large',
+          name,
+          rows: rows.length,
+          bytes: 0,
+          cap: { rows: caps.maxRowsPerRef, bytes: caps.maxBytesTotal }
+        }
+      }
+    }
+
+    plans.push({ name, tab, rows, fields })
+  }
+
+  // Build CTEs.
+  const ctes: string[] = []
+  const refSummaries: ResolveResult['references'] = []
+  let totalBytes = 0
+
+  for (const plan of plans) {
+    const cte = buildCte(plan.name, plan.rows, plan.fields, ctx.dialect)
+    const bytes = byteLengthUtf8(cte)
+    totalBytes += bytes
+    if (totalBytes > caps.maxBytesTotal) {
+      return {
+        ok: false,
+        error: {
+          kind: 'too_large',
+          name: plan.name,
+          rows: plan.rows.length,
+          bytes,
+          cap: { rows: caps.maxRowsPerRef, bytes: caps.maxBytesTotal }
+        }
+      }
+    }
+    ctes.push(cte)
+    refSummaries.push({
+      name: plan.name,
+      tabId: plan.tab.tabId,
+      rows: plan.rows.length,
+      bytes
+    })
+  }
+
+  // Substitute `@name` with `name` in the source, walking the references
+  // back-to-front so positions stay valid.
+  const sortedRefs = [...parsed.references].sort((a, b) => b.start - a.start)
+  let rewritten = source
+  for (const ref of sortedRefs) {
+    rewritten = rewritten.slice(0, ref.start) + ref.name + rewritten.slice(ref.end)
+  }
+
+  const finalSql = mergeIntoWith(ctes, rewritten)
+
+  return {
+    ok: true,
+    result: {
+      finalSql,
+      prependedCtes: ctes,
+      bytesAdded: totalBytes,
+      rowsInlined: plans.reduce((acc, p) => acc + p.rows.length, 0),
+      references: refSummaries
+    }
+  }
+}
+
+/**
+ * Build one CTE for the given name + rows + fields. Uses VALUES with
+ * type casts on the first tuple to anchor the column types — Postgres
+ * needs this to avoid `text`-typing everything.
+ */
+function buildCte(
+  name: string,
+  rows: ReadonlyArray<Record<string, unknown>>,
+  fields: ReadonlyArray<{ name: string; dataType: string }>,
+  dialect: SQLDialect
+): string {
+  const cteIdent = escapeSQLIdentifier(name, dialect)
+  const colList = fields.map((f) => escapeSQLIdentifier(f.name, dialect)).join(', ')
+
+  if (rows.length === 0) {
+    // Empty CTE: emit `WHERE FALSE` over the column list. VALUES requires
+    // at least one tuple, so synthesize an all-NULL one and exclude it.
+    const allNull = fields.map(() => 'NULL').join(', ')
+    return [
+      `${cteIdent}(${colList}) AS (`,
+      `  SELECT * FROM (VALUES (${allNull})) AS _(${colList}) WHERE FALSE`,
+      `)`
+    ].join('\n')
+  }
+
+  const tupleStrings: string[] = []
+  for (let r = 0; r < rows.length; r++) {
+    const row = rows[r]
+    const cells = fields.map((f) => {
+      const v = row[f.name]
+      const lit = escapeSQLValue(v, f.dataType, dialect)
+      // Type-cast only on the first tuple — anchors column types for PG.
+      // Subsequent rows don't need it.
+      if (r === 0 && dialect === 'postgresql' && v !== null && v !== undefined) {
+        return `${lit}::${normalizeTypeForCast(f.dataType)}`
+      }
+      // The first tuple's NULLs still need cast info or PG infers 'text'.
+      if (r === 0 && dialect === 'postgresql' && (v === null || v === undefined)) {
+        return `CAST(NULL AS ${normalizeTypeForCast(f.dataType)})`
+      }
+      return lit
+    })
+    tupleStrings.push(`  (${cells.join(', ')})`)
+  }
+
+  return [
+    `${cteIdent}(${colList}) AS (`,
+    `  VALUES`,
+    tupleStrings.join(',\n'),
+    `)`
+  ].join('\n')
+}
+
+/**
+ * Merge generated CTEs into the source SQL. If the source already begins
+ * with a top-level WITH, we splice the new CTEs in between `WITH` and the
+ * user's first CTE. Otherwise we prepend a fresh WITH clause.
+ *
+ * The detection is intentionally simple — look at the first non-whitespace,
+ * non-comment token. Sufficient for the common cases. A user with truly
+ * gnarly leading WITH RECURSIVE / WITH a AS MATERIALIZED can still write
+ * around it; the resolver will fall through to prepend.
+ */
+function mergeIntoWith(ctes: string[], sql: string): string {
+  if (ctes.length === 0) return sql
+
+  const leadingWith = startsWithBareWith(sql)
+  if (leadingWith.matches) {
+    const before = sql.slice(0, leadingWith.afterWithIndex)
+    const after = sql.slice(leadingWith.afterWithIndex)
+    return `${before}\n${ctes.join(',\n')},${after}`
+  }
+  return `WITH\n${ctes.join(',\n')}\n${sql.trimStart()}`
+}
+
+function startsWithBareWith(sql: string): { matches: boolean; afterWithIndex: number } {
+  let i = 0
+  const n = sql.length
+  // Skip whitespace + simple line comments at the top.
+  while (i < n) {
+    const c = sql[i]
+    if (c === ' ' || c === '\t' || c === '\n' || c === '\r') {
+      i++
+      continue
+    }
+    if (c === '-' && sql[i + 1] === '-') {
+      while (i < n && sql[i] !== '\n') i++
+      continue
+    }
+    break
+  }
+  // Peek the keyword WITH (case-insensitive) followed by whitespace.
+  const head = sql.slice(i, i + 4).toUpperCase()
+  if (head === 'WITH' && /\s/.test(sql[i + 4] ?? '')) {
+    return { matches: true, afterWithIndex: i + 4 }
+  }
+  return { matches: false, afterWithIndex: -1 }
+}
+
+/**
+ * Strip parens/precision from a type string so it's a clean cast target.
+ * `character varying(255)` → `character varying`, `numeric(10,2)` →
+ * `numeric`. Common dialect-y noise like trailing `[]` arrays is kept.
+ */
+function normalizeTypeForCast(dataType: string): string {
+  const trimmed = dataType.trim()
+  // Strip parenthesised precision/scale — but keep `int4[]` etc intact.
+  const noParen = trimmed.replace(/\([^)]*\)/g, '')
+  return noParen.trim() || 'text'
+}
+
+function byteLengthUtf8(s: string): number {
+  // Cheap UTF-8 byte length without pulling Buffer (renderer-safe).
+  let bytes = 0
+  for (let i = 0; i < s.length; i++) {
+    const code = s.charCodeAt(i)
+    if (code < 0x80) bytes += 1
+    else if (code < 0x800) bytes += 2
+    else if (code >= 0xd800 && code <= 0xdbff) {
+      // High surrogate of a pair — counts 4 with its low surrogate.
+      bytes += 4
+      i++
+    } else bytes += 3
+  }
+  return bytes
+}
+
+/** Re-export TabReference for callers building reference summaries. */
+export type { TabReference }

--- a/apps/desktop/src/renderer/src/lib/cross-tab-types.ts
+++ b/apps/desktop/src/renderer/src/lib/cross-tab-types.ts
@@ -1,0 +1,109 @@
+/**
+ * Cross-Tab Query References — public types.
+ *
+ * The feature lets a user write `SELECT … WHERE user_id IN (@active_users)`
+ * in tab B, where `@active_users` is another tab's named result. At submit
+ * time the resolver inlines that result as a `VALUES`-backed CTE.
+ *
+ * These types are the surface area between the parser, the resolver, the
+ * tab store, and (eventually) the Monaco language extension. Keeping them
+ * here (not in `@data-peek/shared`) since cross-tab is renderer-only — the
+ * IPC contract doesn't change. If the resolver ever moves into the main
+ * process for staging via temp tables we can lift these into shared.
+ */
+
+/** Reference name pattern — lowercase identifier, starts with a letter. */
+export const REF_NAME_PATTERN = /^[a-z][a-z0-9_]*$/
+
+/** Hard length cap on a reference name. */
+export const REF_NAME_MAX_LENGTH = 32
+
+export type RefNameValidationError =
+  | { kind: 'empty' }
+  | { kind: 'too_long'; length: number; max: number }
+  | { kind: 'invalid_chars'; detail: string }
+  | { kind: 'reserved_word'; word: string }
+  | { kind: 'duplicate'; conflictingTabId: string }
+
+export type RefNameValidationResult =
+  | { ok: true; normalized: string }
+  | { ok: false; error: RefNameValidationError }
+
+/**
+ * A single `@name` token discovered in source SQL.
+ */
+export interface TabReference {
+  /** The raw match, e.g. "@active_users". */
+  raw: string
+  /** Position in the source SQL (start inclusive, end exclusive). */
+  start: number
+  end: number
+  /** Resolved name (without the @). */
+  name: string
+  /** Resolution status — set during resolve(), starts as 'unknown'. */
+  status: ResolveStatus
+  /** The referenced tab id, when resolved. */
+  tabId?: string
+}
+
+export type ResolveStatus =
+  | 'unknown' // name doesn't match any named tab
+  | 'resolved' // matched a tab with a usable result
+  | 'no_result' // tab exists but hasn't been run yet (or last run errored)
+  | 'errored' // tab's last result was an error
+  | 'circular' // resolving this reference would loop back to itself
+
+/** Parser output — a SQL string + the refs found inside it. */
+export interface ParsedSql {
+  /** All references found, in source order. */
+  references: TabReference[]
+  /** Unique names referenced (deduplicated). */
+  referencedNames: Set<string>
+}
+
+/**
+ * Settings that bound how aggressive the resolver can be. The defaults match
+ * the plan's recommendations; users can raise or lower them in settings.
+ */
+export interface ResolveCaps {
+  /** Max rows per single inlined reference. Plan default: 10,000. */
+  maxRowsPerRef: number
+  /** Max bytes total across all inlined CTEs in one resolve. Plan default: 5MB. */
+  maxBytesTotal: number
+  /** Max columns per reference (sanity). Plan default: 100. */
+  maxColumnsPerRef: number
+}
+
+export const DEFAULT_RESOLVE_CAPS: ResolveCaps = {
+  maxRowsPerRef: 10_000,
+  maxBytesTotal: 5 * 1024 * 1024,
+  maxColumnsPerRef: 100
+}
+
+export type ResolveErrorKind =
+  | { kind: 'unknown_reference'; name: string }
+  | { kind: 'circular'; chain: string[] }
+  | { kind: 'no_result'; name: string }
+  | { kind: 'errored_result'; name: string; error: string }
+  | {
+      kind: 'too_large'
+      name: string
+      rows: number
+      bytes: number
+      cap: { rows: number; bytes: number }
+    }
+  | { kind: 'too_many_columns'; name: string; columns: number; cap: number }
+  | { kind: 'duplicate_cte_name'; name: string }
+
+export interface ResolveResult {
+  /** SQL ready to send to the database — references substituted with CTEs. */
+  finalSql: string
+  /** CTEs prepended to the SQL (one per unique reference). */
+  prependedCtes: string[]
+  /** Total bytes added by inlining — used against maxBytesTotal. */
+  bytesAdded: number
+  /** Rows inlined across all references. */
+  rowsInlined: number
+  /** Per-reference summary, in resolution order. */
+  references: Array<{ name: string; tabId: string; rows: number; bytes: number }>
+}


### PR DESCRIPTION
## Summary

First slice of [Cross-Tab Query References](https://github.com/Rohithgilla12/data-peek/blob/main/docs/PLAN-cross-tab-query.md): the pure-functional layers (types, name validation, parser, resolver) with no React, no Zustand, no Monaco. Sets up the rest of the feature for follow-up PRs that can each be reviewed against a working differ + resolver instead of all-at-once.

Total: **~705 LoC** feature + **~540 LoC** tests, all green.

## What's in this PR

| Layer | File | Notes |
|---|---|---|
| Types | `cross-tab-types.ts` | `TabReference`, `ParsedSql`, `ResolveResult`, `ResolveCaps` (defaults: 10k rows, 5MB, 100 cols) |
| Name validation | `cross-tab-name-validation.ts` | Pattern `^[a-z][a-z0-9_]*$`, 32-char max, 50-word SQL reserved deny list, per-connection uniqueness check. Silently lowercases input. |
| Parser | `cross-tab-parser.ts` | Hand-written single-pass scanner. Skips single-quoted strings (with `''` escapes), double-quoted identifiers, line + nested block comments, PG dollar-quoted bodies, and email-like `foo@bar` sequences |
| Resolver | `cross-tab-resolver.ts` | Builds `VALUES`-backed CTEs with PG type-casts on the first tuple. Merges into existing `WITH` clauses. Alphabetically stable output. Typed errors. Dialect-aware via the existing `escapeSQLIdentifier` / `escapeSQLValue` helpers from `@data-peek/shared` (MySQL backticks, MSSQL brackets, all for free) |
| Tests | `__tests__/cross-tab-*.test.ts` | **54 tests**: 13 validation · 17 parser · 24 resolver |

## What's intentionally NOT in this PR

Each of these wants its own focused review:

- [ ] `BaseTab.refName` field + `setTabRefName` store method
- [ ] Tab rename UI (double-click title, inline input with live validation)
- [ ] Tab header `@` prefix display
- [ ] `handleRunQuery` integration: parse → resolve → run with `finalSql`
- [ ] Monaco language extension (`@` autocomplete, hover preview, diagnostic markers)
- [ ] Pre-submit confirmation dialog (rows / bytes per reference)
- [ ] Staleness tracking store + tab-header badge
- [ ] Notebook cell support

## Why split this way

The plan is ~2k LoC. Shipping it as one PR means the reviewer has to hold the whole world in their head — store changes + UI + scanner + resolver + Monaco hooks all at once. Splitting at the IO boundary (this PR is everything below the IPC + UI line) means the resolver can be reviewed against its tests in isolation, and the integration PR will be a small `handleRunQuery` change + a follow-up to discuss the UX.

The integration point looks like this from the future PR's perspective:

```ts
const parsed = parseTabReferences(queryToRun)
if (parsed.references.length > 0) {
  const resolved = resolveReferences(queryToRun, parsed, {
    lookup: (name) => buildResolvableTab(name, tabStore),
    currentTabId: tabId,
    dialect: tabConnection.dbType,
  })
  if (!resolved.ok) {
    // surface resolved.error in a dialog with row counts + caps
    return
  }
  queryToRun = resolved.result.finalSql
}
```

`buildResolvableTab(name, tabStore)` is the missing piece — waits on `setTabRefName` landing.

## Composes with Watch Mode

The resolver is synchronous and pure, so a watched tab that references `@other` re-resolves on every tick without caching concerns. `@other`'s result may have changed between ticks; the next tick gets the fresh inlined CTEs automatically.

## Test plan

- [ ] Run the new test suite: `pnpm vitest run src/renderer/src/lib/__tests__/cross-tab-*.test.ts` — 54 should pass
- [ ] `pnpm typecheck` clean
- [ ] Review the resolver's CTE output by eye — pick a small case and verify the generated SQL would actually run against PG / MySQL / MSSQL once the wiring lands
- [ ] Skim the name-validation reserved-words list; flag any obvious omissions for the follow-up
- [ ] Consider whether the default caps (10k rows / 5MB / 100 cols) match how you want this to feel, or if they should be smaller for the first release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cross-tab references: use `@name` to include other tab results; name validation, uniqueness and SQL-keyword protection enforced; dialect-aware resolution inlined as CTEs with sensible empty/error handling.
* **Improvements**
  * More robust parsing across SQL dialects/quoting styles and clearer error kinds (unknown, circular, no-result, errored, caps exceeded).
* **Tests**
  * Expanded test coverage for name validation, parsing, resolution and cross-tab edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Rohithgilla12/data-peek/pull/184?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->