### PR TITLE
feat(cross-tab): @name references — naming, resolution & editor magic

### DIFF
--- a/apps/desktop/src/renderer/src/components/cross-tab/__tests__/cross-tab-editor.test.ts
+++ b/apps/desktop/src/renderer/src/components/cross-tab/__tests__/cross-tab-editor.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { atTokenBeforeCursor, filterRefs } from '../cross-tab-editor'
+import type { CrossTabRef } from '@/lib/cross-tab-integration'
+
+describe('atTokenBeforeCursor', () => {
+  it('detects an @-token being typed at a word boundary', () => {
+    expect(atTokenBeforeCursor('SELECT * FROM @act')).toEqual({ active: true, partial: 'act' })
+  })
+  it('detects a bare @ with empty partial', () => {
+    expect(atTokenBeforeCursor('SELECT * FROM @')).toEqual({ active: true, partial: '' })
+  })
+  it('ignores @@ (system variable)', () => {
+    expect(atTokenBeforeCursor('SELECT @@ver').active).toBe(false)
+  })
+  it('ignores email-like sequences', () => {
+    expect(atTokenBeforeCursor("'a@x").active).toBe(false)
+  })
+  it('is inactive when there is no trailing @-token', () => {
+    expect(atTokenBeforeCursor('SELECT * FROM users').active).toBe(false)
+  })
+})
+
+describe('filterRefs', () => {
+  const refs: CrossTabRef[] = [
+    { name: 'active_users', tabTitle: 'A', rowCount: 1, colCount: 1, hasResult: true },
+    { name: 'archived', tabTitle: 'B', rowCount: 1, colCount: 1, hasResult: true },
+    { name: 'pending', tabTitle: 'C', rowCount: 0, colCount: 0, hasResult: false }
+  ]
+  it('returns all refs for an empty partial', () => {
+    expect(filterRefs(refs, '')).toHaveLength(3)
+  })
+  it('prefix-filters by name', () => {
+    expect(filterRefs(refs, 'a').map((r) => r.name)).toEqual(['active_users', 'archived'])
+  })
+})

--- a/apps/desktop/src/renderer/src/components/cross-tab/__tests__/cross-tab-editor.test.ts
+++ b/apps/desktop/src/renderer/src/components/cross-tab/__tests__/cross-tab-editor.test.ts
@@ -22,9 +22,9 @@ describe('atTokenBeforeCursor', () => {
 
 describe('filterRefs', () => {
   const refs: CrossTabRef[] = [
-    { name: 'active_users', tabTitle: 'A', rowCount: 1, colCount: 1, hasResult: true },
-    { name: 'archived', tabTitle: 'B', rowCount: 1, colCount: 1, hasResult: true },
-    { name: 'pending', tabTitle: 'C', rowCount: 0, colCount: 0, hasResult: false }
+    { name: 'active_users', tabTitle: 'A', result: { kind: 'ready', rowCount: 1, colCount: 1 } },
+    { name: 'archived', tabTitle: 'B', result: { kind: 'ready', rowCount: 1, colCount: 1 } },
+    { name: 'pending', tabTitle: 'C', result: { kind: 'not_run' } }
   ]
   it('returns all refs for an empty partial', () => {
     expect(filterRefs(refs, '')).toHaveLength(3)

--- a/apps/desktop/src/renderer/src/components/cross-tab/cross-tab-editor.ts
+++ b/apps/desktop/src/renderer/src/components/cross-tab/cross-tab-editor.ts
@@ -80,6 +80,7 @@ export function ensureCrossTabProviders(monacoInstance: Monaco): void {
       const word = model.getWordAtPosition(position)
       if (!word) return null
       const lineText = model.getLineContent(position.lineNumber)
+      // Monaco columns are 1-based; startColumn-2 indexes the char just before the word.
       if (lineText[word.startColumn - 2] !== '@') return null
       const ref = currentRefs.find((r) => r.name === word.word.toLowerCase())
       if (!ref) return null
@@ -143,4 +144,12 @@ export function updateCrossTabMarkers(
     }
   }
   monacoInstance.editor.setModelMarkers(model, MARKER_OWNER, markers)
+}
+
+/** Clear all cross-tab diagnostic markers from a model (e.g. when the tab has no connection/dialect). */
+export function clearCrossTabMarkers(
+  monacoInstance: Monaco,
+  model: monaco.editor.ITextModel
+): void {
+  monacoInstance.editor.setModelMarkers(model, MARKER_OWNER, [])
 }

--- a/apps/desktop/src/renderer/src/components/cross-tab/cross-tab-editor.ts
+++ b/apps/desktop/src/renderer/src/components/cross-tab/cross-tab-editor.ts
@@ -1,0 +1,146 @@
+/**
+ * Monaco providers for cross-tab @name references — completion, hover, and
+ * diagnostics. Follows the singleton-provider + module-state pattern from
+ * sql-editor.tsx: the active editor pushes refs via updateCrossTabRefs and
+ * the providers read the latest snapshot.
+ */
+
+import type * as monaco from 'monaco-editor'
+import type { Monaco } from '@monaco-editor/react'
+import type { DatabaseType } from '@data-peek/shared'
+import { parseTabReferences } from '@/lib/cross-tab-parser'
+import type { CrossTabRef } from '@/lib/cross-tab-integration'
+
+let currentRefs: CrossTabRef[] = []
+let providersRegistered = false
+
+const MARKER_OWNER = 'cross-tab'
+
+export function updateCrossTabRefs(refs: CrossTabRef[]): void {
+  currentRefs = refs
+}
+
+/** True when the text immediately before the cursor is an @-token being typed (not @@, not email). */
+export function atTokenBeforeCursor(textBeforeCursor: string): {
+  active: boolean
+  partial: string
+} {
+  const m = textBeforeCursor.match(/@([a-z0-9_]*)$/i)
+  if (!m) return { active: false, partial: '' }
+  const at = textBeforeCursor.length - m[0].length
+  const prev = at > 0 ? textBeforeCursor[at - 1] : ''
+  if (/[A-Za-z0-9_.$@]/.test(prev)) return { active: false, partial: '' }
+  return { active: true, partial: m[1].toLowerCase() }
+}
+
+export function filterRefs(refs: CrossTabRef[], partial: string): CrossTabRef[] {
+  if (!partial) return refs
+  return refs.filter((r) => r.name.startsWith(partial))
+}
+
+/** Register the completion + hover providers once, globally. */
+export function ensureCrossTabProviders(monacoInstance: Monaco): void {
+  if (providersRegistered) return
+  providersRegistered = true
+
+  monacoInstance.languages.registerCompletionItemProvider('sql', {
+    triggerCharacters: ['@'],
+    provideCompletionItems: (model, position) => {
+      const textBeforeCursor = model.getValueInRange({
+        startLineNumber: position.lineNumber,
+        startColumn: 1,
+        endLineNumber: position.lineNumber,
+        endColumn: position.column
+      })
+      const tok = atTokenBeforeCursor(textBeforeCursor)
+      if (!tok.active) return { suggestions: [] }
+      const word = model.getWordUntilPosition(position)
+      const range = {
+        startLineNumber: position.lineNumber,
+        endLineNumber: position.lineNumber,
+        startColumn: word.startColumn,
+        endColumn: word.endColumn
+      }
+      return {
+        suggestions: filterRefs(currentRefs, tok.partial).map((r) => ({
+          label: `@${r.name}`,
+          kind: monacoInstance.languages.CompletionItemKind.Variable,
+          insertText: r.name,
+          range,
+          detail: r.hasResult ? `${r.rowCount} rows · ${r.colCount} cols` : 'not run yet',
+          documentation: { value: `Result of tab **${r.tabTitle}**` },
+          sortText: '0' + r.name
+        }))
+      }
+    }
+  })
+
+  monacoInstance.languages.registerHoverProvider('sql', {
+    provideHover: (model, position) => {
+      const word = model.getWordAtPosition(position)
+      if (!word) return null
+      const lineText = model.getLineContent(position.lineNumber)
+      if (lineText[word.startColumn - 2] !== '@') return null
+      const ref = currentRefs.find((r) => r.name === word.word.toLowerCase())
+      if (!ref) return null
+      return {
+        range: new monacoInstance.Range(
+          position.lineNumber,
+          word.startColumn - 1,
+          position.lineNumber,
+          word.endColumn
+        ),
+        contents: [
+          { value: `**@${ref.name}** — tab "${ref.tabTitle}"` },
+          {
+            value: ref.hasResult
+              ? `${ref.rowCount} rows · ${ref.colCount} columns`
+              : "_hasn't been run yet_"
+          }
+        ]
+      }
+    }
+  })
+}
+
+/**
+ * Recompute diagnostic markers for the model. Unknown names → Error; named
+ * but not-yet-run → Warning. For mysql/mssql, only known names are parsed
+ * (so @vars aren't flagged).
+ */
+export function updateCrossTabMarkers(
+  monacoInstance: Monaco,
+  model: monaco.editor.ITextModel,
+  dbType: DatabaseType
+): void {
+  const byName = new Map(currentRefs.map((r) => [r.name, r]))
+  const knownNames = dbType === 'mysql' || dbType === 'mssql' ? new Set(byName.keys()) : undefined
+  const parsed = parseTabReferences(model.getValue(), { dialect: dbType, knownNames })
+
+  const markers: monaco.editor.IMarkerData[] = []
+  for (const ref of parsed.references) {
+    const known = byName.get(ref.name)
+    const start = model.getPositionAt(ref.start)
+    const end = model.getPositionAt(ref.end)
+    const base = {
+      startLineNumber: start.lineNumber,
+      startColumn: start.column,
+      endLineNumber: end.lineNumber,
+      endColumn: end.column
+    }
+    if (!known) {
+      markers.push({
+        ...base,
+        severity: monacoInstance.MarkerSeverity.Error,
+        message: `No tab named @${ref.name} on this connection.`
+      })
+    } else if (!known.hasResult) {
+      markers.push({
+        ...base,
+        severity: monacoInstance.MarkerSeverity.Warning,
+        message: `@${ref.name} hasn't been run yet.`
+      })
+    }
+  }
+  monacoInstance.editor.setModelMarkers(model, MARKER_OWNER, markers)
+}

--- a/apps/desktop/src/renderer/src/components/cross-tab/cross-tab-editor.ts
+++ b/apps/desktop/src/renderer/src/components/cross-tab/cross-tab-editor.ts
@@ -67,7 +67,10 @@ export function ensureCrossTabProviders(monacoInstance: Monaco): void {
           kind: monacoInstance.languages.CompletionItemKind.Variable,
           insertText: r.name,
           range,
-          detail: r.hasResult ? `${r.rowCount} rows · ${r.colCount} cols` : 'not run yet',
+          detail:
+            r.result.kind === 'ready'
+              ? `${r.result.rowCount} rows · ${r.result.colCount} cols`
+              : 'not run yet',
           documentation: { value: `Result of tab **${r.tabTitle}**` },
           sortText: '0' + r.name
         }))
@@ -94,9 +97,10 @@ export function ensureCrossTabProviders(monacoInstance: Monaco): void {
         contents: [
           { value: `**@${ref.name}** — tab "${ref.tabTitle}"` },
           {
-            value: ref.hasResult
-              ? `${ref.rowCount} rows · ${ref.colCount} columns`
-              : "_hasn't been run yet_"
+            value:
+              ref.result.kind === 'ready'
+                ? `${ref.result.rowCount} rows · ${ref.result.colCount} columns`
+                : "_hasn't been run yet_"
           }
         ]
       }
@@ -135,7 +139,7 @@ export function updateCrossTabMarkers(
         severity: monacoInstance.MarkerSeverity.Error,
         message: `No tab named @${ref.name} on this connection.`
       })
-    } else if (!known.hasResult) {
+    } else if (known.result.kind === 'not_run') {
       markers.push({
         ...base,
         severity: monacoInstance.MarkerSeverity.Warning,

--- a/apps/desktop/src/renderer/src/components/cross-tab/cross-tab-editor.ts
+++ b/apps/desktop/src/renderer/src/components/cross-tab/cross-tab-editor.ts
@@ -1,8 +1,9 @@
 /**
  * Monaco providers for cross-tab @name references — completion, hover, and
- * diagnostics. Follows the singleton-provider + module-state pattern from
- * sql-editor.tsx: the active editor pushes refs via updateCrossTabRefs and
- * the providers read the latest snapshot.
+ * diagnostics. The completion/hover providers are registered once globally for
+ * the 'sql' language and fire for whichever model is focused, so refs are kept
+ * per-model: a second SQLEditor mounting (a dashboard widget dialog, the sidebar
+ * quick query, a notebook cell) must not clobber the active tab editor's refs.
  */
 
 import type * as monaco from 'monaco-editor'
@@ -11,13 +12,22 @@ import type { DatabaseType } from '@data-peek/shared'
 import { parseTabReferences } from '@/lib/cross-tab-parser'
 import type { CrossTabRef } from '@/lib/cross-tab-integration'
 
-let currentRefs: CrossTabRef[] = []
+const refsByModel = new Map<string, CrossTabRef[]>()
 let providersRegistered = false
 
 const MARKER_OWNER = 'cross-tab'
 
-export function updateCrossTabRefs(refs: CrossTabRef[]): void {
-  currentRefs = refs
+function refsFor(model: monaco.editor.ITextModel): CrossTabRef[] {
+  return refsByModel.get(model.uri.toString()) ?? []
+}
+
+export function updateCrossTabRefs(model: monaco.editor.ITextModel, refs: CrossTabRef[]): void {
+  refsByModel.set(model.uri.toString(), refs)
+}
+
+/** Forget a model's refs + markers when its editor unmounts. */
+export function disposeCrossTabRefs(model: monaco.editor.ITextModel): void {
+  refsByModel.delete(model.uri.toString())
 }
 
 /** True when the text immediately before the cursor is an @-token being typed (not @@, not email). */
@@ -62,7 +72,7 @@ export function ensureCrossTabProviders(monacoInstance: Monaco): void {
         endColumn: word.endColumn
       }
       return {
-        suggestions: filterRefs(currentRefs, tok.partial).map((r) => ({
+        suggestions: filterRefs(refsFor(model), tok.partial).map((r) => ({
           label: `@${r.name}`,
           kind: monacoInstance.languages.CompletionItemKind.Variable,
           insertText: r.name,
@@ -85,7 +95,7 @@ export function ensureCrossTabProviders(monacoInstance: Monaco): void {
       const lineText = model.getLineContent(position.lineNumber)
       // Monaco columns are 1-based; startColumn-2 indexes the char just before the word.
       if (lineText[word.startColumn - 2] !== '@') return null
-      const ref = currentRefs.find((r) => r.name === word.word.toLowerCase())
+      const ref = refsFor(model).find((r) => r.name === word.word.toLowerCase())
       if (!ref) return null
       return {
         range: new monacoInstance.Range(
@@ -118,7 +128,7 @@ export function updateCrossTabMarkers(
   model: monaco.editor.ITextModel,
   dbType: DatabaseType
 ): void {
-  const byName = new Map(currentRefs.map((r) => [r.name, r]))
+  const byName = new Map(refsFor(model).map((r) => [r.name, r]))
   const knownNames = dbType === 'mysql' || dbType === 'mssql' ? new Set(byName.keys()) : undefined
   const parsed = parseTabReferences(model.getValue(), { dialect: dbType, knownNames })
 

--- a/apps/desktop/src/renderer/src/components/cross-tab/cross-tab-submit-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/cross-tab/cross-tab-submit-dialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import {
   Button,
   Checkbox,
@@ -26,6 +26,12 @@ export function CrossTabSubmitDialog({
   onConfirm
 }: CrossTabSubmitDialogProps) {
   const [dontAskAgain, setDontAskAgain] = useState(false)
+
+  // The dialog stays mounted across opens; reset the opt-out so a checked-then-
+  // cancelled box can't silently persist on the next confirm.
+  useEffect(() => {
+    if (!open) setDontAskAgain(false)
+  }, [open])
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/apps/desktop/src/renderer/src/components/cross-tab/cross-tab-submit-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/cross-tab/cross-tab-submit-dialog.tsx
@@ -1,10 +1,13 @@
+import { useState } from 'react'
 import {
   Button,
+  Checkbox,
   Dialog,
   DialogContent,
   DialogFooter,
   DialogHeader,
-  DialogTitle
+  DialogTitle,
+  Label
 } from '@data-peek/ui'
 import { Layers } from 'lucide-react'
 import type { ResolveForRunSummary } from '@/lib/cross-tab-integration'
@@ -13,7 +16,7 @@ interface CrossTabSubmitDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   summary: ResolveForRunSummary | null
-  onConfirm: () => void
+  onConfirm: (dontAskAgain: boolean) => void
 }
 
 export function CrossTabSubmitDialog({
@@ -22,6 +25,8 @@ export function CrossTabSubmitDialog({
   summary,
   onConfirm
 }: CrossTabSubmitDialogProps) {
+  const [dontAskAgain, setDontAskAgain] = useState(false)
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-md">
@@ -45,6 +50,16 @@ export function CrossTabSubmitDialog({
             Inlined: {summary?.rowsInlined.toLocaleString()} rows ·{' '}
             {((summary?.bytesAdded ?? 0) / 1024).toFixed(1)}KB
           </div>
+          <div className="flex items-center gap-2 pt-2 border-t border-border/50">
+            <Checkbox
+              id="dont-ask-again"
+              checked={dontAskAgain}
+              onCheckedChange={(checked) => setDontAskAgain(checked === true)}
+            />
+            <Label htmlFor="dont-ask-again" className="text-xs font-normal cursor-pointer">
+              Don&apos;t ask again this session
+            </Label>
+          </div>
         </div>
         <DialogFooter>
           <Button variant="outline" onClick={() => onOpenChange(false)}>
@@ -52,7 +67,7 @@ export function CrossTabSubmitDialog({
           </Button>
           <Button
             onClick={() => {
-              onConfirm()
+              onConfirm(dontAskAgain)
               onOpenChange(false)
             }}
           >

--- a/apps/desktop/src/renderer/src/components/cross-tab/cross-tab-submit-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/cross-tab/cross-tab-submit-dialog.tsx
@@ -1,0 +1,65 @@
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@data-peek/ui'
+import { Layers } from 'lucide-react'
+import type { ResolveForRunSummary } from '@/lib/cross-tab-integration'
+
+interface CrossTabSubmitDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  summary: ResolveForRunSummary | null
+  onConfirm: () => void
+}
+
+export function CrossTabSubmitDialog({
+  open,
+  onOpenChange,
+  summary,
+  onConfirm
+}: CrossTabSubmitDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Layers className="size-4" />
+            Running with {summary?.refCount ?? 0} tab{' '}
+            {summary?.refCount === 1 ? 'reference' : 'references'}
+          </DialogTitle>
+        </DialogHeader>
+        <div className="space-y-2 text-sm">
+          {summary?.references.map((r) => (
+            <div key={r.name} className="flex items-center justify-between font-mono text-xs">
+              <span className="text-muted-foreground">@{r.name}</span>
+              <span>
+                {r.rows.toLocaleString()} rows · {(r.bytes / 1024).toFixed(1)}KB
+              </span>
+            </div>
+          ))}
+          <div className="border-t border-border/50 pt-2 font-mono text-xs">
+            Inlined: {summary?.rowsInlined.toLocaleString()} rows ·{' '}
+            {((summary?.bytesAdded ?? 0) / 1024).toFixed(1)}KB
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            onClick={() => {
+              onConfirm()
+              onOpenChange(false)
+            }}
+          >
+            Run query
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/desktop/src/renderer/src/components/query-editor/editor-toolbar.tsx
+++ b/apps/desktop/src/renderer/src/components/query-editor/editor-toolbar.tsx
@@ -47,6 +47,8 @@ interface EditorToolbarProps {
   setShareDialogOpen: (v: boolean) => void
   /** Slot for the Watch button — rendered between Benchmark and Format. */
   watchSlot?: ReactNode
+  /** Slot for the cross-tab inlined-refs pill — rendered next to the Watch button. */
+  refsSlot?: ReactNode
 }
 
 export function EditorToolbar({
@@ -69,7 +71,8 @@ export function EditorToolbar({
   handleFormatQuery,
   setSaveDialogOpen,
   setShareDialogOpen,
-  watchSlot
+  watchSlot,
+  refsSlot
 }: EditorToolbarProps) {
   const executable = isExecutableTab(tab) ? tab : null
   const query = executable?.query ?? ''
@@ -171,6 +174,7 @@ export function EditorToolbar({
           disabled={isExecuting || !hasQuery}
         />
         {watchSlot}
+        {refsSlot}
         {!isEditorCollapsed && (
           <>
             <div className="mx-1 h-4 w-px bg-border/60" />

--- a/apps/desktop/src/renderer/src/components/sql-editor.tsx
+++ b/apps/desktop/src/renderer/src/components/sql-editor.tsx
@@ -5,7 +5,13 @@ import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker'
 import { formatSQL } from '@/lib/sql-formatter'
 import { cn } from '@data-peek/ui'
 import { useTheme } from '@/components/theme-provider'
-import type { SchemaInfo, Snippet, TableInfo } from '@data-peek/shared'
+import type { DatabaseType, SchemaInfo, Snippet, TableInfo } from '@data-peek/shared'
+import type { CrossTabRef } from '@/lib/cross-tab-integration'
+import {
+  ensureCrossTabProviders,
+  updateCrossTabRefs,
+  updateCrossTabMarkers
+} from '@/components/cross-tab/cross-tab-editor'
 import { SQL_KEYWORDS } from '@/constants/sql-keywords'
 
 // Configure Monaco workers for Vite + Electron (avoids CSP issues)
@@ -474,6 +480,10 @@ export interface SQLEditorProps {
   onMount?: (editor: EditorType, monaco: Monaco) => void
   /** Enable glyph margin (for breakpoint decorations) */
   glyphMargin?: boolean
+  /** Named tabs available for @name references on this connection. */
+  crossTabRefs?: CrossTabRef[]
+  /** Dialect used for cross-tab parsing/markers. */
+  crossTabDialect?: DatabaseType
 }
 
 // Custom dark theme inspired by the app's aesthetic
@@ -567,11 +577,14 @@ export function SQLEditor({
   schemas = [],
   snippets = [],
   onMount,
-  glyphMargin = false
+  glyphMargin = false,
+  crossTabRefs = [],
+  crossTabDialect
 }: SQLEditorProps) {
   const { theme } = useTheme()
   const editorRef = React.useRef<EditorType | null>(null)
   const monacoRef = React.useRef<Monaco | null>(null)
+  const crossTabDialectRef = React.useRef<DatabaseType | undefined>(crossTabDialect)
 
   // Use refs to always hold the latest callbacks to avoid stale closures
   const onRunRef = React.useRef(onRun)
@@ -594,6 +607,10 @@ export function SQLEditor({
     onFormatRef.current = onFormat
   }, [onFormat])
 
+  React.useEffect(() => {
+    crossTabDialectRef.current = crossTabDialect
+  }, [crossTabDialect])
+
   const handleEditorDidMount: OnMount = (editor, monaco) => {
     editorRef.current = editor
     monacoRef.current = monaco
@@ -606,6 +623,13 @@ export function SQLEditor({
     updateCompletionSchemas(schemas)
     updateCompletionSnippets(snippets)
     ensureCompletionProvider(monaco)
+
+    updateCrossTabRefs(crossTabRefs)
+    ensureCrossTabProviders(monaco)
+    const crossTabModel = editor.getModel()
+    if (crossTabModel && crossTabDialectRef.current) {
+      updateCrossTabMarkers(monaco, crossTabModel, crossTabDialectRef.current)
+    }
 
     // Set the theme based on current app theme
     const editorTheme = resolvedTheme === 'dark' ? 'data-peek-dark' : 'data-peek-light'
@@ -701,8 +725,21 @@ export function SQLEditor({
     updateCompletionSnippets(snippets)
   }, [snippets])
 
+  // Update cross-tab refs + markers when they change
+  React.useEffect(() => {
+    updateCrossTabRefs(crossTabRefs)
+    const model = editorRef.current?.getModel()
+    if (monacoRef.current && model && crossTabDialect) {
+      updateCrossTabMarkers(monacoRef.current, model, crossTabDialect)
+    }
+  }, [crossTabRefs, crossTabDialect])
+
   const handleChange = (newValue: string | undefined) => {
     onChange?.(newValue ?? '')
+    const model = editorRef.current?.getModel()
+    if (monacoRef.current && model && crossTabDialectRef.current) {
+      updateCrossTabMarkers(monacoRef.current, model, crossTabDialectRef.current)
+    }
   }
 
   return (

--- a/apps/desktop/src/renderer/src/components/sql-editor.tsx
+++ b/apps/desktop/src/renderer/src/components/sql-editor.tsx
@@ -10,7 +10,8 @@ import type { CrossTabRef } from '@/lib/cross-tab-integration'
 import {
   ensureCrossTabProviders,
   updateCrossTabRefs,
-  updateCrossTabMarkers
+  updateCrossTabMarkers,
+  clearCrossTabMarkers
 } from '@/components/cross-tab/cross-tab-editor'
 import { SQL_KEYWORDS } from '@/constants/sql-keywords'
 
@@ -729,16 +730,23 @@ export function SQLEditor({
   React.useEffect(() => {
     updateCrossTabRefs(crossTabRefs)
     const model = editorRef.current?.getModel()
-    if (monacoRef.current && model && crossTabDialect) {
+    if (!monacoRef.current || !model) return
+    if (crossTabDialect) {
       updateCrossTabMarkers(monacoRef.current, model, crossTabDialect)
+    } else {
+      clearCrossTabMarkers(monacoRef.current, model)
     }
   }, [crossTabRefs, crossTabDialect])
 
   const handleChange = (newValue: string | undefined) => {
     onChange?.(newValue ?? '')
     const model = editorRef.current?.getModel()
-    if (monacoRef.current && model && crossTabDialectRef.current) {
-      updateCrossTabMarkers(monacoRef.current, model, crossTabDialectRef.current)
+    if (monacoRef.current && model) {
+      if (crossTabDialectRef.current) {
+        updateCrossTabMarkers(monacoRef.current, model, crossTabDialectRef.current)
+      } else {
+        clearCrossTabMarkers(monacoRef.current, model)
+      }
     }
   }
 

--- a/apps/desktop/src/renderer/src/components/sql-editor.tsx
+++ b/apps/desktop/src/renderer/src/components/sql-editor.tsx
@@ -11,7 +11,8 @@ import {
   ensureCrossTabProviders,
   updateCrossTabRefs,
   updateCrossTabMarkers,
-  clearCrossTabMarkers
+  clearCrossTabMarkers,
+  disposeCrossTabRefs
 } from '@/components/cross-tab/cross-tab-editor'
 import { SQL_KEYWORDS } from '@/constants/sql-keywords'
 
@@ -625,11 +626,13 @@ export function SQLEditor({
     updateCompletionSnippets(snippets)
     ensureCompletionProvider(monaco)
 
-    updateCrossTabRefs(crossTabRefs)
     ensureCrossTabProviders(monaco)
     const crossTabModel = editor.getModel()
-    if (crossTabModel && crossTabDialectRef.current) {
-      updateCrossTabMarkers(monaco, crossTabModel, crossTabDialectRef.current)
+    if (crossTabModel) {
+      updateCrossTabRefs(crossTabModel, crossTabRefs)
+      if (crossTabDialectRef.current) {
+        updateCrossTabMarkers(monaco, crossTabModel, crossTabDialectRef.current)
+      }
     }
 
     // Set the theme based on current app theme
@@ -728,15 +731,23 @@ export function SQLEditor({
 
   // Update cross-tab refs + markers when they change
   React.useEffect(() => {
-    updateCrossTabRefs(crossTabRefs)
     const model = editorRef.current?.getModel()
     if (!monacoRef.current || !model) return
+    updateCrossTabRefs(model, crossTabRefs)
     if (crossTabDialect) {
       updateCrossTabMarkers(monacoRef.current, model, crossTabDialect)
     } else {
       clearCrossTabMarkers(monacoRef.current, model)
     }
   }, [crossTabRefs, crossTabDialect])
+
+  // Drop this model's cross-tab refs when the editor unmounts.
+  React.useEffect(() => {
+    return () => {
+      const model = editorRef.current?.getModel()
+      if (model) disposeCrossTabRefs(model)
+    }
+  }, [])
 
   const handleChange = (newValue: string | undefined) => {
     onChange?.(newValue ?? '')

--- a/apps/desktop/src/renderer/src/components/tab-query-editor.tsx
+++ b/apps/desktop/src/renderer/src/components/tab-query-editor.tsx
@@ -333,7 +333,8 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
   const executeSql = useCallback(
     async (sqlToExecute: string, originalQuery: string) => {
       const currentTab = useTabStore.getState().getTab(tabId)
-      if (!currentTab || !isExecutableTab(currentTab) || !tabConnection) return
+      if (!currentTab || !isExecutableTab(currentTab) || !tabConnection || currentTab.isExecuting)
+        return
 
       // Generate unique execution ID for cancellation support
       const executionId = crypto.randomUUID()
@@ -1620,7 +1621,7 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
             />
           }
           refsSlot={
-            refsSummary && refsSummary.refCount > 0 ? (
+            refsSummary ? (
               <code className="text-[10px] bg-muted/50 px-2 py-0.5 rounded">
                 {refsSummary.refCount} {refsSummary.refCount === 1 ? 'ref' : 'refs'} ·{' '}
                 {refsSummary.rowsInlined.toLocaleString()} rows inlined
@@ -1743,9 +1744,10 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
           if (!o) setPendingHeavyRun(null)
         }}
         summary={pendingHeavyRun?.summary ?? null}
-        onConfirm={() => {
+        onConfirm={(dontAskAgain) => {
           const run = pendingHeavyRun
           setPendingHeavyRun(null)
+          if (dontAskAgain) skipHeavyConfirmRef.current = true
           if (run) void executeSql(run.sql, run.originalQuery)
         }}
       />

--- a/apps/desktop/src/renderer/src/components/tab-query-editor.tsx
+++ b/apps/desktop/src/renderer/src/components/tab-query-editor.tsx
@@ -536,12 +536,12 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
         tabs: useTabStore.getState().tabs
       })
       if (!resolved.ok) {
+        setRefsSummary(null)
         updateTabMultiResult(tabId, null, crossTabErrorMessage(resolved.error))
         return
       }
 
       const summary = resolved.summary
-      setRefsSummary(summary.refCount > 0 ? summary : null)
 
       // Heavy inlined payloads get a confirm dialog so the user knows what's about to run.
       const isHeavy = summary.rowsInlined > HEAVY_ROWS || summary.bytesAdded > HEAVY_BYTES
@@ -550,6 +550,7 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
         return
       }
 
+      setRefsSummary(summary.refCount > 0 ? summary : null)
       await executeSql(resolved.finalSql, queryToRun)
     },
     [tabId, tabConnection, executeSql, updateTabMultiResult]
@@ -1756,7 +1757,10 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
           const run = pendingHeavyRun
           setPendingHeavyRun(null)
           if (dontAskAgain) skipHeavyConfirmRef.current = true
-          if (run) void executeSql(run.sql, run.originalQuery)
+          if (run) {
+            setRefsSummary(run.summary.refCount > 0 ? run.summary : null)
+            void executeSql(run.sql, run.originalQuery)
+          }
         }}
       />
 

--- a/apps/desktop/src/renderer/src/components/tab-query-editor.tsx
+++ b/apps/desktop/src/renderer/src/components/tab-query-editor.tsx
@@ -34,7 +34,7 @@ import {
 import { type DataTableColumn as EditableDataTableColumn } from '@/components/editable-data-table'
 import type { EditContext, TableInfo } from '@data-peek/shared'
 import { analyzeEditableSelect, sqlMatchesStoredTable } from '@/lib/editable-select'
-import { resolveForRun, crossTabErrorMessage } from '@/lib/cross-tab-integration'
+import { resolveForRun, crossTabErrorMessage, buildCrossTabRefs } from '@/lib/cross-tab-integration'
 import type { ResolveForRunSummary } from '@/lib/cross-tab-integration'
 import { CrossTabSubmitDialog } from '@/components/cross-tab/cross-tab-submit-dialog'
 import { SQLEditor } from '@/components/sql-editor'
@@ -125,6 +125,12 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
   const getAllSnippets = useSnippetStore((s) => s.getAllSnippets)
   const initializeSnippets = useSnippetStore((s) => s.initializeSnippets)
   const allSnippets = getAllSnippets()
+
+  const allTabs = useTabStore((s) => s.tabs)
+  const crossTabRefs = useMemo(
+    () => buildCrossTabRefs(allTabs, tab?.connectionId ?? null, tabId),
+    [allTabs, tab?.connectionId, tabId]
+  )
 
   const stepSession = useStepStore((s) => s.sessions.get(tabId))
   const startStep = useStepStore((s) => s.startStep)
@@ -1583,6 +1589,8 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
               snippets={allSnippets}
               readOnly={!!stepSession}
               glyphMargin={!!stepSession}
+              crossTabRefs={crossTabRefs}
+              crossTabDialect={tabConnection?.dbType}
               onMount={(editor, monaco) => {
                 editorRef.current = editor
                 monacoRef.current = monaco

--- a/apps/desktop/src/renderer/src/components/tab-query-editor.tsx
+++ b/apps/desktop/src/renderer/src/components/tab-query-editor.tsx
@@ -34,6 +34,7 @@ import {
 import { type DataTableColumn as EditableDataTableColumn } from '@/components/editable-data-table'
 import type { EditContext, TableInfo } from '@data-peek/shared'
 import { analyzeEditableSelect, sqlMatchesStoredTable } from '@/lib/editable-select'
+import { resolveForRun, crossTabErrorMessage } from '@/lib/cross-tab-integration'
 import { SQLEditor } from '@/components/sql-editor'
 import { formatSQL } from '@/lib/sql-formatter'
 import {
@@ -323,6 +324,19 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
       const queryToRun = (selectedSql ?? currentTab.query).trim()
       if (!queryToRun) return
 
+      // Resolve @name cross-tab references into VALUES-backed CTEs.
+      const resolved = resolveForRun(queryToRun, {
+        dbType: tabConnection.dbType,
+        connectionId: currentTab.connectionId,
+        currentTabId: tabId,
+        tabs: useTabStore.getState().tabs
+      })
+      if (!resolved.ok) {
+        updateTabMultiResult(tabId, null, crossTabErrorMessage(resolved.error))
+        return
+      }
+      const sqlToExecute = resolved.finalSql
+
       // Generate unique execution ID for cancellation support
       const executionId = crypto.randomUUID()
       updateTabExecuting(tabId, true, executionId)
@@ -343,7 +357,7 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
         // Use telemetry-enabled query API with timeout from settings
         const response = await window.api.db.queryWithTelemetry(
           tabConnection,
-          queryToRun,
+          sqlToExecute,
           executionId,
           queryTimeoutMs
         )

--- a/apps/desktop/src/renderer/src/components/tab-query-editor.tsx
+++ b/apps/desktop/src/renderer/src/components/tab-query-editor.tsx
@@ -35,6 +35,8 @@ import { type DataTableColumn as EditableDataTableColumn } from '@/components/ed
 import type { EditContext, TableInfo } from '@data-peek/shared'
 import { analyzeEditableSelect, sqlMatchesStoredTable } from '@/lib/editable-select'
 import { resolveForRun, crossTabErrorMessage } from '@/lib/cross-tab-integration'
+import type { ResolveForRunSummary } from '@/lib/cross-tab-integration'
+import { CrossTabSubmitDialog } from '@/components/cross-tab/cross-tab-submit-dialog'
 import { SQLEditor } from '@/components/sql-editor'
 import { formatSQL } from '@/lib/sql-formatter'
 import {
@@ -79,6 +81,10 @@ import { gateForWatch } from '@/lib/watch-sql-gate'
 import { useStepStore } from '@/stores/step-store'
 import { DDL_KEYWORD_REGEX } from '@shared/index'
 import type { editor as monacoEditor } from 'monaco-editor'
+
+// Above these thresholds, inlined cross-tab refs trigger a confirm dialog before running.
+const HEAVY_ROWS = 1000
+const HEAVY_BYTES = 256 * 1024
 
 /** Safely coerce a value to string[] or undefined. Handles pg driver returning array_agg as a raw string. */
 function ensureArray(value: unknown): string[] | undefined {
@@ -228,6 +234,15 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
   // Share results image dialog state
   const [shareResultsOpen, setShareResultsOpen] = useState(false)
 
+  // Cross-tab @name reference state: pill summary + heavy-run confirm gating.
+  const [refsSummary, setRefsSummary] = useState<ResolveForRunSummary | null>(null)
+  const [pendingHeavyRun, setPendingHeavyRun] = useState<{
+    summary: ResolveForRunSummary
+    sql: string
+    originalQuery: string
+  } | null>(null)
+  const skipHeavyConfirmRef = useRef(false)
+
   // Export with masked columns confirmation
   const [pendingExport, setPendingExport] = useState<null | {
     format: ExportFormat
@@ -311,31 +326,14 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
     }
   }
 
-  const handleRunQuery = useCallback(
-    async (selectedSql?: string) => {
-      // Read fresh tab state from store to avoid stale closure issues
-      // (important for server-side pagination where query is updated before this runs)
+  // Execution body for a query run. `sqlToExecute` is the resolved SQL actually sent to
+  // the database (with cross-tab @name references inlined). `originalQuery` is the user's
+  // typed text, used for history and stored-table checks so they reflect intent, not the
+  // expanded CTE payload. Reads fresh tab state from the store to avoid stale closures.
+  const executeSql = useCallback(
+    async (sqlToExecute: string, originalQuery: string) => {
       const currentTab = useTabStore.getState().getTab(tabId)
-
-      if (!currentTab || !isExecutableTab(currentTab) || !tabConnection || currentTab.isExecuting) {
-        return
-      }
-
-      const queryToRun = (selectedSql ?? currentTab.query).trim()
-      if (!queryToRun) return
-
-      // Resolve @name cross-tab references into VALUES-backed CTEs.
-      const resolved = resolveForRun(queryToRun, {
-        dbType: tabConnection.dbType,
-        connectionId: currentTab.connectionId,
-        currentTabId: tabId,
-        tabs: useTabStore.getState().tabs
-      })
-      if (!resolved.ok) {
-        updateTabMultiResult(tabId, null, crossTabErrorMessage(resolved.error))
-        return
-      }
-      const sqlToExecute = resolved.finalSql
+      if (!currentTab || !isExecutableTab(currentTab) || !tabConnection) return
 
       // Generate unique execution ID for cancellation support
       const executionId = crypto.randomUUID()
@@ -398,7 +396,7 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
             const previewSqlMatches =
               currentTab.type === 'table-preview' &&
               sqlMatchesStoredTable(
-                queryToRun,
+                originalQuery,
                 { schema: currentTab.schemaName, table: currentTab.tableName },
                 tabConnection.dbType
               )
@@ -441,7 +439,7 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
             // Add to global history with total row count
             const totalRows = multiResult.statements.reduce((sum, s) => sum + s.rowCount, 0)
             addToHistory({
-              query: queryToRun,
+              query: originalQuery,
               durationMs: multiResult.totalDurationMs,
               rowCount: totalRows,
               status: 'success',
@@ -464,7 +462,7 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
             markTabSaved(tabId)
 
             addToHistory({
-              query: queryToRun,
+              query: originalQuery,
               durationMs: singleResult.durationMs,
               rowCount: result.rowCount,
               status: 'success',
@@ -477,7 +475,7 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
           setTelemetry(null)
 
           addToHistory({
-            query: queryToRun,
+            query: originalQuery,
             durationMs: 0,
             rowCount: 0,
             status: 'error',
@@ -508,6 +506,46 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
       queryTimeoutMs,
       setTablePreviewTotalCount
     ]
+  )
+
+  const handleRunQuery = useCallback(
+    async (selectedSql?: string) => {
+      // Read fresh tab state from store to avoid stale closure issues
+      // (important for server-side pagination where query is updated before this runs)
+      const currentTab = useTabStore.getState().getTab(tabId)
+
+      if (!currentTab || !isExecutableTab(currentTab) || !tabConnection || currentTab.isExecuting) {
+        return
+      }
+
+      const queryToRun = (selectedSql ?? currentTab.query).trim()
+      if (!queryToRun) return
+
+      // Resolve @name cross-tab references into VALUES-backed CTEs.
+      const resolved = resolveForRun(queryToRun, {
+        dbType: tabConnection.dbType,
+        connectionId: currentTab.connectionId,
+        currentTabId: tabId,
+        tabs: useTabStore.getState().tabs
+      })
+      if (!resolved.ok) {
+        updateTabMultiResult(tabId, null, crossTabErrorMessage(resolved.error))
+        return
+      }
+
+      const summary = resolved.summary
+      setRefsSummary(summary.refCount > 0 ? summary : null)
+
+      // Heavy inlined payloads get a confirm dialog so the user knows what's about to run.
+      const isHeavy = summary.rowsInlined > HEAVY_ROWS || summary.bytesAdded > HEAVY_BYTES
+      if (isHeavy && !skipHeavyConfirmRef.current) {
+        setPendingHeavyRun({ summary, sql: resolved.finalSql, originalQuery: queryToRun })
+        return
+      }
+
+      await executeSql(resolved.finalSql, queryToRun)
+    },
+    [tabId, tabConnection, executeSql, updateTabMultiResult]
   )
 
   const handleCancelQuery = useCallback(async () => {
@@ -1581,6 +1619,14 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
               disabled={!tabConnection}
             />
           }
+          refsSlot={
+            refsSummary && refsSummary.refCount > 0 ? (
+              <code className="text-[10px] bg-muted/50 px-2 py-0.5 rounded">
+                {refsSummary.refCount} {refsSummary.refCount === 1 ? 'ref' : 'refs'} ·{' '}
+                {refsSummary.rowsInlined.toLocaleString()} rows inlined
+              </code>
+            ) : undefined
+          }
         />
       </div>
 
@@ -1689,6 +1735,20 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
           </div>
         </>
       )}
+
+      {/* Cross-tab heavy-run confirm dialog */}
+      <CrossTabSubmitDialog
+        open={pendingHeavyRun !== null}
+        onOpenChange={(o) => {
+          if (!o) setPendingHeavyRun(null)
+        }}
+        summary={pendingHeavyRun?.summary ?? null}
+        onConfirm={() => {
+          const run = pendingHeavyRun
+          setPendingHeavyRun(null)
+          if (run) void executeSql(run.sql, run.originalQuery)
+        }}
+      />
 
       {/* Save Query Dialog */}
       <SaveQueryDialog open={saveDialogOpen} onOpenChange={setSaveDialogOpen} query={tab.query} />

--- a/apps/desktop/src/renderer/src/components/tab-query-editor.tsx
+++ b/apps/desktop/src/renderer/src/components/tab-query-editor.tsx
@@ -34,7 +34,12 @@ import {
 import { type DataTableColumn as EditableDataTableColumn } from '@/components/editable-data-table'
 import type { EditContext, TableInfo } from '@data-peek/shared'
 import { analyzeEditableSelect, sqlMatchesStoredTable } from '@/lib/editable-select'
-import { resolveForRun, crossTabErrorMessage, buildCrossTabRefs } from '@/lib/cross-tab-integration'
+import {
+  resolveForRun,
+  crossTabErrorMessage,
+  buildCrossTabRefs,
+  isHeavyResolve
+} from '@/lib/cross-tab-integration'
 import type { ResolveForRunSummary } from '@/lib/cross-tab-integration'
 import { CrossTabSubmitDialog } from '@/components/cross-tab/cross-tab-submit-dialog'
 import { SQLEditor } from '@/components/sql-editor'
@@ -81,10 +86,6 @@ import { gateForWatch } from '@/lib/watch-sql-gate'
 import { useStepStore } from '@/stores/step-store'
 import { DDL_KEYWORD_REGEX } from '@shared/index'
 import type { editor as monacoEditor } from 'monaco-editor'
-
-// Above these thresholds, inlined cross-tab refs trigger a confirm dialog before running.
-const HEAVY_ROWS = 1000
-const HEAVY_BYTES = 256 * 1024
 
 /** Safely coerce a value to string[] or undefined. Handles pg driver returning array_agg as a raw string. */
 function ensureArray(value: unknown): string[] | undefined {
@@ -544,7 +545,7 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
       const summary = resolved.summary
 
       // Heavy inlined payloads get a confirm dialog so the user knows what's about to run.
-      const isHeavy = summary.rowsInlined > HEAVY_ROWS || summary.bytesAdded > HEAVY_BYTES
+      const isHeavy = isHeavyResolve(summary)
       if (isHeavy && !skipHeavyConfirmRef.current) {
         setPendingHeavyRun({ summary, sql: resolved.finalSql, originalQuery: queryToRun })
         return

--- a/apps/desktop/src/renderer/src/components/tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tab.tsx
@@ -6,6 +6,24 @@ import { cn, ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuSepara
 import type { Tab as TabType } from '@/stores/tab-store'
 import { useTabStore } from '@/stores/tab-store'
 import { useWatchStore } from '@/stores/watch-store'
+import type { RefNameValidationError } from '@/lib/cross-tab-types'
+
+function refNameErrorMessage(error: RefNameValidationError): string {
+  switch (error.kind) {
+    case 'empty':
+      return 'Enter a name'
+    case 'too_long':
+      return `Too long (max ${error.max})`
+    case 'invalid_chars':
+      return error.detail
+    case 'reserved_word':
+      return `"${error.word}" is a reserved word`
+    case 'duplicate':
+      return 'Already used on this connection'
+    case 'not_a_query_tab':
+      return 'Only query tabs can be named'
+  }
+}
 
 interface TabProps {
   tab: TabType
@@ -129,13 +147,14 @@ export function Tab({
                 if (e.key === 'Enter') {
                   const res = setTabName(tab.id, nameDraft)
                   if (res.ok) setRenaming(false)
-                  else setNameError('Invalid or duplicate name')
+                  else setNameError(refNameErrorMessage(res.error))
                 } else if (e.key === 'Escape') {
                   setRenaming(false)
                 }
               }}
               onBlur={() => setRenaming(false)}
               placeholder="name"
+              title={nameError ?? undefined}
               className={cn(
                 'w-24 bg-transparent text-sm outline-none border-b',
                 nameError ? 'border-red-500' : 'border-primary/50'

--- a/apps/desktop/src/renderer/src/components/tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tab.tsx
@@ -1,8 +1,10 @@
+import { useState } from 'react'
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { FileCode, Table2, Pin, X, Network, SearchCode } from 'lucide-react'
 import { cn, ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuSeparator, ContextMenuTrigger } from '@data-peek/ui'
 import type { Tab as TabType } from '@/stores/tab-store'
+import { useTabStore } from '@/stores/tab-store'
 import { useWatchStore } from '@/stores/watch-store'
 
 interface TabProps {
@@ -36,6 +38,14 @@ export function Tab({
   const watchState = useWatchStore((s) => s.states[tab.id])
   const isWatching = !!watchState?.enabled
   const isPaused = !!watchState?.paused
+
+  const setTabName = useTabStore((s) => s.setTabName)
+  const clearTabName = useTabStore((s) => s.clearTabName)
+  const isQuery = tab.type === 'query'
+  const refName = isQuery ? tab.name : undefined
+  const [renaming, setRenaming] = useState(false)
+  const [nameDraft, setNameDraft] = useState('')
+  const [nameError, setNameError] = useState<string | null>(null)
 
   const style = {
     transform: CSS.Transform.toString(transform),
@@ -104,7 +114,39 @@ export function Tab({
           )}
 
           {/* Title */}
-          <span className="truncate text-sm">{tab.title}</span>
+          {renaming ? (
+            <input
+              autoFocus
+              value={nameDraft}
+              onChange={(e) => {
+                setNameDraft(e.target.value)
+                setNameError(null)
+              }}
+              onClick={(e) => e.stopPropagation()}
+              onKeyDown={(e) => {
+                e.stopPropagation()
+                if (e.key === 'Enter') {
+                  const res = setTabName(tab.id, nameDraft)
+                  if (res.ok) setRenaming(false)
+                  else setNameError('Invalid or duplicate name')
+                } else if (e.key === 'Escape') {
+                  setRenaming(false)
+                }
+              }}
+              onBlur={() => setRenaming(false)}
+              placeholder="name"
+              className={cn(
+                'w-24 bg-transparent text-sm outline-none border-b',
+                nameError ? 'border-red-500' : 'border-primary/50'
+              )}
+            />
+          ) : refName ? (
+            <span className="truncate text-sm">
+              <span className="text-primary">@{refName}</span>
+            </span>
+          ) : (
+            <span className="truncate text-sm">{tab.title}</span>
+          )}
 
           {/* Close button (hidden for pinned tabs) */}
           {!tab.isPinned && (
@@ -133,6 +175,21 @@ export function Tab({
           </ContextMenuItem>
         )}
         <ContextMenuSeparator />
+        {isQuery && (
+          <ContextMenuItem
+            onClick={() => {
+              setNameDraft(refName ?? '')
+              setNameError(null)
+              setRenaming(true)
+            }}
+          >
+            Name as @…
+          </ContextMenuItem>
+        )}
+        {isQuery && refName && (
+          <ContextMenuItem onClick={() => clearTabName(tab.id)}>Clear @name</ContextMenuItem>
+        )}
+        {isQuery && <ContextMenuSeparator />}
         {!tab.isPinned && (
           <ContextMenuItem onClick={onClose}>
             <X className="mr-2 size-4" />

--- a/apps/desktop/src/renderer/src/components/tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tab.tsx
@@ -123,6 +123,7 @@ export function Tab({
                 setNameError(null)
               }}
               onClick={(e) => e.stopPropagation()}
+              onPointerDown={(e) => e.stopPropagation()}
               onKeyDown={(e) => {
                 e.stopPropagation()
                 if (e.key === 'Enter') {

--- a/apps/desktop/src/renderer/src/components/tab.tsx
+++ b/apps/desktop/src/renderer/src/components/tab.tsx
@@ -20,8 +20,6 @@ function refNameErrorMessage(error: RefNameValidationError): string {
       return `"${error.word}" is a reserved word`
     case 'duplicate':
       return 'Already used on this connection'
-    case 'not_a_query_tab':
-      return 'Only query tabs can be named'
   }
 }
 
@@ -146,8 +144,13 @@ export function Tab({
                 e.stopPropagation()
                 if (e.key === 'Enter') {
                   const res = setTabName(tab.id, nameDraft)
-                  if (res.ok) setRenaming(false)
-                  else setNameError(refNameErrorMessage(res.error))
+                  if (res.ok) {
+                    setRenaming(false)
+                  } else if (res.error.kind === 'not_a_query_tab') {
+                    setNameError('Only query tabs can be named')
+                  } else {
+                    setNameError(refNameErrorMessage(res.error))
+                  }
                 } else if (e.key === 'Escape') {
                   setRenaming(false)
                 }

--- a/apps/desktop/src/renderer/src/lib/__tests__/cross-tab-integration.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/cross-tab-integration.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from 'vitest'
+import {
+  toSQLDialect,
+  mapTabToResolvable,
+  buildTabLookup,
+  resolveForRun,
+  buildCrossTabRefs,
+  crossTabErrorMessage
+} from '../cross-tab-integration'
+import type { QueryTab, Tab } from '../../stores/tab-store'
+
+function qtab(id: string, connectionId: string | null, o: Partial<QueryTab> = {}): QueryTab {
+  return {
+    id, type: 'query', title: 'Query', isPinned: false, connectionId,
+    createdAt: 0, order: 0, query: '', savedQuery: '',
+    result: null, multiResult: null, activeResultIndex: 0, error: null,
+    isExecuting: false, executionId: null, currentPage: 1, pageSize: 100, ...o
+  }
+}
+
+const RES = {
+  columns: [{ name: 'id', dataType: 'integer' }, { name: 'email', dataType: 'text' }],
+  rows: [{ id: 1, email: 'a@x.com' }, { id: 2, email: 'b@x.com' }],
+  rowCount: 2,
+  durationMs: 1
+}
+
+describe('toSQLDialect', () => {
+  it('maps database types to escaper dialects (sqlite → standard)', () => {
+    expect(toSQLDialect('postgresql')).toBe('postgresql')
+    expect(toSQLDialect('mysql')).toBe('mysql')
+    expect(toSQLDialect('mssql')).toBe('mssql')
+    expect(toSQLDialect('sqlite')).toBe('standard')
+  })
+})
+
+describe('mapTabToResolvable', () => {
+  it('maps a successful legacy result to kind:success with fields from columns', () => {
+    const r = mapTabToResolvable(qtab('a', 'c1', { name: 'u', result: RES }))
+    expect(r.result.kind).toBe('success')
+    if (r.result.kind !== 'success') return
+    expect(r.result.rows).toHaveLength(2)
+    expect(r.result.fields).toEqual(RES.columns)
+  })
+
+  it('prefers the active multiResult statement over legacy result', () => {
+    const tab = qtab('a', 'c1', {
+      name: 'u',
+      result: RES,
+      activeResultIndex: 1,
+      multiResult: {
+        statements: [
+          { rows: [], fields: [], rowCount: 0 },
+          { rows: [{ x: 9 }], fields: [{ name: 'x', dataType: 'integer' }], rowCount: 1 }
+        ],
+        totalDurationMs: 1,
+        statementCount: 2
+      } as unknown as QueryTab['multiResult']
+    })
+    const r = mapTabToResolvable(tab)
+    expect(r.result.kind).toBe('success')
+    if (r.result.kind !== 'success') return
+    expect(r.result.rows).toEqual([{ x: 9 }])
+  })
+
+  it('maps an error to kind:error', () => {
+    const r = mapTabToResolvable(qtab('a', 'c1', { name: 'u', error: 'boom' }))
+    expect(r.result).toEqual({ kind: 'error', message: 'boom' })
+  })
+
+  it('maps a never-run tab to kind:none', () => {
+    const r = mapTabToResolvable(qtab('a', 'c1', { name: 'u' }))
+    expect(r.result).toEqual({ kind: 'none' })
+  })
+})
+
+describe('buildTabLookup', () => {
+  const tabs: Tab[] = [
+    qtab('a', 'c1', { name: 'recent', result: RES }),
+    qtab('b', 'c1'),
+    qtab('c', 'c2', { name: 'recent', result: RES }),
+    qtab('self', 'c1', { name: 'me', result: RES })
+  ]
+  it('finds a named tab on the same connection', () => {
+    const lookup = buildTabLookup(tabs, 'c1', 'b')
+    expect(lookup('recent')?.tabId).toBe('a')
+  })
+  it('does not cross connections', () => {
+    const lookup = buildTabLookup(tabs, 'c1', 'b')
+    expect(lookup('recent')?.tabId).toBe('a')
+  })
+  it('excludes the current tab (no self-reference via lookup)', () => {
+    const lookup = buildTabLookup(tabs, 'c1', 'self')
+    expect(lookup('me')).toBeNull()
+  })
+  it('returns null for an unknown name', () => {
+    const lookup = buildTabLookup(tabs, 'c1', 'b')
+    expect(lookup('nope')).toBeNull()
+  })
+})
+
+describe('resolveForRun', () => {
+  const tabs: Tab[] = [qtab('a', 'c1', { name: 'active_users', result: RES })]
+
+  it('passes through SQL with no references', () => {
+    const r = resolveForRun('SELECT 1', { dbType: 'postgresql', connectionId: 'c1', currentTabId: 'b', tabs })
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.finalSql).toBe('SELECT 1')
+    expect(r.summary.refCount).toBe(0)
+  })
+
+  it('resolves a reference into a CTE (postgres)', () => {
+    const r = resolveForRun('SELECT * FROM @active_users', { dbType: 'postgresql', connectionId: 'c1', currentTabId: 'b', tabs })
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.finalSql).toContain('WITH')
+    expect(r.finalSql).toContain('active_users')
+    expect(r.finalSql).not.toContain('@active_users')
+    expect(r.summary.refCount).toBe(1)
+    expect(r.summary.rowsInlined).toBe(2)
+  })
+
+  it('resolves across all dialects without throwing', () => {
+    for (const dbType of ['postgresql', 'mysql', 'mssql', 'sqlite'] as const) {
+      const r = resolveForRun('SELECT * FROM @active_users', { dbType, connectionId: 'c1', currentTabId: 'b', tabs })
+      expect(r.ok).toBe(true)
+      if (!r.ok) return
+      expect(r.finalSql).not.toContain('@active_users')
+    }
+  })
+
+  it('reports unknown_reference on postgres for a missing name', () => {
+    const r = resolveForRun('SELECT * FROM @ghost', { dbType: 'postgresql', connectionId: 'c1', currentTabId: 'b', tabs })
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(r.error.kind).toBe('unknown_reference')
+  })
+
+  it('on mysql, ignores @vars that are not named tabs (no error)', () => {
+    const r = resolveForRun('SELECT @offset, * FROM @active_users', { dbType: 'mysql', connectionId: 'c1', currentTabId: 'b', tabs })
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.finalSql).toContain('@offset')
+    expect(r.finalSql).not.toContain('@active_users')
+  })
+})
+
+describe('buildCrossTabRefs', () => {
+  it('summarizes named query tabs on the connection (excluding current)', () => {
+    const tabs: Tab[] = [
+      qtab('a', 'c1', { name: 'active_users', title: 'Users', result: RES }),
+      qtab('b', 'c1', { name: 'pending' }),
+      qtab('cur', 'c1', { name: 'self', result: RES })
+    ]
+    const refs = buildCrossTabRefs(tabs, 'c1', 'cur')
+    expect(refs).toEqual([
+      { name: 'active_users', tabTitle: 'Users', rowCount: 2, colCount: 2, hasResult: true },
+      { name: 'pending', tabTitle: 'Query', rowCount: 0, colCount: 0, hasResult: false }
+    ])
+  })
+})
+
+describe('crossTabErrorMessage', () => {
+  it('renders each error kind', () => {
+    expect(crossTabErrorMessage({ kind: 'unknown_reference', name: 'x' })).toBe('No tab named @x on this connection.')
+    expect(crossTabErrorMessage({ kind: 'no_result', name: 'x' })).toContain("hasn't been run")
+    expect(crossTabErrorMessage({ kind: 'circular', chain: ['x'] })).toContain('reference itself')
+    expect(crossTabErrorMessage({ kind: 'too_large', name: 'x', rows: 5, bytes: 1, cap: { rows: 4, bytes: 9 } })).toContain('cap 4')
+    expect(crossTabErrorMessage({ kind: 'too_many_columns', name: 'x', columns: 200, cap: 100 })).toContain('200 columns')
+    expect(crossTabErrorMessage({ kind: 'duplicate_cte_name', name: 'x' })).toContain('collides')
+    expect(crossTabErrorMessage({ kind: 'errored_result', name: 'x', error: 'oops' })).toContain('oops')
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/__tests__/cross-tab-integration.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/cross-tab-integration.test.ts
@@ -118,23 +118,24 @@ describe('buildTabLookup', () => {
     qtab('self', 'c1', { name: 'me', result: RES })
   ]
   it('finds a named tab on the same connection', () => {
-    const lookup = buildTabLookup(tabs, 'c1', 'b')
+    const lookup = buildTabLookup(tabs, 'c1')
     expect(lookup('recent')?.tabId).toBe('a')
   })
   it('does not cross connections', () => {
     // c2 also has a tab named 'recent'; a c1-scoped lookup must resolve to c1's tab
-    const lookupC1 = buildTabLookup(tabs, 'c1', 'b')
+    const lookupC1 = buildTabLookup(tabs, 'c1')
     expect(lookupC1('recent')?.tabId).toBe('a')
     // a c2-scoped lookup resolves to c2's tab, not c1's
-    const lookupC2 = buildTabLookup(tabs, 'c2', 'x')
+    const lookupC2 = buildTabLookup(tabs, 'c2')
     expect(lookupC2('recent')?.tabId).toBe('c')
   })
-  it('excludes the current tab (no self-reference via lookup)', () => {
-    const lookup = buildTabLookup(tabs, 'c1', 'self')
-    expect(lookup('me')).toBeNull()
+  it('includes the current tab so the resolver can flag a self-reference', () => {
+    // The lookup returns the tab itself; the resolver turns tabId === currentTabId into `circular`.
+    const lookup = buildTabLookup(tabs, 'c1')
+    expect(lookup('me')?.tabId).toBe('self')
   })
   it('returns null for an unknown name', () => {
-    const lookup = buildTabLookup(tabs, 'c1', 'b')
+    const lookup = buildTabLookup(tabs, 'c1')
     expect(lookup('nope')).toBeNull()
   })
 })
@@ -238,7 +239,7 @@ describe('resolveForRun', () => {
     expect(r.error.error).toBe('boom')
   })
 
-  it('a self-reference resolves to unknown_reference (current tab excluded from lookup)', () => {
+  it('a self-reference resolves to circular (postgres)', () => {
     const t: Tab[] = [qtab('self', 'c1', { name: 'me', result: RES })]
     const r = resolveForRun('SELECT * FROM @me', {
       dbType: 'postgresql',
@@ -248,7 +249,20 @@ describe('resolveForRun', () => {
     })
     expect(r.ok).toBe(false)
     if (r.ok) return
-    expect(r.error.kind).toBe('unknown_reference')
+    expect(r.error.kind).toBe('circular')
+  })
+
+  it('a self-reference resolves to circular on mysql (current name is a known name)', () => {
+    const t: Tab[] = [qtab('self', 'c1', { name: 'me', result: RES })]
+    const r = resolveForRun('SELECT * FROM @me', {
+      dbType: 'mysql',
+      connectionId: 'c1',
+      currentTabId: 'self',
+      tabs: t
+    })
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(r.error.kind).toBe('circular')
   })
 })
 
@@ -287,6 +301,16 @@ describe('crossTabErrorMessage', () => {
         cap: { rows: 4, bytes: 9 }
       })
     ).toContain('cap 4')
+    // byte-cap breach (under the row cap) names KB, not rows
+    expect(
+      crossTabErrorMessage({
+        kind: 'too_large',
+        name: 'x',
+        rows: 2,
+        bytes: 600 * 1024,
+        cap: { rows: 1000, bytes: 256 * 1024 }
+      })
+    ).toContain('KB')
     expect(
       crossTabErrorMessage({ kind: 'too_many_columns', name: 'x', columns: 200, cap: 100 })
     ).toContain('200 columns')

--- a/apps/desktop/src/renderer/src/lib/__tests__/cross-tab-integration.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/cross-tab-integration.test.ts
@@ -5,7 +5,8 @@ import {
   buildTabLookup,
   resolveForRun,
   buildCrossTabRefs,
-  crossTabErrorMessage
+  crossTabErrorMessage,
+  isHeavyResolve
 } from '../cross-tab-integration'
 import type { QueryTab, Tab } from '../../stores/tab-store'
 
@@ -208,6 +209,47 @@ describe('resolveForRun', () => {
     expect(r.finalSql).toContain('@offset')
     expect(r.finalSql).not.toContain('@active_users')
   })
+
+  it('reports no_result for a named tab that has not been run', () => {
+    const t: Tab[] = [qtab('a', 'c1', { name: 'pending' })]
+    const r = resolveForRun('SELECT * FROM @pending', {
+      dbType: 'postgresql',
+      connectionId: 'c1',
+      currentTabId: 'b',
+      tabs: t
+    })
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(r.error.kind).toBe('no_result')
+  })
+
+  it('reports errored_result (with the message) for a tab whose last run errored', () => {
+    const t: Tab[] = [qtab('a', 'c1', { name: 'broken', error: 'boom' })]
+    const r = resolveForRun('SELECT * FROM @broken', {
+      dbType: 'postgresql',
+      connectionId: 'c1',
+      currentTabId: 'b',
+      tabs: t
+    })
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(r.error.kind).toBe('errored_result')
+    if (r.error.kind !== 'errored_result') return
+    expect(r.error.error).toBe('boom')
+  })
+
+  it('a self-reference resolves to unknown_reference (current tab excluded from lookup)', () => {
+    const t: Tab[] = [qtab('self', 'c1', { name: 'me', result: RES })]
+    const r = resolveForRun('SELECT * FROM @me', {
+      dbType: 'postgresql',
+      connectionId: 'c1',
+      currentTabId: 'self',
+      tabs: t
+    })
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(r.error.kind).toBe('unknown_reference')
+  })
 })
 
 describe('buildCrossTabRefs', () => {
@@ -248,5 +290,29 @@ describe('crossTabErrorMessage', () => {
     expect(crossTabErrorMessage({ kind: 'errored_result', name: 'x', error: 'oops' })).toContain(
       'oops'
     )
+  })
+})
+
+describe('isHeavyResolve', () => {
+  const summary = (rowsInlined: number, bytesAdded: number) => ({
+    refCount: 1,
+    rowsInlined,
+    bytesAdded,
+    references: []
+  })
+  it('is not heavy at exactly the row threshold', () => {
+    expect(isHeavyResolve(summary(1000, 0))).toBe(false)
+  })
+  it('is heavy one row over the threshold', () => {
+    expect(isHeavyResolve(summary(1001, 0))).toBe(true)
+  })
+  it('is heavy when bytes exceed the cap even with rows under', () => {
+    expect(isHeavyResolve(summary(10, 256 * 1024 + 1))).toBe(true)
+  })
+  it('is not heavy at exactly the byte threshold', () => {
+    expect(isHeavyResolve(summary(10, 256 * 1024))).toBe(false)
+  })
+  it('respects custom thresholds', () => {
+    expect(isHeavyResolve(summary(5, 0), { rows: 4, bytes: 100 })).toBe(true)
   })
 })

--- a/apps/desktop/src/renderer/src/lib/__tests__/cross-tab-integration.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/cross-tab-integration.test.ts
@@ -11,16 +11,36 @@ import type { QueryTab, Tab } from '../../stores/tab-store'
 
 function qtab(id: string, connectionId: string | null, o: Partial<QueryTab> = {}): QueryTab {
   return {
-    id, type: 'query', title: 'Query', isPinned: false, connectionId,
-    createdAt: 0, order: 0, query: '', savedQuery: '',
-    result: null, multiResult: null, activeResultIndex: 0, error: null,
-    isExecuting: false, executionId: null, currentPage: 1, pageSize: 100, ...o
+    id,
+    type: 'query',
+    title: 'Query',
+    isPinned: false,
+    connectionId,
+    createdAt: 0,
+    order: 0,
+    query: '',
+    savedQuery: '',
+    result: null,
+    multiResult: null,
+    activeResultIndex: 0,
+    error: null,
+    isExecuting: false,
+    executionId: null,
+    currentPage: 1,
+    pageSize: 100,
+    ...o
   }
 }
 
 const RES = {
-  columns: [{ name: 'id', dataType: 'integer' }, { name: 'email', dataType: 'text' }],
-  rows: [{ id: 1, email: 'a@x.com' }, { id: 2, email: 'b@x.com' }],
+  columns: [
+    { name: 'id', dataType: 'integer' },
+    { name: 'email', dataType: 'text' }
+  ],
+  rows: [
+    { id: 1, email: 'a@x.com' },
+    { id: 2, email: 'b@x.com' }
+  ],
   rowCount: 2,
   durationMs: 1
 }
@@ -72,6 +92,21 @@ describe('mapTabToResolvable', () => {
     const r = mapTabToResolvable(qtab('a', 'c1', { name: 'u' }))
     expect(r.result).toEqual({ kind: 'none' })
   })
+
+  it('treats an out-of-bounds activeResultIndex as no result', () => {
+    const tab = qtab('a', 'c1', {
+      name: 'u',
+      activeResultIndex: 5,
+      multiResult: {
+        statements: [
+          { rows: [{ x: 1 }], fields: [{ name: 'x', dataType: 'integer' }], rowCount: 1 }
+        ],
+        totalDurationMs: 1,
+        statementCount: 1
+      } as unknown as QueryTab['multiResult']
+    })
+    expect(mapTabToResolvable(tab).result).toEqual({ kind: 'none' })
+  })
 })
 
 describe('buildTabLookup', () => {
@@ -86,8 +121,12 @@ describe('buildTabLookup', () => {
     expect(lookup('recent')?.tabId).toBe('a')
   })
   it('does not cross connections', () => {
-    const lookup = buildTabLookup(tabs, 'c1', 'b')
-    expect(lookup('recent')?.tabId).toBe('a')
+    // c2 also has a tab named 'recent'; a c1-scoped lookup must resolve to c1's tab
+    const lookupC1 = buildTabLookup(tabs, 'c1', 'b')
+    expect(lookupC1('recent')?.tabId).toBe('a')
+    // a c2-scoped lookup resolves to c2's tab, not c1's
+    const lookupC2 = buildTabLookup(tabs, 'c2', 'x')
+    expect(lookupC2('recent')?.tabId).toBe('c')
   })
   it('excludes the current tab (no self-reference via lookup)', () => {
     const lookup = buildTabLookup(tabs, 'c1', 'self')
@@ -103,7 +142,12 @@ describe('resolveForRun', () => {
   const tabs: Tab[] = [qtab('a', 'c1', { name: 'active_users', result: RES })]
 
   it('passes through SQL with no references', () => {
-    const r = resolveForRun('SELECT 1', { dbType: 'postgresql', connectionId: 'c1', currentTabId: 'b', tabs })
+    const r = resolveForRun('SELECT 1', {
+      dbType: 'postgresql',
+      connectionId: 'c1',
+      currentTabId: 'b',
+      tabs
+    })
     expect(r.ok).toBe(true)
     if (!r.ok) return
     expect(r.finalSql).toBe('SELECT 1')
@@ -111,7 +155,12 @@ describe('resolveForRun', () => {
   })
 
   it('resolves a reference into a CTE (postgres)', () => {
-    const r = resolveForRun('SELECT * FROM @active_users', { dbType: 'postgresql', connectionId: 'c1', currentTabId: 'b', tabs })
+    const r = resolveForRun('SELECT * FROM @active_users', {
+      dbType: 'postgresql',
+      connectionId: 'c1',
+      currentTabId: 'b',
+      tabs
+    })
     expect(r.ok).toBe(true)
     if (!r.ok) return
     expect(r.finalSql).toContain('WITH')
@@ -123,7 +172,12 @@ describe('resolveForRun', () => {
 
   it('resolves across all dialects without throwing', () => {
     for (const dbType of ['postgresql', 'mysql', 'mssql', 'sqlite'] as const) {
-      const r = resolveForRun('SELECT * FROM @active_users', { dbType, connectionId: 'c1', currentTabId: 'b', tabs })
+      const r = resolveForRun('SELECT * FROM @active_users', {
+        dbType,
+        connectionId: 'c1',
+        currentTabId: 'b',
+        tabs
+      })
       expect(r.ok).toBe(true)
       if (!r.ok) return
       expect(r.finalSql).not.toContain('@active_users')
@@ -131,14 +185,24 @@ describe('resolveForRun', () => {
   })
 
   it('reports unknown_reference on postgres for a missing name', () => {
-    const r = resolveForRun('SELECT * FROM @ghost', { dbType: 'postgresql', connectionId: 'c1', currentTabId: 'b', tabs })
+    const r = resolveForRun('SELECT * FROM @ghost', {
+      dbType: 'postgresql',
+      connectionId: 'c1',
+      currentTabId: 'b',
+      tabs
+    })
     expect(r.ok).toBe(false)
     if (r.ok) return
     expect(r.error.kind).toBe('unknown_reference')
   })
 
   it('on mysql, ignores @vars that are not named tabs (no error)', () => {
-    const r = resolveForRun('SELECT @offset, * FROM @active_users', { dbType: 'mysql', connectionId: 'c1', currentTabId: 'b', tabs })
+    const r = resolveForRun('SELECT @offset, * FROM @active_users', {
+      dbType: 'mysql',
+      connectionId: 'c1',
+      currentTabId: 'b',
+      tabs
+    })
     expect(r.ok).toBe(true)
     if (!r.ok) return
     expect(r.finalSql).toContain('@offset')
@@ -163,12 +227,26 @@ describe('buildCrossTabRefs', () => {
 
 describe('crossTabErrorMessage', () => {
   it('renders each error kind', () => {
-    expect(crossTabErrorMessage({ kind: 'unknown_reference', name: 'x' })).toBe('No tab named @x on this connection.')
+    expect(crossTabErrorMessage({ kind: 'unknown_reference', name: 'x' })).toBe(
+      'No tab named @x on this connection.'
+    )
     expect(crossTabErrorMessage({ kind: 'no_result', name: 'x' })).toContain("hasn't been run")
     expect(crossTabErrorMessage({ kind: 'circular', chain: ['x'] })).toContain('reference itself')
-    expect(crossTabErrorMessage({ kind: 'too_large', name: 'x', rows: 5, bytes: 1, cap: { rows: 4, bytes: 9 } })).toContain('cap 4')
-    expect(crossTabErrorMessage({ kind: 'too_many_columns', name: 'x', columns: 200, cap: 100 })).toContain('200 columns')
+    expect(
+      crossTabErrorMessage({
+        kind: 'too_large',
+        name: 'x',
+        rows: 5,
+        bytes: 1,
+        cap: { rows: 4, bytes: 9 }
+      })
+    ).toContain('cap 4')
+    expect(
+      crossTabErrorMessage({ kind: 'too_many_columns', name: 'x', columns: 200, cap: 100 })
+    ).toContain('200 columns')
     expect(crossTabErrorMessage({ kind: 'duplicate_cte_name', name: 'x' })).toContain('collides')
-    expect(crossTabErrorMessage({ kind: 'errored_result', name: 'x', error: 'oops' })).toContain('oops')
+    expect(crossTabErrorMessage({ kind: 'errored_result', name: 'x', error: 'oops' })).toContain(
+      'oops'
+    )
   })
 })

--- a/apps/desktop/src/renderer/src/lib/__tests__/cross-tab-integration.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/cross-tab-integration.test.ts
@@ -261,8 +261,12 @@ describe('buildCrossTabRefs', () => {
     ]
     const refs = buildCrossTabRefs(tabs, 'c1', 'cur')
     expect(refs).toEqual([
-      { name: 'active_users', tabTitle: 'Users', rowCount: 2, colCount: 2, hasResult: true },
-      { name: 'pending', tabTitle: 'Query', rowCount: 0, colCount: 0, hasResult: false }
+      {
+        name: 'active_users',
+        tabTitle: 'Users',
+        result: { kind: 'ready', rowCount: 2, colCount: 2 }
+      },
+      { name: 'pending', tabTitle: 'Query', result: { kind: 'not_run' } }
     ])
   })
 })

--- a/apps/desktop/src/renderer/src/lib/cross-tab-integration.ts
+++ b/apps/desktop/src/renderer/src/lib/cross-tab-integration.ts
@@ -1,0 +1,177 @@
+/**
+ * Cross-Tab integration layer.
+ *
+ * The seam between the renderer (tab store, query execution, Monaco) and the
+ * pure parser/resolver shipped in #184. Everything here is pure and unit-
+ * tested; React/store wiring lives in the components that call resolveForRun.
+ */
+
+import type { DatabaseType, SQLDialect } from '@data-peek/shared'
+import { parseTabReferences } from './cross-tab-parser'
+import { resolveReferences, type ResolvableTab } from './cross-tab-resolver'
+import type { ResolveErrorKind, ResolveResult } from './cross-tab-types'
+import type { QueryTab, Tab } from '../stores/tab-store'
+
+/**
+ * Map a connection's DatabaseType to the escaper's SQLDialect.
+ * DatabaseType has 'sqlite' (no escaper dialect) — 'standard' gives bare
+ * VALUES and no ::type casts, which SQLite accepts.
+ */
+export function toSQLDialect(dbType: DatabaseType): SQLDialect {
+  switch (dbType) {
+    case 'postgresql':
+      return 'postgresql'
+    case 'mysql':
+      return 'mysql'
+    case 'mssql':
+      return 'mssql'
+    case 'sqlite':
+      return 'standard'
+  }
+}
+
+/** The active result set of a query tab: prefer the active multi-statement, else legacy result. */
+function activeResultOf(
+  tab: QueryTab
+): { rows: ReadonlyArray<Record<string, unknown>>; fields: ReadonlyArray<{ name: string; dataType: string }> } | null {
+  const statements = tab.multiResult?.statements
+  if (statements && statements.length > 0) {
+    const s = statements[tab.activeResultIndex] ?? statements[0]
+    if (s) return { rows: s.rows, fields: s.fields }
+  }
+  if (tab.result) return { rows: tab.result.rows, fields: tab.result.columns }
+  return null
+}
+
+/** Shape a query tab's current state into the resolver's ResolvableTab. */
+export function mapTabToResolvable(tab: QueryTab): ResolvableTab {
+  const name = tab.name ?? ''
+  if (tab.error) {
+    return { tabId: tab.id, name, result: { kind: 'error', message: tab.error } }
+  }
+  const active = activeResultOf(tab)
+  if (!active) {
+    return { tabId: tab.id, name, result: { kind: 'none' } }
+  }
+  return { tabId: tab.id, name, result: { kind: 'success', rows: active.rows, fields: active.fields } }
+}
+
+function namedQueryTabs(tabs: Tab[], connectionId: string | null, currentTabId: string): QueryTab[] {
+  return tabs.filter(
+    (t): t is QueryTab =>
+      t.type === 'query' &&
+      typeof t.name === 'string' &&
+      t.name !== '' &&
+      t.connectionId === connectionId &&
+      t.id !== currentTabId
+  )
+}
+
+/** Build the resolver's lookup: name → ResolvableTab, scoped to the connection, excluding the current tab. */
+export function buildTabLookup(
+  tabs: Tab[],
+  connectionId: string | null,
+  currentTabId: string
+): (name: string) => ResolvableTab | null {
+  const byName = new Map<string, QueryTab>()
+  for (const t of namedQueryTabs(tabs, connectionId, currentTabId)) {
+    byName.set(t.name as string, t)
+  }
+  return (name) => {
+    const tab = byName.get(name)
+    return tab ? mapTabToResolvable(tab) : null
+  }
+}
+
+export interface ResolveForRunSummary {
+  refCount: number
+  rowsInlined: number
+  bytesAdded: number
+  references: ResolveResult['references']
+}
+
+export type ResolveForRunResult =
+  | { ok: true; finalSql: string; summary: ResolveForRunSummary }
+  | { ok: false; error: ResolveErrorKind }
+
+export interface ResolveForRunContext {
+  dbType: DatabaseType
+  connectionId: string | null
+  currentTabId: string
+  tabs: Tab[]
+}
+
+/** Parse + resolve a query's @name references into a runnable SQL string. Pure. */
+export function resolveForRun(sql: string, ctx: ResolveForRunContext): ResolveForRunResult {
+  const knownNames =
+    ctx.dbType === 'mysql' || ctx.dbType === 'mssql'
+      ? new Set(namedQueryTabs(ctx.tabs, ctx.connectionId, ctx.currentTabId).map((t) => t.name as string))
+      : undefined
+
+  const parsed = parseTabReferences(sql, { dialect: ctx.dbType, knownNames })
+  if (parsed.references.length === 0) {
+    return { ok: true, finalSql: sql, summary: { refCount: 0, rowsInlined: 0, bytesAdded: 0, references: [] } }
+  }
+
+  const lookup = buildTabLookup(ctx.tabs, ctx.connectionId, ctx.currentTabId)
+  const resolved = resolveReferences(sql, parsed, {
+    lookup,
+    currentTabId: ctx.currentTabId,
+    dialect: toSQLDialect(ctx.dbType)
+  })
+  if (!resolved.ok) return { ok: false, error: resolved.error }
+
+  return {
+    ok: true,
+    finalSql: resolved.result.finalSql,
+    summary: {
+      refCount: resolved.result.references.length,
+      rowsInlined: resolved.result.rowsInlined,
+      bytesAdded: resolved.result.bytesAdded,
+      references: resolved.result.references
+    }
+  }
+}
+
+/** A named tab summarized for the Monaco editor (autocomplete/hover/markers). */
+export interface CrossTabRef {
+  name: string
+  tabTitle: string
+  rowCount: number
+  colCount: number
+  hasResult: boolean
+}
+
+/** Summarize the named tabs available to the current editor for the Monaco providers. */
+export function buildCrossTabRefs(tabs: Tab[], connectionId: string | null, currentTabId: string): CrossTabRef[] {
+  return namedQueryTabs(tabs, connectionId, currentTabId).map((t) => {
+    const active = activeResultOf(t)
+    return {
+      name: t.name as string,
+      tabTitle: t.title,
+      rowCount: active?.rows.length ?? 0,
+      colCount: active?.fields.length ?? 0,
+      hasResult: !!active && !t.error
+    }
+  })
+}
+
+/** Map a resolve error to a user-facing message shown in the tab error banner. */
+export function crossTabErrorMessage(error: ResolveErrorKind): string {
+  switch (error.kind) {
+    case 'unknown_reference':
+      return `No tab named @${error.name} on this connection.`
+    case 'no_result':
+      return `@${error.name} hasn't been run yet — run it first.`
+    case 'errored_result':
+      return `@${error.name}'s last run errored: ${error.error}`
+    case 'circular':
+      return `@${error.chain.join(' → @')} can't reference itself.`
+    case 'too_large':
+      return `@${error.name} has ${error.rows} rows (cap ${error.cap.rows}). Add a LIMIT to the referenced query.`
+    case 'too_many_columns':
+      return `@${error.name} has ${error.columns} columns (cap ${error.cap}).`
+    case 'duplicate_cte_name':
+      return `@${error.name} collides with a CTE already named in your query — rename one.`
+  }
+}

--- a/apps/desktop/src/renderer/src/lib/cross-tab-integration.ts
+++ b/apps/desktop/src/renderer/src/lib/cross-tab-integration.ts
@@ -171,9 +171,7 @@ export function resolveForRun(sql: string, ctx: ResolveForRunContext): ResolveFo
 export interface CrossTabRef {
   name: string
   tabTitle: string
-  rowCount: number
-  colCount: number
-  hasResult: boolean
+  result: { kind: 'ready'; rowCount: number; colCount: number } | { kind: 'not_run' }
 }
 
 /** Summarize the named tabs available to the current editor for the Monaco providers. */
@@ -184,14 +182,12 @@ export function buildCrossTabRefs(
 ): CrossTabRef[] {
   return namedQueryTabs(tabs, connectionId, currentTabId).map((t) => {
     const active = activeResultOf(t)
-    return {
-      name: t.name,
-      tabTitle: t.title,
-      rowCount: active?.rows.length ?? 0,
-      colCount: active?.fields.length ?? 0,
-      // error beats any stale result — same priority as mapTabToResolvable
-      hasResult: !!active && !t.error
-    }
+    // error beats any stale result — same priority as mapTabToResolvable
+    const result =
+      active && !t.error
+        ? { kind: 'ready' as const, rowCount: active.rows.length, colCount: active.fields.length }
+        : { kind: 'not_run' as const }
+    return { name: t.name, tabTitle: t.title, result }
   })
 }
 

--- a/apps/desktop/src/renderer/src/lib/cross-tab-integration.ts
+++ b/apps/desktop/src/renderer/src/lib/cross-tab-integration.ts
@@ -68,28 +68,36 @@ export function isNamedQueryTab(t: Tab): t is QueryTab & { name: string } {
   return t.type === 'query' && typeof t.name === 'string' && t.name !== ''
 }
 
+/** Named query tabs on the connection, including the current tab. */
+function namedQueryTabsOnConnection(
+  tabs: Tab[],
+  connectionId: string | null
+): Array<QueryTab & { name: string }> {
+  return tabs.filter(
+    (t): t is QueryTab & { name: string } => isNamedQueryTab(t) && t.connectionId === connectionId
+  )
+}
+
+/** ...same, excluding the current tab — the editor never suggests a self-reference. */
 function namedQueryTabs(
   tabs: Tab[],
   connectionId: string | null,
   currentTabId: string
 ): Array<QueryTab & { name: string }> {
-  return tabs.filter(
-    (t): t is QueryTab & { name: string } =>
-      isNamedQueryTab(t) && t.connectionId === connectionId && t.id !== currentTabId
-  )
+  return namedQueryTabsOnConnection(tabs, connectionId).filter((t) => t.id !== currentTabId)
 }
 
 /**
- * Build the resolver's lookup: name → ResolvableTab, scoped to the
- * connection, excluding the current tab.
+ * Build the resolver's lookup: name → ResolvableTab, scoped to the connection.
+ * The current tab is included so a self-reference resolves to its own tab and
+ * the resolver can emit `circular` (instead of a misleading `unknown_reference`).
  */
 export function buildTabLookup(
   tabs: Tab[],
-  connectionId: string | null,
-  currentTabId: string
+  connectionId: string | null
 ): (name: string) => ResolvableTab | null {
   const byName = new Map<string, QueryTab>()
-  for (const t of namedQueryTabs(tabs, connectionId, currentTabId)) {
+  for (const t of namedQueryTabsOnConnection(tabs, connectionId)) {
     byName.set(t.name, t)
   }
   return (name) => {
@@ -133,9 +141,12 @@ export interface ResolveForRunContext {
 
 /** Parse + resolve a query's @name references into a runnable SQL string. Pure. */
 export function resolveForRun(sql: string, ctx: ResolveForRunContext): ResolveForRunResult {
+  // Include the current tab's name so a self-reference (@self) is still parsed
+  // as a cross-tab ref on mysql/mssql and reaches the resolver's circular check,
+  // rather than being mistaken for a bare @variable and passed through.
   const knownNames =
     ctx.dbType === 'mysql' || ctx.dbType === 'mssql'
-      ? new Set(namedQueryTabs(ctx.tabs, ctx.connectionId, ctx.currentTabId).map((t) => t.name))
+      ? new Set(namedQueryTabsOnConnection(ctx.tabs, ctx.connectionId).map((t) => t.name))
       : undefined
 
   const parsed = parseTabReferences(sql, { dialect: ctx.dbType, knownNames })
@@ -147,7 +158,7 @@ export function resolveForRun(sql: string, ctx: ResolveForRunContext): ResolveFo
     }
   }
 
-  const lookup = buildTabLookup(ctx.tabs, ctx.connectionId, ctx.currentTabId)
+  const lookup = buildTabLookup(ctx.tabs, ctx.connectionId)
   const resolved = resolveReferences(sql, parsed, {
     lookup,
     currentTabId: ctx.currentTabId,
@@ -202,11 +213,14 @@ export function crossTabErrorMessage(error: ResolveErrorKind): string {
       return `@${error.name}'s last run errored: ${error.error}`
     case 'circular':
       return `@${error.chain.join(' → @')} can't reference itself.`
-    case 'too_large':
-      return (
-        `@${error.name} has ${error.rows} rows (cap ${error.cap.rows}). ` +
-        'Add a LIMIT to the referenced query.'
-      )
+    case 'too_large': {
+      // too_large fires on the row cap or the byte cap — name whichever was breached.
+      const overBytes = error.bytes > error.cap.bytes
+      const measure = overBytes
+        ? `${Math.round(error.bytes / 1024)}KB (cap ${Math.round(error.cap.bytes / 1024)}KB)`
+        : `${error.rows} rows (cap ${error.cap.rows})`
+      return `@${error.name} has ${measure}. Add a LIMIT to the referenced query.`
+    }
     case 'too_many_columns':
       return `@${error.name} has ${error.columns} columns (cap ${error.cap}).`
     case 'duplicate_cte_name':

--- a/apps/desktop/src/renderer/src/lib/cross-tab-integration.ts
+++ b/apps/desktop/src/renderer/src/lib/cross-tab-integration.ts
@@ -31,13 +31,16 @@ export function toSQLDialect(dbType: DatabaseType): SQLDialect {
 }
 
 /** The active result set of a query tab: prefer the active multi-statement, else legacy result. */
-function activeResultOf(
-  tab: QueryTab
-): { rows: ReadonlyArray<Record<string, unknown>>; fields: ReadonlyArray<{ name: string; dataType: string }> } | null {
+function activeResultOf(tab: QueryTab): {
+  rows: ReadonlyArray<Record<string, unknown>>
+  fields: ReadonlyArray<{ name: string; dataType: string }>
+} | null {
   const statements = tab.multiResult?.statements
   if (statements && statements.length > 0) {
-    const s = statements[tab.activeResultIndex] ?? statements[0]
-    if (s) return { rows: s.rows, fields: s.fields }
+    // Out-of-bounds activeResultIndex (e.g. a re-run produced fewer statements)
+    // → treat as no usable result rather than silently inlining the wrong one.
+    const s = tab.activeResultIndex < statements.length ? statements[tab.activeResultIndex] : null
+    return s ? { rows: s.rows, fields: s.fields } : null
   }
   if (tab.result) return { rows: tab.result.rows, fields: tab.result.columns }
   return null
@@ -53,12 +56,20 @@ export function mapTabToResolvable(tab: QueryTab): ResolvableTab {
   if (!active) {
     return { tabId: tab.id, name, result: { kind: 'none' } }
   }
-  return { tabId: tab.id, name, result: { kind: 'success', rows: active.rows, fields: active.fields } }
+  return {
+    tabId: tab.id,
+    name,
+    result: { kind: 'success', rows: active.rows, fields: active.fields }
+  }
 }
 
-function namedQueryTabs(tabs: Tab[], connectionId: string | null, currentTabId: string): QueryTab[] {
+function namedQueryTabs(
+  tabs: Tab[],
+  connectionId: string | null,
+  currentTabId: string
+): Array<QueryTab & { name: string }> {
   return tabs.filter(
-    (t): t is QueryTab =>
+    (t): t is QueryTab & { name: string } =>
       t.type === 'query' &&
       typeof t.name === 'string' &&
       t.name !== '' &&
@@ -75,7 +86,7 @@ export function buildTabLookup(
 ): (name: string) => ResolvableTab | null {
   const byName = new Map<string, QueryTab>()
   for (const t of namedQueryTabs(tabs, connectionId, currentTabId)) {
-    byName.set(t.name as string, t)
+    byName.set(t.name, t)
   }
   return (name) => {
     const tab = byName.get(name)
@@ -105,12 +116,16 @@ export interface ResolveForRunContext {
 export function resolveForRun(sql: string, ctx: ResolveForRunContext): ResolveForRunResult {
   const knownNames =
     ctx.dbType === 'mysql' || ctx.dbType === 'mssql'
-      ? new Set(namedQueryTabs(ctx.tabs, ctx.connectionId, ctx.currentTabId).map((t) => t.name as string))
+      ? new Set(namedQueryTabs(ctx.tabs, ctx.connectionId, ctx.currentTabId).map((t) => t.name))
       : undefined
 
   const parsed = parseTabReferences(sql, { dialect: ctx.dbType, knownNames })
   if (parsed.references.length === 0) {
-    return { ok: true, finalSql: sql, summary: { refCount: 0, rowsInlined: 0, bytesAdded: 0, references: [] } }
+    return {
+      ok: true,
+      finalSql: sql,
+      summary: { refCount: 0, rowsInlined: 0, bytesAdded: 0, references: [] }
+    }
   }
 
   const lookup = buildTabLookup(ctx.tabs, ctx.connectionId, ctx.currentTabId)
@@ -143,14 +158,19 @@ export interface CrossTabRef {
 }
 
 /** Summarize the named tabs available to the current editor for the Monaco providers. */
-export function buildCrossTabRefs(tabs: Tab[], connectionId: string | null, currentTabId: string): CrossTabRef[] {
+export function buildCrossTabRefs(
+  tabs: Tab[],
+  connectionId: string | null,
+  currentTabId: string
+): CrossTabRef[] {
   return namedQueryTabs(tabs, connectionId, currentTabId).map((t) => {
     const active = activeResultOf(t)
     return {
-      name: t.name as string,
+      name: t.name,
       tabTitle: t.title,
       rowCount: active?.rows.length ?? 0,
       colCount: active?.fields.length ?? 0,
+      // error beats any stale result — same priority as mapTabToResolvable
       hasResult: !!active && !t.error
     }
   })

--- a/apps/desktop/src/renderer/src/lib/cross-tab-integration.ts
+++ b/apps/desktop/src/renderer/src/lib/cross-tab-integration.ts
@@ -78,7 +78,10 @@ function namedQueryTabs(
   )
 }
 
-/** Build the resolver's lookup: name → ResolvableTab, scoped to the connection, excluding the current tab. */
+/**
+ * Build the resolver's lookup: name → ResolvableTab, scoped to the
+ * connection, excluding the current tab.
+ */
 export function buildTabLookup(
   tabs: Tab[],
   connectionId: string | null,
@@ -188,7 +191,10 @@ export function crossTabErrorMessage(error: ResolveErrorKind): string {
     case 'circular':
       return `@${error.chain.join(' → @')} can't reference itself.`
     case 'too_large':
-      return `@${error.name} has ${error.rows} rows (cap ${error.cap.rows}). Add a LIMIT to the referenced query.`
+      return (
+        `@${error.name} has ${error.rows} rows (cap ${error.cap.rows}). ` +
+        'Add a LIMIT to the referenced query.'
+      )
     case 'too_many_columns':
       return `@${error.name} has ${error.columns} columns (cap ${error.cap}).`
     case 'duplicate_cte_name':

--- a/apps/desktop/src/renderer/src/lib/cross-tab-integration.ts
+++ b/apps/desktop/src/renderer/src/lib/cross-tab-integration.ts
@@ -63,6 +63,11 @@ export function mapTabToResolvable(tab: QueryTab): ResolvableTab {
   }
 }
 
+/** True when the tab is a query tab carrying a non-empty cross-tab reference name. */
+export function isNamedQueryTab(t: Tab): t is QueryTab & { name: string } {
+  return t.type === 'query' && typeof t.name === 'string' && t.name !== ''
+}
+
 function namedQueryTabs(
   tabs: Tab[],
   connectionId: string | null,
@@ -70,11 +75,7 @@ function namedQueryTabs(
 ): Array<QueryTab & { name: string }> {
   return tabs.filter(
     (t): t is QueryTab & { name: string } =>
-      t.type === 'query' &&
-      typeof t.name === 'string' &&
-      t.name !== '' &&
-      t.connectionId === connectionId &&
-      t.id !== currentTabId
+      isNamedQueryTab(t) && t.connectionId === connectionId && t.id !== currentTabId
   )
 }
 
@@ -102,6 +103,21 @@ export interface ResolveForRunSummary {
   rowsInlined: number
   bytesAdded: number
   references: ResolveResult['references']
+}
+
+/**
+ * Default thresholds above which an inlined run prompts a confirm dialog.
+ * A UX heuristic for "this round-trip could be noticeably heavy" — separate
+ * from the resolver's hard ResolveCaps.
+ */
+export const HEAVY_RUN_DEFAULTS = { rows: 1000, bytes: 256 * 1024 }
+
+/** True when the inlined payload is large enough to warrant a pre-run confirmation. */
+export function isHeavyResolve(
+  summary: ResolveForRunSummary,
+  thresholds: { rows: number; bytes: number } = HEAVY_RUN_DEFAULTS
+): boolean {
+  return summary.rowsInlined > thresholds.rows || summary.bytesAdded > thresholds.bytes
 }
 
 export type ResolveForRunResult =

--- a/apps/desktop/src/renderer/src/lib/cross-tab-types.ts
+++ b/apps/desktop/src/renderer/src/lib/cross-tab-types.ts
@@ -24,11 +24,15 @@ export type RefNameValidationError =
   | { kind: 'invalid_chars'; detail: string }
   | { kind: 'reserved_word'; word: string }
   | { kind: 'duplicate'; conflictingTabId: string }
-  | { kind: 'not_a_query_tab' }
 
 export type RefNameValidationResult =
   | { ok: true; normalized: string }
   | { ok: false; error: RefNameValidationError }
+
+/** Result of TabStore.setTabName — name-validation outcomes plus the non-query-tab precondition. */
+export type SetTabNameResult =
+  | RefNameValidationResult
+  | { ok: false; error: { kind: 'not_a_query_tab' } }
 
 /**
  * A single `@name` token discovered in source SQL.

--- a/apps/desktop/src/renderer/src/lib/cross-tab-types.ts
+++ b/apps/desktop/src/renderer/src/lib/cross-tab-types.ts
@@ -24,6 +24,7 @@ export type RefNameValidationError =
   | { kind: 'invalid_chars'; detail: string }
   | { kind: 'reserved_word'; word: string }
   | { kind: 'duplicate'; conflictingTabId: string }
+  | { kind: 'not_a_query_tab' }
 
 export type RefNameValidationResult =
   | { ok: true; normalized: string }

--- a/apps/desktop/src/renderer/src/stores/__tests__/tab-store-naming.test.ts
+++ b/apps/desktop/src/renderer/src/stores/__tests__/tab-store-naming.test.ts
@@ -95,4 +95,29 @@ describe('tab-store cross-tab naming', () => {
     if (res.ok) return
     expect(res.error.kind).toBe('duplicate')
   })
+
+  it('drops a named tab’s name when moved onto a connection that already uses it', () => {
+    useTabStore.setState({
+      tabs: [
+        queryTab('a', 'conn2', { name: 'recent' }),
+        queryTab('b', 'conn1', { name: 'recent' })
+      ],
+      activeTabId: 'b'
+    })
+    useTabStore.getState().syncActiveTabWithConnection('conn2')
+    const moved = useTabStore.getState().getTab('b') as QueryTab
+    expect(moved.connectionId).toBe('conn2')
+    expect(moved.name).toBeUndefined()
+  })
+
+  it('keeps a named tab’s name when moved onto a connection where it is free', () => {
+    useTabStore.setState({
+      tabs: [queryTab('a', 'conn2', { name: 'other' }), queryTab('b', 'conn1', { name: 'recent' })],
+      activeTabId: 'b'
+    })
+    useTabStore.getState().syncActiveTabWithConnection('conn2')
+    const moved = useTabStore.getState().getTab('b') as QueryTab
+    expect(moved.connectionId).toBe('conn2')
+    expect(moved.name).toBe('recent')
+  })
 })

--- a/apps/desktop/src/renderer/src/stores/__tests__/tab-store-naming.test.ts
+++ b/apps/desktop/src/renderer/src/stores/__tests__/tab-store-naming.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useTabStore, type QueryTab } from '../tab-store'
+
+function queryTab(id: string, connectionId: string | null, overrides: Partial<QueryTab> = {}): QueryTab {
+  return {
+    id,
+    type: 'query',
+    title: 'Query',
+    isPinned: false,
+    connectionId,
+    createdAt: 0,
+    order: 0,
+    query: 'select 1',
+    savedQuery: '',
+    result: null,
+    multiResult: null,
+    activeResultIndex: 0,
+    error: null,
+    isExecuting: false,
+    executionId: null,
+    currentPage: 1,
+    pageSize: 100,
+    ...overrides
+  }
+}
+
+describe('tab-store cross-tab naming', () => {
+  beforeEach(() => {
+    useTabStore.setState({ tabs: [], activeTabId: null })
+  })
+
+  it('setTabName normalizes and stores a valid name', () => {
+    useTabStore.setState({ tabs: [queryTab('a', 'conn1')] })
+    const res = useTabStore.getState().setTabName('a', '  Active_Users  ')
+    expect(res.ok).toBe(true)
+    if (!res.ok) return
+    expect(res.normalized).toBe('active_users')
+    expect((useTabStore.getState().getTab('a') as QueryTab).name).toBe('active_users')
+  })
+
+  it('rejects a duplicate name on the same connection', () => {
+    useTabStore.setState({
+      tabs: [queryTab('a', 'conn1', { name: 'recent' }), queryTab('b', 'conn1')]
+    })
+    const res = useTabStore.getState().setTabName('b', 'recent')
+    expect(res.ok).toBe(false)
+    if (res.ok) return
+    expect(res.error.kind).toBe('duplicate')
+  })
+
+  it('allows the same name on a different connection', () => {
+    useTabStore.setState({
+      tabs: [queryTab('a', 'conn1', { name: 'recent' }), queryTab('b', 'conn2')]
+    })
+    const res = useTabStore.getState().setTabName('b', 'recent')
+    expect(res.ok).toBe(true)
+  })
+
+  it('rejects a reserved word', () => {
+    useTabStore.setState({ tabs: [queryTab('a', 'conn1')] })
+    const res = useTabStore.getState().setTabName('a', 'select')
+    expect(res.ok).toBe(false)
+    if (res.ok) return
+    expect(res.error.kind).toBe('reserved_word')
+  })
+
+  it('clearTabName removes the name', () => {
+    useTabStore.setState({ tabs: [queryTab('a', 'conn1', { name: 'recent' })] })
+    useTabStore.getState().clearTabName('a')
+    expect((useTabStore.getState().getTab('a') as QueryTab).name).toBeUndefined()
+  })
+
+  it('getNamedTabs returns only named query tabs on the connection', () => {
+    useTabStore.setState({
+      tabs: [
+        queryTab('a', 'conn1', { name: 'recent' }),
+        queryTab('b', 'conn1'),
+        queryTab('c', 'conn2', { name: 'other' })
+      ]
+    })
+    const named = useTabStore.getState().getNamedTabs('conn1')
+    expect(named.map((t) => t.id)).toEqual(['a'])
+  })
+})

--- a/apps/desktop/src/renderer/src/stores/__tests__/tab-store-naming.test.ts
+++ b/apps/desktop/src/renderer/src/stores/__tests__/tab-store-naming.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { useTabStore, type QueryTab } from '../tab-store'
 
-function queryTab(id: string, connectionId: string | null, overrides: Partial<QueryTab> = {}): QueryTab {
+function queryTab(
+  id: string,
+  connectionId: string | null,
+  overrides: Partial<QueryTab> = {}
+): QueryTab {
   return {
     id,
     type: 'query',
@@ -80,5 +84,27 @@ describe('tab-store cross-tab naming', () => {
     })
     const named = useTabStore.getState().getNamedTabs('conn1')
     expect(named.map((t) => t.id)).toEqual(['a'])
+  })
+
+  it('allows a tab to re-set its own existing name', () => {
+    useTabStore.setState({ tabs: [queryTab('a', 'conn1', { name: 'recent' })] })
+    const res = useTabStore.getState().setTabName('a', 'recent')
+    expect(res.ok).toBe(true)
+  })
+
+  it('names a tab with a null connection', () => {
+    useTabStore.setState({ tabs: [queryTab('a', null)] })
+    const res = useTabStore.getState().setTabName('a', 'scratch')
+    expect(res.ok).toBe(true)
+  })
+
+  it('treats two null-connection tabs as the same scope for duplicates', () => {
+    useTabStore.setState({
+      tabs: [queryTab('a', null, { name: 'scratch' }), queryTab('b', null)]
+    })
+    const res = useTabStore.getState().setTabName('b', 'scratch')
+    expect(res.ok).toBe(false)
+    if (res.ok) return
+    expect(res.error.kind).toBe('duplicate')
   })
 })

--- a/apps/desktop/src/renderer/src/stores/__tests__/tab-store-naming.test.ts
+++ b/apps/desktop/src/renderer/src/stores/__tests__/tab-store-naming.test.ts
@@ -74,18 +74,6 @@ describe('tab-store cross-tab naming', () => {
     expect((useTabStore.getState().getTab('a') as QueryTab).name).toBeUndefined()
   })
 
-  it('getNamedTabs returns only named query tabs on the connection', () => {
-    useTabStore.setState({
-      tabs: [
-        queryTab('a', 'conn1', { name: 'recent' }),
-        queryTab('b', 'conn1'),
-        queryTab('c', 'conn2', { name: 'other' })
-      ]
-    })
-    const named = useTabStore.getState().getNamedTabs('conn1')
-    expect(named.map((t) => t.id)).toEqual(['a'])
-  })
-
   it('allows a tab to re-set its own existing name', () => {
     useTabStore.setState({ tabs: [queryTab('a', 'conn1', { name: 'recent' })] })
     const res = useTabStore.getState().setTabName('a', 'recent')

--- a/apps/desktop/src/renderer/src/stores/tab-store.ts
+++ b/apps/desktop/src/renderer/src/stores/tab-store.ts
@@ -12,7 +12,7 @@ import { useConnectionStore } from './connection-store'
 import { useSettingsStore } from './settings-store'
 import { useEditStore } from './edit-store'
 import { validateRefName } from '@/lib/cross-tab-name-validation'
-import type { RefNameValidationResult } from '@/lib/cross-tab-types'
+import type { SetTabNameResult } from '@/lib/cross-tab-types'
 import { isNamedQueryTab } from '@/lib/cross-tab-integration'
 
 /**
@@ -254,7 +254,7 @@ interface TabState {
   renameTab: (tabId: string, title: string) => void
 
   // Cross-tab naming
-  setTabName: (tabId: string, name: string) => RefNameValidationResult
+  setTabName: (tabId: string, name: string) => SetTabNameResult
   clearTabName: (tabId: string) => void
 
   // Connection sync

--- a/apps/desktop/src/renderer/src/stores/tab-store.ts
+++ b/apps/desktop/src/renderer/src/stores/tab-store.ts
@@ -13,6 +13,7 @@ import { useSettingsStore } from './settings-store'
 import { useEditStore } from './edit-store'
 import { validateRefName } from '@/lib/cross-tab-name-validation'
 import type { RefNameValidationResult } from '@/lib/cross-tab-types'
+import { isNamedQueryTab } from '@/lib/cross-tab-integration'
 
 /**
  * Extended QueryResult with multi-statement support
@@ -255,7 +256,6 @@ interface TabState {
   // Cross-tab naming
   setTabName: (tabId: string, name: string) => RefNameValidationResult
   clearTabName: (tabId: string) => void
-  getNamedTabs: (connectionId: string | null) => QueryTab[]
 
   // Connection sync
   syncActiveTabWithConnection: (connectionId: string | null) => void
@@ -937,12 +937,7 @@ export const useTabStore = create<TabState>()(
         }
         const taken = new Map<string, string>()
         for (const t of get().tabs) {
-          if (
-            t.type === 'query' &&
-            t.connectionId === tab.connectionId &&
-            typeof t.name === 'string' &&
-            t.name
-          ) {
+          if (isNamedQueryTab(t) && t.connectionId === tab.connectionId) {
             taken.set(t.name, t.id)
           }
         }
@@ -961,16 +956,6 @@ export const useTabStore = create<TabState>()(
           )
           return tabs === state.tabs ? {} : { tabs }
         })
-      },
-
-      getNamedTabs: (connectionId) => {
-        return get().tabs.filter(
-          (t): t is QueryTab =>
-            t.type === 'query' &&
-            typeof t.name === 'string' &&
-            t.name !== '' &&
-            t.connectionId === connectionId
-        )
       },
 
       syncActiveTabWithConnection: (connectionId) => {

--- a/apps/desktop/src/renderer/src/stores/tab-store.ts
+++ b/apps/desktop/src/renderer/src/stores/tab-store.ts
@@ -181,6 +181,8 @@ interface PersistedTab {
   tableName?: string
   mode?: 'create' | 'edit'
   notebookId?: string
+  /** Cross-tab reference name (query tabs only). */
+  name?: string
 }
 
 interface TabState {
@@ -1166,7 +1168,8 @@ export const useTabStore = create<TabState>()(
               ...base,
               query: t.query,
               schemaName: t.type === 'table-preview' ? t.schemaName : undefined,
-              tableName: t.type === 'table-preview' ? t.tableName : undefined
+              tableName: t.type === 'table-preview' ? t.tableName : undefined,
+              name: t.type === 'query' ? t.name : undefined
             }
           }),
         activeTabId: state.activeTabId

--- a/apps/desktop/src/renderer/src/stores/tab-store.ts
+++ b/apps/desktop/src/renderer/src/stores/tab-store.ts
@@ -931,28 +931,34 @@ export const useTabStore = create<TabState>()(
       setTabName: (tabId, name) => {
         const tab = get().tabs.find((t) => t.id === tabId)
         if (!tab || tab.type !== 'query') {
-          return { ok: false, error: { kind: 'invalid_chars', detail: 'Only query tabs can be named.' } }
+          return { ok: false, error: { kind: 'not_a_query_tab' } }
         }
         const taken = new Map<string, string>()
         for (const t of get().tabs) {
-          if (t.type === 'query' && t.connectionId === tab.connectionId && typeof t.name === 'string' && t.name) {
+          if (
+            t.type === 'query' &&
+            t.connectionId === tab.connectionId &&
+            typeof t.name === 'string' &&
+            t.name
+          ) {
             taken.set(t.name, t.id)
           }
         }
         const result = validateRefName(name, { takenNames: taken, ownTabId: tabId })
         if (!result.ok) return result
         set((state) => ({
-          tabs: state.tabs.map((t) => (t.id === tabId ? { ...t, name: result.normalized } : t))
+          tabs: mapTab(state.tabs, tabId, (t) => ({ ...t, name: result.normalized }))
         }))
         return result
       },
 
       clearTabName: (tabId) => {
-        set((state) => ({
-          tabs: state.tabs.map((t) =>
-            t.id === tabId && t.type === 'query' ? { ...t, name: undefined } : t
+        set((state) => {
+          const tabs = mapTab(state.tabs, tabId, (t) =>
+            t.type === 'query' && t.name !== undefined ? { ...t, name: undefined } : t
           )
-        }))
+          return tabs === state.tabs ? {} : { tabs }
+        })
       },
 
       getNamedTabs: (connectionId) => {
@@ -1095,9 +1101,7 @@ export const useTabStore = create<TabState>()(
       },
 
       findSchemaIntelTab: (connectionId) => {
-        return get().tabs.find(
-          (t) => t.type === 'schema-intel' && t.connectionId === connectionId
-        )
+        return get().tabs.find((t) => t.type === 'schema-intel' && t.connectionId === connectionId)
       }
     }),
     {

--- a/apps/desktop/src/renderer/src/stores/tab-store.ts
+++ b/apps/desktop/src/renderer/src/stores/tab-store.ts
@@ -11,6 +11,8 @@ import {
 import { useConnectionStore } from './connection-store'
 import { useSettingsStore } from './settings-store'
 import { useEditStore } from './edit-store'
+import { validateRefName } from '@/lib/cross-tab-name-validation'
+import type { RefNameValidationResult } from '@/lib/cross-tab-types'
 
 /**
  * Extended QueryResult with multi-statement support
@@ -60,6 +62,8 @@ export interface QueryTab extends BaseTab {
   executionId: string | null // ID for cancellation support
   currentPage: number
   pageSize: number
+  /** User-assigned cross-tab reference name (e.g. used as @active_users). Query tabs only. */
+  name?: string
 }
 
 // Table preview tab
@@ -245,6 +249,11 @@ interface TabState {
 
   // Tab title
   renameTab: (tabId: string, title: string) => void
+
+  // Cross-tab naming
+  setTabName: (tabId: string, name: string) => RefNameValidationResult
+  clearTabName: (tabId: string) => void
+  getNamedTabs: (connectionId: string | null) => QueryTab[]
 
   // Connection sync
   syncActiveTabWithConnection: (connectionId: string | null) => void
@@ -917,6 +926,43 @@ export const useTabStore = create<TabState>()(
         set((state) => ({
           tabs: state.tabs.map((t) => (t.id === tabId ? { ...t, title } : t))
         }))
+      },
+
+      setTabName: (tabId, name) => {
+        const tab = get().tabs.find((t) => t.id === tabId)
+        if (!tab || tab.type !== 'query') {
+          return { ok: false, error: { kind: 'invalid_chars', detail: 'Only query tabs can be named.' } }
+        }
+        const taken = new Map<string, string>()
+        for (const t of get().tabs) {
+          if (t.type === 'query' && t.connectionId === tab.connectionId && typeof t.name === 'string' && t.name) {
+            taken.set(t.name, t.id)
+          }
+        }
+        const result = validateRefName(name, { takenNames: taken, ownTabId: tabId })
+        if (!result.ok) return result
+        set((state) => ({
+          tabs: state.tabs.map((t) => (t.id === tabId ? { ...t, name: result.normalized } : t))
+        }))
+        return result
+      },
+
+      clearTabName: (tabId) => {
+        set((state) => ({
+          tabs: state.tabs.map((t) =>
+            t.id === tabId && t.type === 'query' ? { ...t, name: undefined } : t
+          )
+        }))
+      },
+
+      getNamedTabs: (connectionId) => {
+        return get().tabs.filter(
+          (t): t is QueryTab =>
+            t.type === 'query' &&
+            typeof t.name === 'string' &&
+            t.name !== '' &&
+            t.connectionId === connectionId
+        )
       },
 
       syncActiveTabWithConnection: (connectionId) => {

--- a/apps/desktop/src/renderer/src/stores/tab-store.ts
+++ b/apps/desktop/src/renderer/src/stores/tab-store.ts
@@ -967,8 +967,25 @@ export const useTabStore = create<TabState>()(
         // ERD and table designer are also database-specific
         if (activeTab.type !== 'query') return
 
+        // A tab's @name is unique per connection. Moving a named tab onto a
+        // connection that already uses that name would make @name resolution
+        // ambiguous, so drop the name when it collides on the target connection.
+        let keepName = true
+        if (isNamedQueryTab(activeTab)) {
+          const taken = new Set<string>()
+          for (const t of get().tabs) {
+            if (isNamedQueryTab(t) && t.connectionId === connectionId && t.id !== activeTab.id) {
+              taken.add(t.name)
+            }
+          }
+          keepName = !taken.has(activeTab.name)
+        }
+
         set((state) => ({
-          tabs: state.tabs.map((t) => (t.id === activeTab.id ? { ...t, connectionId } : t))
+          tabs: state.tabs.map((t) => {
+            if (t.id !== activeTab.id || t.type !== 'query') return t
+            return { ...t, connectionId, name: keepName ? t.name : undefined }
+          })
         }))
       },
 

--- a/docs/superpowers/plans/2026-05-29-cross-tab-name-references.md
+++ b/docs/superpowers/plans/2026-05-29-cross-tab-name-references.md
@@ -1,0 +1,1424 @@
+# Cross-Tab `@name` References Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a user name a query tab's result `@active_users` and reference it from another tab's SQL, where the reference is inlined at run time as a `VALUES`-backed CTE — with editor autocomplete, hover preview, and inline diagnostics.
+
+**Architecture:** Renderer-only. PR #184 already shipped the pure parser/resolver/validation core; this plan adds the integration layer — a `name` field on query tabs, a pure `resolveForRun()` orchestrator that wires the tab store into the resolver, execution wiring in `handleRunQuery`, naming UI, and Monaco providers. The DB only ever sees the final rewritten SQL.
+
+**Tech Stack:** React 19, Zustand (`tab-store`), Monaco (`@monaco-editor/react` + `monaco-editor`), `@data-peek/ui` (shadcn Dialog/ContextMenu), Vitest. Helpers from `@data-peek/shared` (`escapeSQLIdentifier`, `isSQLKeyword`, `DatabaseType`, `SQLDialect`).
+
+**Spec:** `docs/superpowers/specs/2026-05-29-cross-tab-name-references-design.md`
+**Foundations (do not rebuild):** `lib/cross-tab-{parser,resolver,name-validation,types}.ts` from PR #184.
+
+---
+
+## Key facts established before planning (read these first)
+
+1. **Tabs are a flat array** `tabs: Tab[]` in `tab-store.ts`. `QueryTab` (exported) extends `BaseTab`; there is **no `name` field yet** anywhere. `Tab` is the discriminated union; `getTab(tabId)` reads one.
+2. **`DatabaseType` ≠ `SQLDialect`.** `DatabaseType = 'postgresql' | 'mysql' | 'sqlite' | 'mssql'`. `SQLDialect = 'postgresql' | 'mysql' | 'mssql' | 'standard'`. The **parser** takes `DatabaseType`; the **resolver** takes `SQLDialect`. `sqlite` must map to `'standard'` (bare `VALUES`, no `::` casts — SQLite accepts both).
+3. **A query tab's active result:** prefer `tab.multiResult.statements[tab.activeResultIndex]` (`{ rows, fields }`); fall back to legacy `tab.result` (`{ rows, columns }`). `QueryResult.columns` and `StatementResult.fields` are both `{ name, dataType }[]` — a direct shape match for the resolver's `ResolvableTab.fields`.
+4. **MySQL/MSSQL `@var` collision:** in those dialects `@name` is also user-variable syntax. The parser's `knownNames` option suppresses non-matching `@name` tokens. Pass `knownNames` **only** for `mysql`/`mssql` (so `@count`/`@offset` aren't hijacked); leave it `undefined` for `postgresql`/`sqlite` so unknown names surface as `unknown_reference` errors.
+5. **Persistence:** only **pinned** tabs persist. `partialize` hand-builds `PersistedTab`; `onRehydrateStorage` reconstructs via `{ ...t, <resets> }` — so a field added to `PersistedTab` + written in `partialize` flows back automatically through the `...t` spread.
+6. **Run path:** `handleRunQuery` (`tab-query-editor.tsx:313`). `queryToRun` at `:324`; `executionId` + `updateTabExecuting` at `:327-328`; `window.api.db.queryWithTelemetry(tabConnection, queryToRun, executionId, queryTimeoutMs)` at `:344`. Errors are written with `updateTabMultiResult(tabId, null, msg)`. `tabConnection.dbType` is the database type.
+7. **Monaco pattern:** `sql-editor.tsx` registers a **singleton** completion provider (`ensureCompletionProvider`) once, reading module-level state (`currentSchemas`) refreshed by the active editor via `useEffect`. We mirror this exactly.
+8. **Toolbar slot:** `EditorToolbar` already accepts `watchSlot?: ReactNode` (rendered inline). We add a sibling `refsSlot?: ReactNode`.
+9. **Dialog/ContextMenu** come from `@data-peek/ui`. Controlled `open` / `onOpenChange`.
+
+**Scope note (trim vs. spec §5):** v1 ships completion + hover + diagnostic squiggles. The optional accent *token coloring* (a Monaco decoration needing a global CSS class) is deferred as polish — the squiggle + hover already deliver the signal. Everything else in the spec stands.
+
+---
+
+## File structure
+
+```
+stores/tab-store.ts                                   (edit) name field, setTabName/clearTabName/getNamedTabs, persistence
+stores/__tests__/tab-store-naming.test.ts             (new)  store action tests
+lib/cross-tab-integration.ts                          (new)  toSQLDialect, mapTabToResolvable, buildTabLookup, resolveForRun, buildCrossTabRefs, crossTabErrorMessage, CrossTabRef type
+lib/__tests__/cross-tab-integration.test.ts           (new)  pure-logic tests
+components/cross-tab/cross-tab-editor.ts              (new)  Monaco completion/hover/markers + module state
+components/cross-tab/__tests__/cross-tab-editor.test.ts (new) pure-helper tests
+components/cross-tab/cross-tab-submit-dialog.tsx     (new)  threshold confirm dialog
+components/sql-editor.tsx                              (edit) crossTabRefs/crossTabDialect props + provider registration + markers
+components/tab.tsx                                     (edit) @name display + "Name as @…" + inline rename input
+components/query-editor/editor-toolbar.tsx            (edit) refsSlot prop
+components/tab-query-editor.tsx                        (edit) wire resolveForRun, confirm dialog, refs pill, push editor context
+```
+
+---
+
+## Phase A — Naming foundation (store)
+
+### Task 1: `name` field + store actions + selector
+
+**Files:**
+- Modify: `apps/desktop/src/renderer/src/stores/tab-store.ts`
+- Test: `apps/desktop/src/renderer/src/stores/__tests__/tab-store-naming.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/desktop/src/renderer/src/stores/__tests__/tab-store-naming.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useTabStore, type QueryTab } from '../tab-store'
+
+function queryTab(id: string, connectionId: string | null, overrides: Partial<QueryTab> = {}): QueryTab {
+  return {
+    id,
+    type: 'query',
+    title: 'Query',
+    isPinned: false,
+    connectionId,
+    createdAt: 0,
+    order: 0,
+    query: 'select 1',
+    savedQuery: '',
+    result: null,
+    multiResult: null,
+    activeResultIndex: 0,
+    error: null,
+    isExecuting: false,
+    executionId: null,
+    currentPage: 1,
+    pageSize: 100,
+    ...overrides
+  }
+}
+
+describe('tab-store cross-tab naming', () => {
+  beforeEach(() => {
+    useTabStore.setState({ tabs: [], activeTabId: null })
+  })
+
+  it('setTabName normalizes and stores a valid name', () => {
+    useTabStore.setState({ tabs: [queryTab('a', 'conn1')] })
+    const res = useTabStore.getState().setTabName('a', '  Active_Users  ')
+    expect(res.ok).toBe(true)
+    if (!res.ok) return
+    expect(res.normalized).toBe('active_users')
+    expect((useTabStore.getState().getTab('a') as QueryTab).name).toBe('active_users')
+  })
+
+  it('rejects a duplicate name on the same connection', () => {
+    useTabStore.setState({
+      tabs: [queryTab('a', 'conn1', { name: 'recent' }), queryTab('b', 'conn1')]
+    })
+    const res = useTabStore.getState().setTabName('b', 'recent')
+    expect(res.ok).toBe(false)
+    if (res.ok) return
+    expect(res.error.kind).toBe('duplicate')
+  })
+
+  it('allows the same name on a different connection', () => {
+    useTabStore.setState({
+      tabs: [queryTab('a', 'conn1', { name: 'recent' }), queryTab('b', 'conn2')]
+    })
+    const res = useTabStore.getState().setTabName('b', 'recent')
+    expect(res.ok).toBe(true)
+  })
+
+  it('rejects a reserved word', () => {
+    useTabStore.setState({ tabs: [queryTab('a', 'conn1')] })
+    const res = useTabStore.getState().setTabName('a', 'select')
+    expect(res.ok).toBe(false)
+    if (res.ok) return
+    expect(res.error.kind).toBe('reserved_word')
+  })
+
+  it('clearTabName removes the name', () => {
+    useTabStore.setState({ tabs: [queryTab('a', 'conn1', { name: 'recent' })] })
+    useTabStore.getState().clearTabName('a')
+    expect((useTabStore.getState().getTab('a') as QueryTab).name).toBeUndefined()
+  })
+
+  it('getNamedTabs returns only named query tabs on the connection', () => {
+    useTabStore.setState({
+      tabs: [
+        queryTab('a', 'conn1', { name: 'recent' }),
+        queryTab('b', 'conn1'),
+        queryTab('c', 'conn2', { name: 'other' })
+      ]
+    })
+    const named = useTabStore.getState().getNamedTabs('conn1')
+    expect(named.map((t) => t.id)).toEqual(['a'])
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm --filter @data-peek/desktop test src/renderer/src/stores/__tests__/tab-store-naming.test.ts`
+Expected: FAIL — `setTabName is not a function` (and `name` missing from `QueryTab`).
+
+- [ ] **Step 3: Add the `name` field to `QueryTab`**
+
+In `tab-store.ts`, in the `QueryTab` interface (after `pageSize: number`):
+
+```ts
+  currentPage: number
+  pageSize: number
+  /** User-assigned cross-tab reference name (e.g. used as @active_users). Query tabs only. */
+  name?: string
+```
+
+- [ ] **Step 4: Add imports for validation at the top of `tab-store.ts`**
+
+Add alongside the existing imports:
+
+```ts
+import { validateRefName } from '@/lib/cross-tab-name-validation'
+import type { RefNameValidationResult } from '@/lib/cross-tab-types'
+```
+
+- [ ] **Step 5: Declare the actions in the store interface**
+
+In the `TabState` interface, near `renameTab`, add:
+
+```ts
+  setTabName: (tabId: string, name: string) => RefNameValidationResult
+  clearTabName: (tabId: string) => void
+  getNamedTabs: (connectionId: string | null) => QueryTab[]
+```
+
+- [ ] **Step 6: Implement the actions**
+
+In the store implementation, after `renameTab` (lines ~916-920), add:
+
+```ts
+      setTabName: (tabId, name) => {
+        const tab = get().tabs.find((t) => t.id === tabId)
+        if (!tab || tab.type !== 'query') {
+          return { ok: false, error: { kind: 'invalid_chars', detail: 'Only query tabs can be named.' } }
+        }
+        const taken = new Map<string, string>()
+        for (const t of get().tabs) {
+          if (t.type === 'query' && t.connectionId === tab.connectionId && typeof t.name === 'string' && t.name) {
+            taken.set(t.name, t.id)
+          }
+        }
+        const result = validateRefName(name, { takenNames: taken, ownTabId: tabId })
+        if (!result.ok) return result
+        set((state) => ({
+          tabs: state.tabs.map((t) => (t.id === tabId ? { ...t, name: result.normalized } : t))
+        }))
+        return result
+      },
+
+      clearTabName: (tabId) => {
+        set((state) => ({
+          tabs: state.tabs.map((t) =>
+            t.id === tabId && t.type === 'query' ? { ...t, name: undefined } : t
+          )
+        }))
+      },
+
+      getNamedTabs: (connectionId) => {
+        return get().tabs.filter(
+          (t): t is QueryTab =>
+            t.type === 'query' &&
+            typeof t.name === 'string' &&
+            t.name !== '' &&
+            t.connectionId === connectionId
+        )
+      },
+```
+
+- [ ] **Step 7: Run the test to verify it passes**
+
+Run: `pnpm --filter @data-peek/desktop test src/renderer/src/stores/__tests__/tab-store-naming.test.ts`
+Expected: PASS (6 tests).
+
+- [ ] **Step 8: Typecheck**
+
+Run: `pnpm --filter @data-peek/desktop typecheck:web`
+Expected: no errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/desktop/src/renderer/src/stores/tab-store.ts apps/desktop/src/renderer/src/stores/__tests__/tab-store-naming.test.ts
+git commit -m "feat(cross-tab): tab name field + setTabName/clearTabName/getNamedTabs"
+```
+
+---
+
+### Task 2: Persist the name for pinned tabs
+
+**Files:**
+- Modify: `apps/desktop/src/renderer/src/stores/tab-store.ts`
+
+This is persistence glue; verified by typecheck + manual reload (no unit test — persistence round-trips through `localStorage` and the rehydrate path).
+
+- [ ] **Step 1: Add `name` to the `PersistedTab` interface**
+
+In `PersistedTab` (lines ~167-180), after `notebookId?: string`:
+
+```ts
+  notebookId?: string
+  /** Cross-tab reference name (query tabs only). */
+  name?: string
+```
+
+- [ ] **Step 2: Write `name` in `partialize`**
+
+In the `partialize` query/table-preview branch (the `return { ...base, query: t.query, ... }` near line 1100), add `name`:
+
+```ts
+            // query or table-preview tabs
+            return {
+              ...base,
+              query: t.query,
+              schemaName: t.type === 'table-preview' ? t.schemaName : undefined,
+              tableName: t.type === 'table-preview' ? t.tableName : undefined,
+              name: t.type === 'query' ? t.name : undefined
+            }
+```
+
+(Rehydration is automatic: `onRehydrateStorage` builds `base = { ...t, <resets> }`, so a persisted `name` flows through the `...t` spread into the reconstructed query tab.)
+
+- [ ] **Step 3: Typecheck**
+
+Run: `pnpm --filter @data-peek/desktop typecheck:web`
+Expected: no errors.
+
+- [ ] **Step 4: Manual verification**
+
+(Requires the dev server — ask the user before starting it.) Pin a query tab, name it via the context menu (after Task 6), reload the app, confirm the `@name` survives on the pinned tab.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/desktop/src/renderer/src/stores/tab-store.ts
+git commit -m "feat(cross-tab): persist tab name for pinned tabs"
+```
+
+---
+
+## Phase B — Resolution integration (pure lib)
+
+### Task 3: `cross-tab-integration.ts` — the resolution orchestrator
+
+**Files:**
+- Create: `apps/desktop/src/renderer/src/lib/cross-tab-integration.ts`
+- Test: `apps/desktop/src/renderer/src/lib/__tests__/cross-tab-integration.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/desktop/src/renderer/src/lib/__tests__/cross-tab-integration.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import {
+  toSQLDialect,
+  mapTabToResolvable,
+  buildTabLookup,
+  resolveForRun,
+  buildCrossTabRefs,
+  crossTabErrorMessage
+} from '../cross-tab-integration'
+import type { QueryTab, Tab } from '../../stores/tab-store'
+
+function qtab(id: string, connectionId: string | null, o: Partial<QueryTab> = {}): QueryTab {
+  return {
+    id, type: 'query', title: 'Query', isPinned: false, connectionId,
+    createdAt: 0, order: 0, query: '', savedQuery: '',
+    result: null, multiResult: null, activeResultIndex: 0, error: null,
+    isExecuting: false, executionId: null, currentPage: 1, pageSize: 100, ...o
+  }
+}
+
+const RES = {
+  columns: [{ name: 'id', dataType: 'integer' }, { name: 'email', dataType: 'text' }],
+  rows: [{ id: 1, email: 'a@x.com' }, { id: 2, email: 'b@x.com' }],
+  rowCount: 2,
+  durationMs: 1
+}
+
+describe('toSQLDialect', () => {
+  it('maps database types to escaper dialects (sqlite → standard)', () => {
+    expect(toSQLDialect('postgresql')).toBe('postgresql')
+    expect(toSQLDialect('mysql')).toBe('mysql')
+    expect(toSQLDialect('mssql')).toBe('mssql')
+    expect(toSQLDialect('sqlite')).toBe('standard')
+  })
+})
+
+describe('mapTabToResolvable', () => {
+  it('maps a successful legacy result to kind:success with fields from columns', () => {
+    const r = mapTabToResolvable(qtab('a', 'c1', { name: 'u', result: RES }))
+    expect(r.result.kind).toBe('success')
+    if (r.result.kind !== 'success') return
+    expect(r.result.rows).toHaveLength(2)
+    expect(r.result.fields).toEqual(RES.columns)
+  })
+
+  it('prefers the active multiResult statement over legacy result', () => {
+    const tab = qtab('a', 'c1', {
+      name: 'u',
+      result: RES,
+      activeResultIndex: 1,
+      multiResult: {
+        statements: [
+          { rows: [], fields: [], rowCount: 0 },
+          { rows: [{ x: 9 }], fields: [{ name: 'x', dataType: 'integer' }], rowCount: 1 }
+        ],
+        totalDurationMs: 1,
+        statementCount: 2
+      } as QueryTab['multiResult']
+    })
+    const r = mapTabToResolvable(tab)
+    expect(r.result.kind).toBe('success')
+    if (r.result.kind !== 'success') return
+    expect(r.result.rows).toEqual([{ x: 9 }])
+  })
+
+  it('maps an error to kind:error', () => {
+    const r = mapTabToResolvable(qtab('a', 'c1', { name: 'u', error: 'boom' }))
+    expect(r.result).toEqual({ kind: 'error', message: 'boom' })
+  })
+
+  it('maps a never-run tab to kind:none', () => {
+    const r = mapTabToResolvable(qtab('a', 'c1', { name: 'u' }))
+    expect(r.result).toEqual({ kind: 'none' })
+  })
+})
+
+describe('buildTabLookup', () => {
+  const tabs: Tab[] = [
+    qtab('a', 'c1', { name: 'recent', result: RES }),
+    qtab('b', 'c1'),
+    qtab('c', 'c2', { name: 'recent', result: RES }),
+    qtab('self', 'c1', { name: 'me', result: RES })
+  ]
+  it('finds a named tab on the same connection', () => {
+    const lookup = buildTabLookup(tabs, 'c1', 'b')
+    expect(lookup('recent')?.tabId).toBe('a')
+  })
+  it('does not cross connections', () => {
+    const lookup = buildTabLookup(tabs, 'c1', 'b')
+    // 'recent' on c1 resolves to a, never c (which is c2)
+    expect(lookup('recent')?.tabId).toBe('a')
+  })
+  it('excludes the current tab (no self-reference via lookup)', () => {
+    const lookup = buildTabLookup(tabs, 'c1', 'self')
+    expect(lookup('me')).toBeNull()
+  })
+  it('returns null for an unknown name', () => {
+    const lookup = buildTabLookup(tabs, 'c1', 'b')
+    expect(lookup('nope')).toBeNull()
+  })
+})
+
+describe('resolveForRun', () => {
+  const tabs: Tab[] = [qtab('a', 'c1', { name: 'active_users', result: RES })]
+
+  it('passes through SQL with no references', () => {
+    const r = resolveForRun('SELECT 1', { dbType: 'postgresql', connectionId: 'c1', currentTabId: 'b', tabs })
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.finalSql).toBe('SELECT 1')
+    expect(r.summary.refCount).toBe(0)
+  })
+
+  it('resolves a reference into a CTE (postgres)', () => {
+    const r = resolveForRun('SELECT * FROM @active_users', { dbType: 'postgresql', connectionId: 'c1', currentTabId: 'b', tabs })
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.finalSql).toContain('WITH')
+    expect(r.finalSql).toContain('active_users')
+    expect(r.finalSql).not.toContain('@active_users')
+    expect(r.summary.refCount).toBe(1)
+    expect(r.summary.rowsInlined).toBe(2)
+  })
+
+  it('resolves across all dialects without throwing', () => {
+    for (const dbType of ['postgresql', 'mysql', 'mssql', 'sqlite'] as const) {
+      const r = resolveForRun('SELECT * FROM @active_users', { dbType, connectionId: 'c1', currentTabId: 'b', tabs })
+      expect(r.ok).toBe(true)
+      if (!r.ok) return
+      expect(r.finalSql).not.toContain('@active_users')
+    }
+  })
+
+  it('reports unknown_reference on postgres for a missing name', () => {
+    const r = resolveForRun('SELECT * FROM @ghost', { dbType: 'postgresql', connectionId: 'c1', currentTabId: 'b', tabs })
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(r.error.kind).toBe('unknown_reference')
+  })
+
+  it('on mysql, ignores @vars that are not named tabs (no error)', () => {
+    const r = resolveForRun('SELECT @offset, * FROM @active_users', { dbType: 'mysql', connectionId: 'c1', currentTabId: 'b', tabs })
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.finalSql).toContain('@offset') // left intact as a user-variable
+    expect(r.finalSql).not.toContain('@active_users') // resolved
+  })
+})
+
+describe('buildCrossTabRefs', () => {
+  it('summarizes named query tabs on the connection (excluding current)', () => {
+    const tabs: Tab[] = [
+      qtab('a', 'c1', { name: 'active_users', title: 'Users', result: RES }),
+      qtab('b', 'c1', { name: 'pending' }), // no result yet
+      qtab('cur', 'c1', { name: 'self', result: RES })
+    ]
+    const refs = buildCrossTabRefs(tabs, 'c1', 'cur')
+    expect(refs).toEqual([
+      { name: 'active_users', tabTitle: 'Users', rowCount: 2, colCount: 2, hasResult: true },
+      { name: 'pending', tabTitle: 'Query', rowCount: 0, colCount: 0, hasResult: false }
+    ])
+  })
+})
+
+describe('crossTabErrorMessage', () => {
+  it('renders each error kind', () => {
+    expect(crossTabErrorMessage({ kind: 'unknown_reference', name: 'x' })).toBe('No tab named @x on this connection.')
+    expect(crossTabErrorMessage({ kind: 'no_result', name: 'x' })).toContain("hasn't been run")
+    expect(crossTabErrorMessage({ kind: 'circular', chain: ['x'] })).toContain('reference itself')
+    expect(crossTabErrorMessage({ kind: 'too_large', name: 'x', rows: 5, bytes: 1, cap: { rows: 4, bytes: 9 } })).toContain('cap 4')
+    expect(crossTabErrorMessage({ kind: 'too_many_columns', name: 'x', columns: 200, cap: 100 })).toContain('200 columns')
+    expect(crossTabErrorMessage({ kind: 'duplicate_cte_name', name: 'x' })).toContain('collides')
+    expect(crossTabErrorMessage({ kind: 'errored_result', name: 'x', error: 'oops' })).toContain('oops')
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm --filter @data-peek/desktop test src/renderer/src/lib/__tests__/cross-tab-integration.test.ts`
+Expected: FAIL — `Cannot find module '../cross-tab-integration'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `apps/desktop/src/renderer/src/lib/cross-tab-integration.ts`:
+
+```ts
+/**
+ * Cross-Tab integration layer.
+ *
+ * The seam between the renderer (tab store, query execution, Monaco) and the
+ * pure parser/resolver shipped in #184. Everything here is pure and unit-
+ * tested; React/store wiring lives in the components that call resolveForRun.
+ */
+
+import type { DatabaseType, SQLDialect } from '@data-peek/shared'
+import { parseTabReferences } from './cross-tab-parser'
+import { resolveReferences, type ResolvableTab } from './cross-tab-resolver'
+import type { ResolveErrorKind, ResolveResult } from './cross-tab-types'
+import type { QueryTab, Tab } from '../stores/tab-store'
+
+/**
+ * Map a connection's DatabaseType to the escaper's SQLDialect.
+ * DatabaseType has 'sqlite' (no escaper dialect) — 'standard' gives bare
+ * VALUES and no ::type casts, which SQLite accepts.
+ */
+export function toSQLDialect(dbType: DatabaseType): SQLDialect {
+  switch (dbType) {
+    case 'postgresql':
+      return 'postgresql'
+    case 'mysql':
+      return 'mysql'
+    case 'mssql':
+      return 'mssql'
+    case 'sqlite':
+      return 'standard'
+  }
+}
+
+/** The active result set of a query tab: prefer the active multi-statement, else legacy result. */
+function activeResultOf(
+  tab: QueryTab
+): { rows: ReadonlyArray<Record<string, unknown>>; fields: ReadonlyArray<{ name: string; dataType: string }> } | null {
+  const statements = tab.multiResult?.statements
+  if (statements && statements.length > 0) {
+    const s = statements[tab.activeResultIndex] ?? statements[0]
+    if (s) return { rows: s.rows, fields: s.fields }
+  }
+  if (tab.result) return { rows: tab.result.rows, fields: tab.result.columns }
+  return null
+}
+
+/** Shape a query tab's current state into the resolver's ResolvableTab. */
+export function mapTabToResolvable(tab: QueryTab): ResolvableTab {
+  const name = tab.name ?? ''
+  if (tab.error) {
+    return { tabId: tab.id, name, result: { kind: 'error', message: tab.error } }
+  }
+  const active = activeResultOf(tab)
+  if (!active) {
+    return { tabId: tab.id, name, result: { kind: 'none' } }
+  }
+  return { tabId: tab.id, name, result: { kind: 'success', rows: active.rows, fields: active.fields } }
+}
+
+function namedQueryTabs(tabs: Tab[], connectionId: string | null, currentTabId: string): QueryTab[] {
+  return tabs.filter(
+    (t): t is QueryTab =>
+      t.type === 'query' &&
+      typeof t.name === 'string' &&
+      t.name !== '' &&
+      t.connectionId === connectionId &&
+      t.id !== currentTabId
+  )
+}
+
+/** Build the resolver's lookup: name → ResolvableTab, scoped to the connection, excluding the current tab. */
+export function buildTabLookup(
+  tabs: Tab[],
+  connectionId: string | null,
+  currentTabId: string
+): (name: string) => ResolvableTab | null {
+  const byName = new Map<string, QueryTab>()
+  for (const t of namedQueryTabs(tabs, connectionId, currentTabId)) {
+    byName.set(t.name as string, t)
+  }
+  return (name) => {
+    const tab = byName.get(name)
+    return tab ? mapTabToResolvable(tab) : null
+  }
+}
+
+export interface ResolveForRunSummary {
+  refCount: number
+  rowsInlined: number
+  bytesAdded: number
+  references: ResolveResult['references']
+}
+
+export type ResolveForRunResult =
+  | { ok: true; finalSql: string; summary: ResolveForRunSummary }
+  | { ok: false; error: ResolveErrorKind }
+
+export interface ResolveForRunContext {
+  dbType: DatabaseType
+  connectionId: string | null
+  currentTabId: string
+  tabs: Tab[]
+}
+
+/** Parse + resolve a query's @name references into a runnable SQL string. Pure. */
+export function resolveForRun(sql: string, ctx: ResolveForRunContext): ResolveForRunResult {
+  // MySQL/MSSQL: @name is also user-variable syntax. Restrict references to
+  // currently-named tabs so @count/@offset aren't captured. PG/SQLite: leave
+  // knownNames undefined so unknown @names surface as unknown_reference.
+  const knownNames =
+    ctx.dbType === 'mysql' || ctx.dbType === 'mssql'
+      ? new Set(namedQueryTabs(ctx.tabs, ctx.connectionId, ctx.currentTabId).map((t) => t.name as string))
+      : undefined
+
+  const parsed = parseTabReferences(sql, { dialect: ctx.dbType, knownNames })
+  if (parsed.references.length === 0) {
+    return { ok: true, finalSql: sql, summary: { refCount: 0, rowsInlined: 0, bytesAdded: 0, references: [] } }
+  }
+
+  const lookup = buildTabLookup(ctx.tabs, ctx.connectionId, ctx.currentTabId)
+  const resolved = resolveReferences(sql, parsed, {
+    lookup,
+    currentTabId: ctx.currentTabId,
+    dialect: toSQLDialect(ctx.dbType)
+  })
+  if (!resolved.ok) return { ok: false, error: resolved.error }
+
+  return {
+    ok: true,
+    finalSql: resolved.result.finalSql,
+    summary: {
+      refCount: resolved.result.references.length,
+      rowsInlined: resolved.result.rowsInlined,
+      bytesAdded: resolved.result.bytesAdded,
+      references: resolved.result.references
+    }
+  }
+}
+
+/** A named tab summarized for the Monaco editor (autocomplete/hover/markers). */
+export interface CrossTabRef {
+  name: string
+  tabTitle: string
+  rowCount: number
+  colCount: number
+  hasResult: boolean
+}
+
+/** Summarize the named tabs available to the current editor for the Monaco providers. */
+export function buildCrossTabRefs(tabs: Tab[], connectionId: string | null, currentTabId: string): CrossTabRef[] {
+  return namedQueryTabs(tabs, connectionId, currentTabId).map((t) => {
+    const active = activeResultOf(t)
+    return {
+      name: t.name as string,
+      tabTitle: t.title,
+      rowCount: active?.rows.length ?? 0,
+      colCount: active?.fields.length ?? 0,
+      hasResult: !!active && !t.error
+    }
+  })
+}
+
+/** Map a resolve error to a user-facing message shown in the tab error banner. */
+export function crossTabErrorMessage(error: ResolveErrorKind): string {
+  switch (error.kind) {
+    case 'unknown_reference':
+      return `No tab named @${error.name} on this connection.`
+    case 'no_result':
+      return `@${error.name} hasn't been run yet — run it first.`
+    case 'errored_result':
+      return `@${error.name}'s last run errored: ${error.error}`
+    case 'circular':
+      return `@${error.chain.join(' → @')} can't reference itself.`
+    case 'too_large':
+      return `@${error.name} has ${error.rows} rows (cap ${error.cap.rows}). Add a LIMIT to the referenced query.`
+    case 'too_many_columns':
+      return `@${error.name} has ${error.columns} columns (cap ${error.cap}).`
+    case 'duplicate_cte_name':
+      return `@${error.name} collides with a CTE already named in your query — rename one.`
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm --filter @data-peek/desktop test src/renderer/src/lib/__tests__/cross-tab-integration.test.ts`
+Expected: PASS (all blocks).
+
+- [ ] **Step 5: Typecheck**
+
+Run: `pnpm --filter @data-peek/desktop typecheck:web`
+Expected: no errors. (If `Tab` is not exported from `tab-store.ts`, add `export` to its `type Tab = …` declaration as part of this task.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/desktop/src/renderer/src/lib/cross-tab-integration.ts apps/desktop/src/renderer/src/lib/__tests__/cross-tab-integration.test.ts
+git commit -m "feat(cross-tab): resolveForRun integration layer + error messages"
+```
+
+---
+
+## Phase C — Execution wiring
+
+### Task 4: Wire `resolveForRun` into `handleRunQuery`
+
+**Files:**
+- Modify: `apps/desktop/src/renderer/src/components/tab-query-editor.tsx`
+
+Verified by typecheck + manual (the pure logic is already covered in Task 3). The confirm dialog is added in Task 5; this task runs every resolved query immediately and shows the error banner on failure.
+
+- [ ] **Step 1: Add the import**
+
+Near the other `@/lib` imports in `tab-query-editor.tsx`:
+
+```ts
+import { resolveForRun, crossTabErrorMessage } from '@/lib/cross-tab-integration'
+```
+
+- [ ] **Step 2: Resolve references before execution**
+
+In `handleRunQuery`, immediately **after** the `queryToRun` line (`const queryToRun = (selectedSql ?? currentTab.query).trim()` / `if (!queryToRun) return`) and **before** `const executionId = crypto.randomUUID()`:
+
+```ts
+      // Resolve @name cross-tab references into VALUES-backed CTEs.
+      const resolved = resolveForRun(queryToRun, {
+        dbType: tabConnection.dbType,
+        connectionId: currentTab.connectionId,
+        currentTabId: tabId,
+        tabs: useTabStore.getState().tabs
+      })
+      if (!resolved.ok) {
+        updateTabMultiResult(tabId, null, crossTabErrorMessage(resolved.error))
+        return
+      }
+      const sqlToExecute = resolved.finalSql
+```
+
+- [ ] **Step 3: Execute the resolved SQL**
+
+Change the telemetry call argument from `queryToRun` to `sqlToExecute`:
+
+```ts
+        const response = await window.api.db.queryWithTelemetry(
+          tabConnection,
+          sqlToExecute,
+          executionId,
+          queryTimeoutMs
+        )
+```
+
+- [ ] **Step 4: Typecheck**
+
+Run: `pnpm --filter @data-peek/desktop typecheck:web`
+Expected: no errors.
+
+- [ ] **Step 5: Manual verification**
+
+(Ask before starting the dev server.) Name tab A `@active_users` (after Task 6), run `SELECT 1 AS id` in it. In tab B run `SELECT * FROM @active_users` → see the result. In tab B run `SELECT * FROM @ghost` → error banner reads "No tab named @ghost on this connection."
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/desktop/src/renderer/src/components/tab-query-editor.tsx
+git commit -m "feat(cross-tab): resolve @name references in the run path"
+```
+
+---
+
+### Task 5: Threshold confirm dialog + inlined-refs pill
+
+**Files:**
+- Create: `apps/desktop/src/renderer/src/components/cross-tab/cross-tab-submit-dialog.tsx`
+- Modify: `apps/desktop/src/renderer/src/components/query-editor/editor-toolbar.tsx`
+- Modify: `apps/desktop/src/renderer/src/components/tab-query-editor.tsx`
+
+Manual verification (UI). Threshold = `rowsInlined > 1000 || bytesAdded > 256 * 1024`.
+
+- [ ] **Step 1: Create the dialog component**
+
+Create `apps/desktop/src/renderer/src/components/cross-tab/cross-tab-submit-dialog.tsx`:
+
+```tsx
+import { Button, Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@data-peek/ui'
+import { Layers } from 'lucide-react'
+import type { ResolveForRunSummary } from '@/lib/cross-tab-integration'
+
+interface CrossTabSubmitDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  summary: ResolveForRunSummary | null
+  onConfirm: () => void
+}
+
+export function CrossTabSubmitDialog({ open, onOpenChange, summary, onConfirm }: CrossTabSubmitDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Layers className="size-4" />
+            Running with {summary?.refCount ?? 0} tab {summary?.refCount === 1 ? 'reference' : 'references'}
+          </DialogTitle>
+        </DialogHeader>
+        <div className="space-y-2 text-sm">
+          {summary?.references.map((r) => (
+            <div key={r.name} className="flex items-center justify-between font-mono text-xs">
+              <span className="text-muted-foreground">@{r.name}</span>
+              <span>
+                {r.rows.toLocaleString()} rows · {(r.bytes / 1024).toFixed(1)}KB
+              </span>
+            </div>
+          ))}
+          <div className="border-t border-border/50 pt-2 font-mono text-xs">
+            Inlined: {summary?.rowsInlined.toLocaleString()} rows · {((summary?.bytesAdded ?? 0) / 1024).toFixed(1)}KB
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            onClick={() => {
+              onConfirm()
+              onOpenChange(false)
+            }}
+          >
+            Run query
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+```
+
+- [ ] **Step 2: Add a `refsSlot` prop to `EditorToolbar`**
+
+In `editor-toolbar.tsx`, in `EditorToolbarProps`, after `watchSlot?: ReactNode`:
+
+```ts
+  /** Slot for the Watch button — rendered between Benchmark and Format. */
+  watchSlot?: ReactNode
+  /** Slot for the "N refs inlined" cross-tab pill. */
+  refsSlot?: ReactNode
+```
+
+Destructure `refsSlot` with the other props, and render it just after `{watchSlot}`:
+
+```tsx
+        {watchSlot}
+        {refsSlot}
+```
+
+- [ ] **Step 3: Add confirm + pill state and gate in `tab-query-editor.tsx`**
+
+Add imports:
+
+```ts
+import { CrossTabSubmitDialog } from '@/components/cross-tab/cross-tab-submit-dialog'
+import type { ResolveForRunSummary } from '@/lib/cross-tab-integration'
+```
+
+Add state inside the component (near other `useState`):
+
+```ts
+  const [refsSummary, setRefsSummary] = useState<ResolveForRunSummary | null>(null)
+  const [pendingHeavyRun, setPendingHeavyRun] = useState<{ summary: ResolveForRunSummary; sql: string } | null>(null)
+  const skipHeavyConfirmRef = useRef(false)
+  const HEAVY_ROWS = 1000
+  const HEAVY_BYTES = 256 * 1024
+```
+
+- [ ] **Step 4: Extract the actual execution into a runnable callback**
+
+Refactor the body of `handleRunQuery` that follows resolution so the execution (from `const executionId = crypto.randomUUID()` through the `try/catch/finally`) lives in a helper `executeSql(sqlToExecute: string)`. Then in `handleRunQuery`, after a successful resolve:
+
+```ts
+      const summary = resolved.summary
+      setRefsSummary(summary.refCount > 0 ? summary : null)
+
+      const isHeavy = summary.rowsInlined > HEAVY_ROWS || summary.bytesAdded > HEAVY_BYTES
+      if (isHeavy && !skipHeavyConfirmRef.current) {
+        setPendingHeavyRun({ summary, sql: resolved.finalSql })
+        return
+      }
+      await executeSql(resolved.finalSql)
+```
+
+`executeSql` keeps the existing `executionId`/`updateTabExecuting`/`queryWithTelemetry`/writeback logic verbatim, taking `sqlToExecute` as its parameter.
+
+- [ ] **Step 5: Render the dialog + pill**
+
+Add the pill to the `EditorToolbar` usage (next to `watchSlot`):
+
+```tsx
+          refsSlot={
+            refsSummary && refsSummary.refCount > 0 ? (
+              <code className="text-[10px] bg-muted/50 px-2 py-0.5 rounded">
+                {refsSummary.refCount} {refsSummary.refCount === 1 ? 'ref' : 'refs'} ·{' '}
+                {refsSummary.rowsInlined.toLocaleString()} rows inlined
+              </code>
+            ) : undefined
+          }
+```
+
+Render the dialog near the other dialogs at the bottom of the component's JSX:
+
+```tsx
+      <CrossTabSubmitDialog
+        open={pendingHeavyRun !== null}
+        onOpenChange={(o) => {
+          if (!o) setPendingHeavyRun(null)
+        }}
+        summary={pendingHeavyRun?.summary ?? null}
+        onConfirm={() => {
+          const run = pendingHeavyRun
+          setPendingHeavyRun(null)
+          if (run) void executeSql(run.sql)
+        }}
+      />
+```
+
+- [ ] **Step 6: Typecheck**
+
+Run: `pnpm --filter @data-peek/desktop typecheck:web`
+Expected: no errors.
+
+- [ ] **Step 7: Manual verification**
+
+(Ask before starting the dev server.) Reference a small tab → runs immediately, pill shows "1 ref · N rows inlined". Reference a tab whose result is >1000 rows → confirm dialog appears with the per-ref breakdown; Cancel aborts, Run query proceeds.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/desktop/src/renderer/src/components/cross-tab/cross-tab-submit-dialog.tsx apps/desktop/src/renderer/src/components/query-editor/editor-toolbar.tsx apps/desktop/src/renderer/src/components/tab-query-editor.tsx
+git commit -m "feat(cross-tab): threshold confirm dialog + inlined-refs pill"
+```
+
+---
+
+## Phase D — Naming UI
+
+### Task 6: `@name` display + rename affordance in `tab.tsx`
+
+**Files:**
+- Modify: `apps/desktop/src/renderer/src/components/tab.tsx`
+
+Manual verification (UI). `tab.tsx` reads stores directly already (`useWatchStore`); we do the same for naming to avoid threading props through `tab-bar.tsx`.
+
+- [ ] **Step 1: Add imports + local state**
+
+In `tab.tsx`, add:
+
+```ts
+import { useState } from 'react'
+import { useTabStore } from '@/stores/tab-store'
+```
+
+Inside the `Tab` component body, near the existing `watchState` read:
+
+```ts
+  const setTabName = useTabStore((s) => s.setTabName)
+  const clearTabName = useTabStore((s) => s.clearTabName)
+  const isQuery = tab.type === 'query'
+  const refName = isQuery ? (tab as { name?: string }).name : undefined
+  const [renaming, setRenaming] = useState(false)
+  const [nameDraft, setNameDraft] = useState('')
+  const [nameError, setNameError] = useState<string | null>(null)
+```
+
+- [ ] **Step 2: Show the `@name` prefix in the title**
+
+Replace the title span (`<span className="truncate text-sm">{tab.title}</span>`) with:
+
+```tsx
+          {/* Title (with @name prefix when the tab is named) */}
+          {renaming ? (
+            <input
+              autoFocus
+              value={nameDraft}
+              onChange={(e) => {
+                setNameDraft(e.target.value)
+                setNameError(null)
+              }}
+              onClick={(e) => e.stopPropagation()}
+              onKeyDown={(e) => {
+                e.stopPropagation()
+                if (e.key === 'Enter') {
+                  const res = setTabName(tab.id, nameDraft)
+                  if (res.ok) setRenaming(false)
+                  else setNameError('Invalid or duplicate name')
+                } else if (e.key === 'Escape') {
+                  setRenaming(false)
+                }
+              }}
+              onBlur={() => setRenaming(false)}
+              placeholder="name"
+              className={cn(
+                'w-24 bg-transparent text-sm outline-none border-b',
+                nameError ? 'border-red-500' : 'border-primary/50'
+              )}
+            />
+          ) : refName ? (
+            <span className="truncate text-sm">
+              <span className="text-primary">@{refName}</span>
+            </span>
+          ) : (
+            <span className="truncate text-sm">{tab.title}</span>
+          )}
+```
+
+(`cn` is already imported in `tab.tsx`.)
+
+- [ ] **Step 3: Add the context-menu items**
+
+In the `<ContextMenuContent>`, before the close items (after the Pin/Unpin block + separator), add (query tabs only):
+
+```tsx
+        {isQuery && (
+          <ContextMenuItem
+            onClick={() => {
+              setNameDraft(refName ?? '')
+              setNameError(null)
+              setRenaming(true)
+            }}
+          >
+            Name as @…
+          </ContextMenuItem>
+        )}
+        {isQuery && refName && (
+          <ContextMenuItem onClick={() => clearTabName(tab.id)}>Clear @name</ContextMenuItem>
+        )}
+```
+
+- [ ] **Step 4: Typecheck**
+
+Run: `pnpm --filter @data-peek/desktop typecheck:web`
+Expected: no errors.
+
+- [ ] **Step 5: Manual verification**
+
+(Ask before starting the dev server.) Right-click a query tab → "Name as @…" → type `active_users`, Enter → header shows `@active_users` in accent. Try a duplicate or `select` → red underline, not saved. "Clear @name" reverts to the title.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/desktop/src/renderer/src/components/tab.tsx
+git commit -m "feat(cross-tab): tab @name display + rename affordance"
+```
+
+---
+
+## Phase E — Editor magic (Monaco)
+
+### Task 7: `cross-tab-editor.ts` module + completion provider
+
+**Files:**
+- Create: `apps/desktop/src/renderer/src/components/cross-tab/cross-tab-editor.ts`
+- Test: `apps/desktop/src/renderer/src/components/cross-tab/__tests__/cross-tab-editor.test.ts`
+
+- [ ] **Step 1: Write the failing test (pure helpers only)**
+
+Create `apps/desktop/src/renderer/src/components/cross-tab/__tests__/cross-tab-editor.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { atTokenBeforeCursor, filterRefs } from '../cross-tab-editor'
+import type { CrossTabRef } from '@/lib/cross-tab-integration'
+
+describe('atTokenBeforeCursor', () => {
+  it('detects an @-token being typed at a word boundary', () => {
+    expect(atTokenBeforeCursor('SELECT * FROM @act')).toEqual({ active: true, partial: 'act' })
+  })
+  it('detects a bare @ with empty partial', () => {
+    expect(atTokenBeforeCursor('SELECT * FROM @')).toEqual({ active: true, partial: '' })
+  })
+  it('ignores @@ (system variable)', () => {
+    expect(atTokenBeforeCursor('SELECT @@ver').active).toBe(false)
+  })
+  it('ignores email-like sequences', () => {
+    expect(atTokenBeforeCursor("'a@x").active).toBe(false)
+  })
+  it('is inactive when there is no trailing @-token', () => {
+    expect(atTokenBeforeCursor('SELECT * FROM users').active).toBe(false)
+  })
+})
+
+describe('filterRefs', () => {
+  const refs: CrossTabRef[] = [
+    { name: 'active_users', tabTitle: 'A', rowCount: 1, colCount: 1, hasResult: true },
+    { name: 'archived', tabTitle: 'B', rowCount: 1, colCount: 1, hasResult: true },
+    { name: 'pending', tabTitle: 'C', rowCount: 0, colCount: 0, hasResult: false }
+  ]
+  it('returns all refs for an empty partial', () => {
+    expect(filterRefs(refs, '')).toHaveLength(3)
+  })
+  it('prefix-filters by name', () => {
+    expect(filterRefs(refs, 'a').map((r) => r.name)).toEqual(['active_users', 'archived'])
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm --filter @data-peek/desktop test src/renderer/src/components/cross-tab/__tests__/cross-tab-editor.test.ts`
+Expected: FAIL — `Cannot find module '../cross-tab-editor'`.
+
+- [ ] **Step 3: Write the module**
+
+Create `apps/desktop/src/renderer/src/components/cross-tab/cross-tab-editor.ts`:
+
+```ts
+/**
+ * Monaco providers for cross-tab @name references — completion, hover, and
+ * diagnostics. Follows the singleton-provider + module-state pattern from
+ * sql-editor.tsx: the active editor pushes refs via updateCrossTabRefs and
+ * the providers read the latest snapshot.
+ */
+
+import * as monaco from 'monaco-editor'
+import type { Monaco } from '@monaco-editor/react'
+import type { DatabaseType } from '@data-peek/shared'
+import { parseTabReferences } from '@/lib/cross-tab-parser'
+import type { CrossTabRef } from '@/lib/cross-tab-integration'
+
+let currentRefs: CrossTabRef[] = []
+let providersRegistered = false
+
+const MARKER_OWNER = 'cross-tab'
+
+export function updateCrossTabRefs(refs: CrossTabRef[]): void {
+  currentRefs = refs
+}
+
+/** True when the text immediately before the cursor is an @-token being typed (not @@, not email). */
+export function atTokenBeforeCursor(textBeforeCursor: string): { active: boolean; partial: string } {
+  const m = textBeforeCursor.match(/@([a-z0-9_]*)$/i)
+  if (!m) return { active: false, partial: '' }
+  const at = textBeforeCursor.length - m[0].length
+  const prev = at > 0 ? textBeforeCursor[at - 1] : ''
+  if (/[A-Za-z0-9_.$@]/.test(prev)) return { active: false, partial: '' }
+  return { active: true, partial: m[1].toLowerCase() }
+}
+
+export function filterRefs(refs: CrossTabRef[], partial: string): CrossTabRef[] {
+  if (!partial) return refs
+  return refs.filter((r) => r.name.startsWith(partial))
+}
+
+/** Register the completion + hover providers once, globally. */
+export function ensureCrossTabProviders(monacoInstance: Monaco): void {
+  if (providersRegistered) return
+  providersRegistered = true
+
+  monacoInstance.languages.registerCompletionItemProvider('sql', {
+    triggerCharacters: ['@'],
+    provideCompletionItems: (model, position) => {
+      const textBeforeCursor = model.getValueInRange({
+        startLineNumber: position.lineNumber,
+        startColumn: 1,
+        endLineNumber: position.lineNumber,
+        endColumn: position.column
+      })
+      const tok = atTokenBeforeCursor(textBeforeCursor)
+      if (!tok.active) return { suggestions: [] }
+      const word = model.getWordUntilPosition(position)
+      const range = {
+        startLineNumber: position.lineNumber,
+        endLineNumber: position.lineNumber,
+        startColumn: word.startColumn,
+        endColumn: word.endColumn
+      }
+      return {
+        suggestions: filterRefs(currentRefs, tok.partial).map((r) => ({
+          label: `@${r.name}`,
+          kind: monacoInstance.languages.CompletionItemKind.Variable,
+          insertText: r.name,
+          range,
+          detail: r.hasResult ? `${r.rowCount} rows · ${r.colCount} cols` : 'not run yet',
+          documentation: { value: `Result of tab **${r.tabTitle}**` },
+          sortText: '0' + r.name
+        }))
+      }
+    }
+  })
+
+  monacoInstance.languages.registerHoverProvider('sql', {
+    provideHover: (model, position) => {
+      const word = model.getWordAtPosition(position)
+      if (!word) return null
+      const lineText = model.getLineContent(position.lineNumber)
+      if (lineText[word.startColumn - 2] !== '@') return null
+      const ref = currentRefs.find((r) => r.name === word.word.toLowerCase())
+      if (!ref) return null
+      return {
+        range: new monacoInstance.Range(position.lineNumber, word.startColumn - 1, position.lineNumber, word.endColumn),
+        contents: [
+          { value: `**@${ref.name}** — tab "${ref.tabTitle}"` },
+          {
+            value: ref.hasResult
+              ? `${ref.rowCount} rows · ${ref.colCount} columns`
+              : "_hasn't been run yet_"
+          }
+        ]
+      }
+    }
+  })
+}
+
+/**
+ * Recompute diagnostic markers for the model. Unknown names → Error; named
+ * but not-yet-run → Warning. For mysql/mssql, only known names are parsed
+ * (so @vars aren't flagged).
+ */
+export function updateCrossTabMarkers(monacoInstance: Monaco, model: monaco.editor.ITextModel, dbType: DatabaseType): void {
+  const byName = new Map(currentRefs.map((r) => [r.name, r]))
+  const knownNames = dbType === 'mysql' || dbType === 'mssql' ? new Set(byName.keys()) : undefined
+  const parsed = parseTabReferences(model.getValue(), { dialect: dbType, knownNames })
+
+  const markers: monaco.editor.IMarkerData[] = []
+  for (const ref of parsed.references) {
+    const known = byName.get(ref.name)
+    const start = model.getPositionAt(ref.start)
+    const end = model.getPositionAt(ref.end)
+    const base = {
+      startLineNumber: start.lineNumber,
+      startColumn: start.column,
+      endLineNumber: end.lineNumber,
+      endColumn: end.column
+    }
+    if (!known) {
+      markers.push({ ...base, severity: monacoInstance.MarkerSeverity.Error, message: `No tab named @${ref.name} on this connection.` })
+    } else if (!known.hasResult) {
+      markers.push({ ...base, severity: monacoInstance.MarkerSeverity.Warning, message: `@${ref.name} hasn't been run yet.` })
+    }
+  }
+  monacoInstance.editor.setModelMarkers(model, MARKER_OWNER, markers)
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm --filter @data-peek/desktop test src/renderer/src/components/cross-tab/__tests__/cross-tab-editor.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck + commit**
+
+```bash
+pnpm --filter @data-peek/desktop typecheck:web
+git add apps/desktop/src/renderer/src/components/cross-tab/cross-tab-editor.ts apps/desktop/src/renderer/src/components/cross-tab/__tests__/cross-tab-editor.test.ts
+git commit -m "feat(cross-tab): Monaco completion/hover/markers module"
+```
+
+---
+
+### Task 8: Wire the providers into `SQLEditor` + push context from `tab-query-editor`
+
+**Files:**
+- Modify: `apps/desktop/src/renderer/src/components/sql-editor.tsx`
+- Modify: `apps/desktop/src/renderer/src/components/tab-query-editor.tsx`
+
+Manual verification (editor behavior).
+
+- [ ] **Step 1: Add imports + props to `SQLEditor`**
+
+In `sql-editor.tsx`, add imports:
+
+```ts
+import type { DatabaseType } from '@data-peek/shared'
+import type { CrossTabRef } from '@/lib/cross-tab-integration'
+import { ensureCrossTabProviders, updateCrossTabRefs, updateCrossTabMarkers } from '@/components/cross-tab/cross-tab-editor'
+```
+
+Add to `SQLEditorProps`:
+
+```ts
+  /** Named tabs available for @name references on this connection. */
+  crossTabRefs?: CrossTabRef[]
+  /** Dialect used for cross-tab parsing/markers. */
+  crossTabDialect?: DatabaseType
+```
+
+Destructure them in the component signature with defaults: `crossTabRefs = []`, `crossTabDialect`.
+
+- [ ] **Step 2: Register providers on mount + keep a dialect ref**
+
+Add a ref near `monacoRef`:
+
+```ts
+  const crossTabDialectRef = React.useRef<DatabaseType | undefined>(crossTabDialect)
+  React.useEffect(() => {
+    crossTabDialectRef.current = crossTabDialect
+  }, [crossTabDialect])
+```
+
+In `handleEditorDidMount`, after `ensureCompletionProvider(monaco)`:
+
+```ts
+    updateCrossTabRefs(crossTabRefs)
+    ensureCrossTabProviders(monaco)
+    const model = editor.getModel()
+    if (model && crossTabDialectRef.current) {
+      updateCrossTabMarkers(monaco, model, crossTabDialectRef.current)
+    }
+```
+
+- [ ] **Step 3: Refresh refs + markers when they change**
+
+Add effects (near the existing schema/snippet effects):
+
+```ts
+  React.useEffect(() => {
+    updateCrossTabRefs(crossTabRefs)
+    const model = editorRef.current?.getModel()
+    if (monacoRef.current && model && crossTabDialect) {
+      updateCrossTabMarkers(monacoRef.current, model, crossTabDialect)
+    }
+  }, [crossTabRefs, crossTabDialect])
+```
+
+- [ ] **Step 4: Recompute markers on edit**
+
+In `handleChange`, after `onChange?.(newValue ?? '')`:
+
+```ts
+    const model = editorRef.current?.getModel()
+    if (monacoRef.current && model && crossTabDialectRef.current) {
+      updateCrossTabMarkers(monacoRef.current, model, crossTabDialectRef.current)
+    }
+```
+
+- [ ] **Step 5: Push context from `tab-query-editor.tsx`**
+
+Add import:
+
+```ts
+import { buildCrossTabRefs } from '@/lib/cross-tab-integration'
+```
+
+Read all tabs and compute refs (near the other store reads):
+
+```ts
+  const allTabs = useTabStore((s) => s.tabs)
+  const crossTabRefs = React.useMemo(
+    () => buildCrossTabRefs(allTabs, tab?.connectionId ?? null, tabId),
+    [allTabs, tab?.connectionId, tabId]
+  )
+```
+
+Pass to `<SQLEditor>`:
+
+```tsx
+              schemas={schemas}
+              snippets={allSnippets}
+              crossTabRefs={crossTabRefs}
+              crossTabDialect={tabConnection?.dbType}
+```
+
+(`React` is already imported in `tab-query-editor.tsx`; if it uses named hooks, use `useMemo` directly with the existing import style.)
+
+- [ ] **Step 6: Typecheck**
+
+Run: `pnpm --filter @data-peek/desktop typecheck:web`
+Expected: no errors.
+
+- [ ] **Step 7: Manual verification**
+
+(Ask before starting the dev server.) Name tab A `@active_users` and run it. In tab B: type `SELECT * FROM @` → autocomplete lists `@active_users` with "N rows · M cols". Type `@ghost` → red squiggle "No tab named @ghost". Hover `@active_users` → preview popover. Name a tab but don't run it, reference it → yellow squiggle "hasn't been run yet".
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/desktop/src/renderer/src/components/sql-editor.tsx apps/desktop/src/renderer/src/components/tab-query-editor.tsx
+git commit -m "feat(cross-tab): wire Monaco @name completion/hover/diagnostics"
+```
+
+---
+
+## Phase F — Final verification
+
+### Task 9: Full suite + docs + branch wrap-up
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `pnpm --filter @data-peek/desktop test`
+Expected: all green, including the pre-existing 885 lines of cross-tab parser/resolver/validation tests + the new integration, store, and editor-helper tests.
+
+- [ ] **Step 2: Full typecheck + lint**
+
+Run: `pnpm --filter @data-peek/desktop typecheck && pnpm --filter @data-peek/desktop lint`
+Expected: no errors.
+
+- [ ] **Step 3: Update feature docs (per CLAUDE.md "Feature Documentation")**
+
+Add a "Cross-tab references" entry to `README.md` Features and to the relevant `docs/` page. Note the marketing-site (`apps/web`) update can follow at launch.
+
+- [ ] **Step 4: Commit docs**
+
+```bash
+git add README.md docs
+git commit -m "docs(cross-tab): document @name references"
+```
+
+- [ ] **Step 5: Manual end-to-end demo**
+
+(Ask before starting the dev server.) The full flow from the spec's marketing angle: tab A `SELECT id FROM users WHERE last_seen > now() - interval '24 hours'`, name it `@active_users`, run. Tab B: `SELECT count(*) FROM events WHERE user_id IN (@active_users)` via autocomplete → result lands; pill shows refs inlined.
+
+---
+
+## Self-review
+
+**Spec coverage:**
+- Tab naming (store + UI) → Tasks 1, 2, 6. ✓
+- Lookup adapter (`mapTabToResolvable`, `buildTabLookup`) → Task 3. ✓
+- Execution wiring in `handleRunQuery` → Task 4. ✓
+- Threshold-only confirm + indicator pill → Task 5. ✓
+- Editor magic (completion, hover, diagnostics) → Tasks 7, 8. ✓
+- Error handling via existing banner → Task 4 (`crossTabErrorMessage`, tested in Task 3). ✓
+- `DatabaseType`→`SQLDialect` reconciliation → `toSQLDialect` in Task 3. ✓
+- Only query tabs nameable → guarded in `setTabName`, `buildTabLookup`, `buildCrossTabRefs`, and the `tab.tsx` menu. ✓
+- Deferred (staleness, settings, notebook, table-preview refs, error action buttons, token accent-coloring) → not implemented, by design. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code. UI/editor glue tasks that can't be unit-tested use explicit manual-verification steps with concrete expected behavior (not "test the above"). ✓
+
+**Type consistency:** `ResolveForRunSummary`, `ResolveForRunResult`, `CrossTabRef`, `crossTabErrorMessage`, `resolveForRun`, `buildCrossTabRefs`, `toSQLDialect` are defined in Task 3 and consumed with matching signatures in Tasks 5 and 8. `setTabName` returns `RefNameValidationResult` (Task 1) consumed in Task 6. The resolver's `ResolvableTab`/`ResolveErrorKind`/`ResolveResult` shapes match #184's exported types. ✓
+
+**Assumption to verify during Task 3:** that `tab-store.ts` exports the `Tab` union type. If not, the Task 3 typecheck step adds the `export`.

--- a/docs/superpowers/plans/2026-05-29-cross-tab-name-references.md
+++ b/docs/superpowers/plans/2026-05-29-cross-tab-name-references.md
@@ -31,7 +31,7 @@
 
 ## File structure
 
-```
+```text
 stores/tab-store.ts                                   (edit) name field, setTabName/clearTabName/getNamedTabs, persistence
 stores/__tests__/tab-store-naming.test.ts             (new)  store action tests
 lib/cross-tab-integration.ts                          (new)  toSQLDialect, mapTabToResolvable, buildTabLookup, resolveForRun, buildCrossTabRefs, crossTabErrorMessage, CrossTabRef type

--- a/docs/superpowers/specs/2026-05-29-cross-tab-name-references-design.md
+++ b/docs/superpowers/specs/2026-05-29-cross-tab-name-references-design.md
@@ -1,0 +1,251 @@
+# Cross-Tab `@name` References — v1 Integration Design
+
+**Date:** 2026-05-29
+**Status:** Approved (design); pending implementation plan
+**Builds on:** PR #184 (`feat(cross-tab): @name references — foundations`)
+**Parent plan:** `docs/PLAN-cross-tab-query.md`
+
+## Overview
+
+Most analytical work is two or three dependent queries, not a 20-cell notebook.
+Today you write query A in tab 1, see the result, then write query B in tab 2 —
+with no way to use tab 1's result as input to tab 2 short of copy-pasting values
+or rewriting A as a CTE.
+
+This feature adds **named tab references**: name a query tab's result `@active_users`,
+then write `SELECT … WHERE user_id IN (@active_users)` in another tab. At submit
+time the referenced result is inlined as a `VALUES`-backed CTE. No notebook
+ceremony, no server-side staging.
+
+PR #184 already merged the **pure logic core** — parser, resolver, name validation,
+types — with 885 lines of tests. This spec covers the **remaining integration layer**:
+tab naming, the lookup adapter, query-execution wiring, and the editor experience
+(autocomplete / hover / diagnostics).
+
+## What #184 already shipped (do not rebuild)
+
+All in `apps/desktop/src/renderer/src/lib/`, all unit-tested, **none wired into the app**:
+
+- `cross-tab-types.ts` — `TabReference`, `ParsedSql`, `ResolveCaps`
+  (`DEFAULT_RESOLVE_CAPS` = 10k rows / 5MB / 100 cols), `ResolveResult`,
+  `ResolveErrorKind`, `RefNameValidationResult`.
+- `cross-tab-parser.ts` — `parseTabReferences(sql, { dialect, knownNames? })`.
+  A dialect-aware single-pass scanner that finds `@name` tokens while skipping
+  string literals, quoted identifiers (`"…"`, backtick, `[…]`), line/block
+  comments, Postgres dollar-quoted bodies, emails, and `@@var` system variables.
+- `cross-tab-resolver.ts` — `resolveReferences(source, parsed, ctx)` where
+  `ctx = { lookup, currentTabId, dialect, caps? }`. Builds per-dialect
+  `VALUES`-CTEs (PG/SQLite typed `VALUES`, MySQL `VALUES ROW(...)`, MSSQL
+  `SELECT * FROM (VALUES …)`), merges into a leading `WITH`/`WITH RECURSIVE`,
+  enforces caps, detects self-reference, and substitutes `@name` → quoted
+  identifier. Returns `{ ok: true, result } | { ok: false, error }`.
+- `cross-tab-name-validation.ts` — `validateRefName(candidate, { takenNames?, ownTabId? })`.
+  Shape (`/^[a-z][a-z0-9_]*$/`, ≤32 chars), reserved-word rejection
+  (local list + shared `isSQLKeyword`), per-connection uniqueness.
+
+The resolver is **decoupled via a `lookup(name) => ResolvableTab | null` callback**,
+so the entire remaining feature is integration — no changes to the parser or resolver.
+
+## Decisions (locked during brainstorming)
+
+1. **Scope = functional core + editor magic.** Tab naming, lookup adapter,
+   execution wiring, error banners, *plus* Monaco autocomplete / hover preview /
+   inline diagnostics. Staleness tracking, settings panel, and notebook-cell
+   references are deferred.
+2. **Confirm UX = threshold-only.** Run immediately by default with a subtle
+   "refs inlined" indicator; show a blocking confirm dialog **only** when the
+   inlined payload is heavy (>1,000 rows OR >256KB). This honors CLAUDE.md
+   design principle #2 ("speed over ceremony — no confirmation dialogs where
+   undo works") while keeping a guard before sending a large query to a DB. The
+   hard caps (10k rows / 5MB) still hard-fail with a clear error.
+3. **Architecture = name on the tab + pure lookup helper** (Approach A). No new
+   store. Add `name?` to `QueryTab`; derive the resolver's `lookup` with a pure
+   `buildTabLookup()` helper. Matches the plan's Phase 1 and #184's pure-function
+   ethos; deferred staleness later just adds a field.
+
+## Settled by investigation
+
+- **Resolution runs renderer-side**, inside `handleRunQuery`
+  (`tab-query-editor.tsx:313`), right after `queryToRun` is computed (`:323`)
+  and before `window.api.db.queryWithTelemetry(...)` (`:344`). Matches the
+  `cross-tab-types.ts` note that the feature is renderer-only. **No IPC / main /
+  `@data-peek/shared` changes.**
+- **`@name` inlines a named query tab's full in-memory active result.**
+  `QueryTab` holds its complete result set in `result.rows` and uses *client-side*
+  pagination (`currentPage`/`pageSize`) for display — only `TablePreviewTab` has
+  server-side `totalRowCount`. So there is no "first page only" wrong-answer trap
+  for query tabs.
+- **`QueryResult.columns` is `{ name, dataType }[]`** — a direct shape match for
+  the resolver's `ResolvableTab.result.fields`. Mapping is a field rename, not a
+  transform.
+- **Only query tabs are nameable in v1.** Table-preview tabs (server-side paged)
+  and notebook cells are out — sidesteps partiality and scopes cleanly.
+- **The editor experience extends the existing singleton-provider pattern.**
+  `sql-editor.tsx` already registers a global SQL completion provider once
+  (`ensureCompletionProvider`) reading module-level mutable state
+  (`currentSchemas`/`currentSnippets`) that the active editor refreshes via
+  `useEffect`. Cross-tab providers follow the identical shape.
+
+## Architecture & data flow
+
+```
+User runs SQL in tab B (⌘↵)
+        │
+handleRunQuery (tab-query-editor.tsx:313)
+        │  queryToRun computed (:323)
+        ▼
+resolveForRun(queryToRun, { dialect, connectionId, currentTabId, tabs })   ← NEW (pure)
+        │   ├─ parseTabReferences(sql, { dialect, knownNames })   [#184]
+        │   ├─ buildTabLookup(tabs, connectionId, currentTabId)   ← NEW
+        │   └─ resolveReferences(sql, parsed, ctx)               [#184]
+        ▼
+   ok? ──no──▶ map ResolveErrorKind → message → updateTabResult(tabId, null, msg)
+        │ yes
+   over threshold (>1k rows OR >256KB)? ──yes──▶ submit dialog → Cancel | Run
+        │ no / confirmed
+        ▼
+window.api.db.queryWithTelemetry(tabConnection, finalSql, …)   [existing, :344]
+        │
+        ▼
+   toolbar pill: "N refs · M rows inlined"
+```
+
+The database only ever receives `finalSql` (the user's SQL with `@name` tokens
+replaced by quoted identifiers and the matching `VALUES`-CTEs prepended).
+
+## Components
+
+### 1. Tab naming — `stores/tab-store.ts`
+
+- Add `name?: string` to the `QueryTab` interface and to `PersistedTab` (so the
+  name survives app restart).
+- `setTabName(tabId, name): RefNameValidationResult` — normalizes and validates
+  via `validateRefName`, passing `takenNames` = names of *other* tabs on the same
+  connection (from `getNamedTabs(connectionId)`) and `ownTabId = tabId`. On
+  success persists the normalized name; returns the validation result so the UI
+  renders inline errors. Does **not** throw.
+- `clearTabName(tabId)` — removes the name (header reverts to auto `title`).
+- `getNamedTabs(connectionId): Array<{ tabId; name; title }>` — selector for the
+  same connection. (Closing a tab removes its name implicitly, since the name
+  lives on the tab object — no separate cleanup.)
+
+### 2. Tab-naming UI — `components/tab.tsx`
+
+- Entry points: **double-click the tab title**, or **right-click → "Name as @…"**.
+  Reuses the existing inline-rename affordance used for `renameTab`, but writes
+  `name` instead of `title`.
+- Inline input validates on each keystroke: invalid shape / duplicate / reserved
+  word → red underline + short message. `Enter` saves, `Esc` cancels.
+- A named tab shows the **`@name` prefix** in the header with a subtle accent so
+  it reads as referenceable. Clearing reverts to the auto-derived title.
+
+### 3. Lookup adapter — `lib/cross-tab-integration.ts` (NEW, pure)
+
+- `mapTabToResolvable(tab): ResolvableTab` — maps a `QueryTab`'s **active** result:
+  - active result = legacy `result`, or `multiResult.results[activeResultIndex]`
+    when multi-statement.
+  - `null` result → `{ kind: 'none' }`; stored error → `{ kind: 'error', message }`;
+    success → `{ kind: 'success', rows: r.rows, fields: r.columns }`.
+- `buildTabLookup(tabs, connectionId, currentTabId): (name) => ResolvableTab | null`
+  — connection-scoped, excludes the current tab, matches on `tab.name`.
+- `resolveForRun(sql, ctx): ResolveForRunResult` — orchestrates
+  parse → build lookup → resolve. Returns a discriminated union:
+  `{ ok: true; finalSql; summary: { refCount; rowsInlined; bytesAdded; references } }`
+  or `{ ok: false; error: ResolveErrorKind }`. This is the single seam that
+  `handleRunQuery` calls — fully unit-testable without React.
+- `dialectFor(dbType)` — maps the connection's `dbType` to the parser's
+  `DatabaseType` and the resolver's `SQLDialect`. (Implementation note: both come
+  from `@data-peek/shared`; reconcile the two unions here so callers pass one
+  connection type.)
+
+### 4. Editor experience — `components/cross-tab/cross-tab-editor.ts` (NEW)
+
+Extends the singleton-provider pattern from `sql-editor.tsx`:
+
+- Module state `currentNamedTabs` + `currentConnectionId`, refreshed by the active
+  query editor via `useEffect` (mirrors how `currentSchemas`/`currentSnippets`
+  are updated today).
+- **Completion** — a provider with `triggerCharacters: ['@']`. When the cursor is
+  inside an `@…` token, suggest connection-scoped named tabs (excluding the
+  current tab); `detail` = "N rows · M cols", `documentation` = a short rows
+  preview.
+- **Hover** — `registerHoverProvider('sql')` for `@name`: name, source tab title,
+  row/column counts, first-rows preview.
+- **Diagnostics + accent styling** — on content change (debounced), parse the
+  current SQL and `setModelMarkers`: `Error` squiggle for unknown names, `Warning`
+  for "exists but not run yet". A decoration gives resolved `@name` tokens the
+  accent color (avoids a custom Monaco tokenizer).
+- Pure helpers (cursor-in-`@`-token test, completion filter) extracted for unit
+  tests.
+
+### 5. Confirm / indicator UX
+
+- `cross-tab-submit-dialog.tsx` (NEW) — shown only when
+  `summary.rowsInlined > 1000 || summary.bytesAdded > 256*1024`. Lists per-ref
+  breakdown + totals; `[Cancel] [Run]`; a "don't ask again this session" toggle.
+- Below threshold → **run immediately**.
+- Whenever any ref was inlined, a subtle **"N refs · M rows inlined"** pill appears
+  in the editor toolbar / results header.
+
+### 6. Error handling
+
+Each `ResolveErrorKind` maps to a clear message rendered via the **existing tab
+error banner** (`updateTabResult(tabId, null, msg)`):
+
+| kind | message |
+|---|---|
+| `unknown_reference` | No tab named `@x` on this connection. |
+| `no_result` | `@x` hasn't been run yet. |
+| `errored_result` | `@x`'s last run errored: *msg*. |
+| `circular` | `@x` can't reference itself. |
+| `too_large` | `@x` has N rows; cap is 10,000. Add a `LIMIT`. |
+| `too_many_columns` | `@x` has N columns; cap is 100. |
+| `duplicate_cte_name` | `@x` collides with a CTE in your query — rename one. |
+
+Editor squiggles + hover prevent most of these before the user runs. Resolve-error
+**action buttons** ("Open and run @x") are a stretch goal, not v1.
+
+## Testing
+
+- **Unit (Vitest)** — `lib/__tests__/cross-tab-integration.test.ts`:
+  `mapTabToResolvable` (success / error / none / multi-statement / missing),
+  `buildTabLookup` (connection scoping + self-exclusion), `resolveForRun`
+  end-to-end across all four dialects, and the threshold decision. Plus the
+  extracted editor pure helpers.
+- **Store** — `setTabName` normalization, per-connection uniqueness, `clearTabName`,
+  persistence round-trip.
+- Builds on #184's existing parser/resolver/validation tests (885 lines); those
+  cover CTE generation and edge cases and are not re-tested here.
+- **Manual** — the demo flow: name tab A `@active_users`, reference it from tab B,
+  run, confirm the CTE-backed result; verify squiggle on an unknown name and
+  hover preview on a known one.
+
+## Out of scope (deferred)
+
+- Staleness tracking + "stale" badges (Phase 6).
+- Cross-Tab settings panel — caps remain at `DEFAULT_RESOLVE_CAPS` (Phase 8).
+- Notebook-cell references (Phase 7).
+- Table-preview (server-side-paged) tabs as reference targets.
+- Resolve-error action buttons ("Open and run").
+
+## File plan
+
+```
+stores/tab-store.ts                                 (edit: name field, setTabName/clearTabName, getNamedTabs)
+lib/cross-tab-integration.ts                        (NEW: mapTabToResolvable, buildTabLookup, resolveForRun, dialectFor)
+lib/__tests__/cross-tab-integration.test.ts         (NEW)
+components/tab.tsx                                   (edit: rename affordance + @name display)
+components/tab-query-editor.tsx                     (edit: wire resolveForRun, threshold dialog, pill, push editor context)
+components/cross-tab/cross-tab-editor.ts            (NEW: Monaco completion/hover/markers/decorations + module state)
+components/cross-tab/cross-tab-submit-dialog.tsx    (NEW)
+```
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| `DatabaseType` (parser) vs `SQLDialect` (resolver) unions diverge | Centralize the map in `dialectFor()`; assert exhaustiveness |
+| Global Monaco providers don't know the focused editor's connection | Active editor pushes `currentConnectionId` to module state on focus/update, exactly like the schema provider does today |
+| Multi-statement tab — which result does `@name` use? | The **active** result set (`activeResultIndex`); documented and tested |
+| Large in-memory result inlined into a prod query | Threshold confirm dialog + hard caps (10k/5MB) hard-fail with a clear message |
+| Marker recompute on every keystroke is costly | Debounce; parse is a cheap single pass |

--- a/docs/superpowers/specs/2026-05-29-cross-tab-name-references-design.md
+++ b/docs/superpowers/specs/2026-05-29-cross-tab-name-references-design.md
@@ -1,7 +1,7 @@
 # Cross-Tab `@name` References — v1 Integration Design
 
 **Date:** 2026-05-29
-**Status:** Approved (design); pending implementation plan
+**Status:** Approved (design & implementation plan)
 **Builds on:** PR #184 (`feat(cross-tab): @name references — foundations`)
 **Parent plan:** `docs/PLAN-cross-tab-query.md`
 
@@ -88,7 +88,7 @@ so the entire remaining feature is integration — no changes to the parser or r
 
 ## Architecture & data flow
 
-```
+```text
 User runs SQL in tab B (⌘↵)
         │
 handleRunQuery (tab-query-editor.tsx:313)
@@ -230,7 +230,7 @@ Editor squiggles + hover prevent most of these before the user runs. Resolve-err
 
 ## File plan
 
-```
+```text
 stores/tab-store.ts                                 (edit: name field, setTabName/clearTabName, getNamedTabs)
 lib/cross-tab-integration.ts                        (NEW: mapTabToResolvable, buildTabLookup, resolveForRun, dialectFor)
 lib/__tests__/cross-tab-integration.test.ts         (NEW)

--- a/seeds/cross-tab-demo.sql
+++ b/seeds/cross-tab-demo.sql
@@ -1,0 +1,97 @@
+-- Cross-Tab @name references — test data + runbook (Postgres)
+--
+-- Self-contained: traffic_events has no foreign keys, so this file loads on
+-- its own. Load it into the SAME database as acme_saas_seed.sql to also run
+-- the users/memberships/events examples at the bottom.
+--
+-- Why this exists: every acme_saas table is <= 20 rows, which never trips the
+-- cross-tab heavy-confirm dialog (fires when an inlined reference exceeds
+-- 1,000 rows or 256 KB) or the hard cap (refuses references over 10,000 rows
+-- or 5 MB). traffic_events is 12,000 rows so you can exercise both thresholds.
+
+DROP TABLE IF EXISTS traffic_events;
+
+CREATE TABLE traffic_events (
+    id          BIGSERIAL PRIMARY KEY,
+    session_id  TEXT NOT NULL,
+    path        TEXT NOT NULL,
+    country     TEXT NOT NULL,
+    status_code INT  NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL
+);
+
+-- 12,000 rows, ~4,000 distinct sessions across 8 countries.
+INSERT INTO traffic_events (session_id, path, country, status_code, created_at)
+SELECT
+    'sess_' || (1 + floor(random() * 4000))::int,
+    (ARRAY['/', '/pricing', '/docs', '/login', '/app', '/blog'])[1 + floor(random() * 6)::int],
+    (ARRAY['US', 'GB', 'DE', 'IN', 'BR', 'JP', 'CA', 'AU'])[1 + floor(random() * 8)::int],
+    (ARRAY[200, 200, 200, 301, 404, 500])[1 + floor(random() * 6)::int],
+    NOW() - (random() * INTERVAL '90 days')
+FROM generate_series(1, 12000);
+
+CREATE INDEX idx_traffic_events_country ON traffic_events (country);
+CREATE INDEX idx_traffic_events_session ON traffic_events (session_id);
+
+
+-- Runbook ---------------------------------------------------------------------
+-- Name a tab: right-click the tab → "Name as @…", type the name, Enter.
+-- Then reference it from another tab's SQL. Run with Cmd/Ctrl+Enter.
+--
+-- 1) Core flow (runs immediately, shows the "refs inlined" pill)
+--    Tab A:  SELECT DISTINCT session_id FROM traffic_events
+--            WHERE country = 'US' ORDER BY session_id LIMIT 400;
+--    Name Tab A:  @us_sessions
+--    Tab B:  SELECT country, count(*) FROM traffic_events
+--            WHERE session_id IN (SELECT session_id FROM @us_sessions)
+--            GROUP BY country ORDER BY count(*) DESC;
+--    Expect: result lands; toolbar pill "1 ref · 400 rows inlined".
+--
+-- 2) Autocomplete + hover + diagnostics (no run needed)
+--    In Tab B, type "SELECT * FROM @"  → autocomplete lists @us_sessions
+--      with "400 rows · 1 cols". Hover @us_sessions → preview popover.
+--    Type "SELECT * FROM @ghost"       → red squiggle "No tab named @ghost".
+--    Open a new tab, name it @draft but DON'T run it, then reference @draft
+--      → amber squiggle "@draft hasn't been run yet."
+--
+-- 3) Heavy-confirm dialog (>1,000 inlined rows)
+--    Tab A:  SELECT * FROM traffic_events
+--            WHERE country IN ('US', 'GB', 'DE') LIMIT 2000;
+--    Name Tab A:  @big_sample
+--    Tab B:  SELECT count(*) FROM @big_sample;
+--    Expect: a confirm dialog ("Running with 1 tab reference · 2,000 rows").
+--      Cancel aborts; "Run query" proceeds; the "don't ask again this
+--      session" checkbox suppresses it for the rest of the session.
+--
+-- 4) Hard cap (>10,000 rows → refused)
+--    Tab A:  SELECT * FROM traffic_events;     -- 12,000 rows
+--    Name Tab A:  @everything
+--    Tab B:  SELECT count(*) FROM @everything;
+--    Expect: error banner "@everything has 12000 rows (cap 10,000). Add a
+--      LIMIT to the referenced query." (no query is sent to the DB).
+--
+-- 5) Error on a never-run / unknown ref (the run path, not just the editor)
+--    Run "SELECT * FROM @ghost" → banner "No tab named @ghost on this
+--      connection." Run "SELECT * FROM @draft" (named, never run) → banner
+--      "@draft hasn't been run yet — run it first."
+--
+-- 6) Cross-connection isolation (needs two connections)
+--    Name @us_sessions on connection A. Open a query tab on connection B and
+--      reference @us_sessions → it is NOT found (red squiggle + the same
+--      "No tab named …" error). Names are scoped per connection.
+--
+-- 7) Multi-dialect spot check (optional)
+--    Load acme_saas_mysql_seed.sql into a MySQL connection. Name a SELECT and
+--      reference it — note @offset / @count user-variables are left untouched
+--      (only registered tab names resolve on MySQL/MSSQL).
+
+
+-- Examples using acme_saas_seed.sql (load both files into one database) -------
+-- Tab A:  SELECT user_id FROM memberships WHERE role = 'owner';
+-- Name Tab A:  @owners
+-- Tab B:  SELECT u.name, count(e.id) AS events
+--         FROM users u
+--         JOIN events e ON e.user_id = u.id
+--         WHERE u.id IN (SELECT user_id FROM @owners)
+--         GROUP BY u.name
+--         ORDER BY events DESC;


### PR DESCRIPTION
## Summary

Builds the **integration layer** on top of #184's parser/resolver/validation core, turning cross-tab `@name` references into a working, end-to-end feature.

- **Name a query tab** `@active_users` (right-click → "Name as @…", inline rename with per-connection uniqueness + reserved-word validation; persists for pinned tabs).
- **Reference it from another tab**: `SELECT * FROM @active_users` resolves at run time — the referenced tab's result is inlined as a `VALUES`-backed CTE (dialect-aware: PG/SQLite/MySQL/MSSQL).
- **Editor magic** (Monaco): `@` autocomplete listing named tabs (rows·cols), hover preview, and inline diagnostics (red squiggle for unknown names, amber for not-yet-run).
- **Speed over ceremony**: runs immediately with a subtle "N refs · M rows inlined" pill; a confirm dialog appears **only** for heavy inlines (>1,000 rows or >256KB), with a "don't ask again this session" toggle. Hard caps (10k rows / 5MB) hard-fail with a clear message.

Only **query tabs** are nameable in v1; references are scoped per-connection.

### Architecture
Renderer-only. `resolveForRun()` (pure, in `lib/cross-tab-integration.ts`) is the single seam between the tab store and #184's resolver; `handleRunQuery` calls it and runs the rewritten SQL. The Monaco providers and the run path share one `namedQueryTabs` predicate, so editor hints and run behavior stay in lockstep. No IPC/main/shared changes.

Spec: `docs/superpowers/specs/2026-05-29-cross-tab-name-references-design.md`
Plan: `docs/superpowers/plans/2026-05-29-cross-tab-name-references.md`

### Deferred (not in this PR, by design)
Staleness tracking + badges, Cross-Tab settings panel, notebook-cell refs, table-preview-tab refs as targets, resolve-error action buttons.

## Test Plan
- [x] 753/753 unit tests pass (new: cross-tab-integration, tab-store naming, cross-tab-editor helpers)
- [x] Full typecheck (node + web) clean
- [ ] Manual: name tab A `@active_users` + run; in tab B `SELECT * FROM @active_users` → CTE-backed result; pill shows refs inlined
- [ ] Manual: type `@` → autocomplete; hover `@name` → preview; `@ghost` → red squiggle; named-but-unrun → amber squiggle
- [ ] Manual: reference a >1,000-row result → confirm dialog (Cancel aborts, "don't ask again" suppresses); cross-connection ref → "No tab named @x"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Name query tabs and reference them via `@name` with editor autocompletion, hover previews, diagnostic markers, and run-time inlining.

* **User Experience**
  * Inline renaming UI and context-menu actions to name/clear `@names`; toolbar pill showing refs/rows inlined.
  * Heavy-run confirmation dialog (with “Don’t ask again this session”) when large inlines are detected.

* **Persistence & Behavior**
  * Named-tab persistence for pinned tabs and connection-scoped name collision handling.

* **Documentation & Tests**
  * Design/plan docs, demo seed script, and extensive unit/integration tests for resolution, naming, and editor behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->