### PR TITLE
feat(video): keyboard cell-grid scene for the v0.23.0 release video

### DIFF
--- a/apps/video/src/Root.tsx
+++ b/apps/video/src/Root.tsx
@@ -34,7 +34,7 @@ export const RemotionRoot = () => {
       <Composition
         id="ReleaseVideo-v0-23-0"
         component={ReleaseVideo023}
-        durationInFrames={774}
+        durationInFrames={762}
         fps={30}
         width={1920}
         height={1080}

--- a/apps/video/src/Root.tsx
+++ b/apps/video/src/Root.tsx
@@ -34,7 +34,7 @@ export const RemotionRoot = () => {
       <Composition
         id="ReleaseVideo-v0-23-0"
         component={ReleaseVideo023}
-        durationInFrames={604}
+        durationInFrames={774}
         fps={30}
         width={1920}
         height={1080}

--- a/apps/video/src/compositions/ReleaseVideo023/CellGridScene.tsx
+++ b/apps/video/src/compositions/ReleaseVideo023/CellGridScene.tsx
@@ -1,0 +1,541 @@
+import {
+  AbsoluteFill,
+  useCurrentFrame,
+  useVideoConfig,
+  spring,
+  interpolate,
+} from 'remotion'
+import { brand } from '../../lib/colors'
+import { CyanGlow } from '../../components/CyanGlow'
+import { Keyboard } from 'lucide-react'
+
+/**
+ * Cell-grid scene: a focused cell ring snaps between cells via deterministic
+ * arrow-key choreography, then Enter docks an inspector that scrubs in
+ * lockstep with the cursor. ~150 frames (5s).
+ */
+
+const COL_COUNT = 4
+const ROW_COUNT = 6
+const ROW_HEIGHT = 38
+const HEADER_HEIGHT = 36
+const COLUMN_WIDTHS = [70, 280, 110, 160] as const
+const TOTAL_GRID_WIDTH = COLUMN_WIDTHS.reduce((a, b) => a + b, 0)
+
+const columns = [
+  { name: 'id', type: 'int4' },
+  { name: 'email', type: 'text' },
+  { name: 'plan', type: 'text' },
+  { name: 'created_at', type: 'timestamptz' },
+] as const
+
+type Row = readonly [number, string, 'free' | 'pro' | 'enterprise', string]
+const rows: Row[] = [
+  [1842, 'jordan@cmp.io', 'pro', '2026-04-12 08:43:12+00'],
+  [1843, 'sam.lee.developer@really-long-domain.example.com', 'free', '2026-04-12 09:11:04+00'],
+  [1844, 'ana@cmp.io', 'enterprise', '2026-04-13 14:22:51+00'],
+  [1845, 'devops-bot+notifications@cmp.io', 'pro', '2026-04-14 07:05:33+00'],
+  [1846, 'hi@k.so', 'free', '2026-04-14 10:50:18+00'],
+  [1847, 'billing@cmp.io', 'pro', '2026-04-15 12:18:47+00'],
+]
+
+type ArrowKey = 'right' | 'down' | 'enter'
+type KeyEvent = { frame: number; key: ArrowKey }
+
+// Choreography — starts at (0,0), each event advances focus and (eventually) opens inspector.
+const events: KeyEvent[] = [
+  { frame: 26, key: 'right' }, // (0,0) → (1,0) — long email cell
+  { frame: 42, key: 'down' }, // (1,0) → (1,1)
+  { frame: 58, key: 'enter' }, // open inspector at (1,1)
+  { frame: 88, key: 'down' }, // (1,1) → (1,2)
+  { frame: 104, key: 'right' }, // (1,2) → (2,2)
+  { frame: 120, key: 'down' }, // (2,2) → (2,3)
+]
+
+interface FocusState {
+  col: number
+  row: number
+  changedAt: number
+  inspectorOpenAtFrame: number | null
+  lastKey: ArrowKey | null
+  lastKeyFrame: number
+}
+
+function resolveFocus(frame: number): FocusState {
+  let col = 0
+  let row = 0
+  let changedAt = 0
+  let inspectorOpenAtFrame: number | null = null
+  let lastKey: ArrowKey | null = null
+  let lastKeyFrame = -100
+  for (const ev of events) {
+    if (ev.frame > frame) break
+    lastKey = ev.key
+    lastKeyFrame = ev.frame
+    if (ev.key === 'right') {
+      col = Math.min(col + 1, COL_COUNT - 1)
+      changedAt = ev.frame
+    } else if (ev.key === 'down') {
+      row = Math.min(row + 1, ROW_COUNT - 1)
+      changedAt = ev.frame
+    } else if (ev.key === 'enter' && inspectorOpenAtFrame === null) {
+      inspectorOpenAtFrame = ev.frame
+    }
+  }
+  return { col, row, changedAt, inspectorOpenAtFrame, lastKey, lastKeyFrame }
+}
+
+const ACCENT = brand.accent
+
+export const CellGridScene: React.FC = () => {
+  const frame = useCurrentFrame()
+  const { fps } = useVideoConfig()
+
+  const cardEntrance = spring({ frame, fps, config: { damping: 200 } })
+  const cardOpacity = interpolate(cardEntrance, [0, 1], [0, 1])
+  const cardTy = interpolate(cardEntrance, [0, 1], [30, 0])
+
+  const focus = resolveFocus(frame)
+
+  // Geometry: prefix-sum x offsets, fixed row height.
+  const colOffsets: number[] = []
+  {
+    let running = 0
+    for (const w of COLUMN_WIDTHS) {
+      colOffsets.push(running)
+      running += w
+    }
+  }
+  const targetX = colOffsets[focus.col]
+  const targetW = COLUMN_WIDTHS[focus.col]
+  const targetY = HEADER_HEIGHT + focus.row * ROW_HEIGHT
+
+  // Snap interpolation — match the 160ms snap from the real grid.
+  const ringX = interpolate(
+    frame,
+    [focus.changedAt, focus.changedAt + Math.round(fps * 0.16)],
+    [colOffsets[focus.col === 0 ? 0 : Math.max(0, focus.col)], targetX],
+    { extrapolateLeft: 'clamp', extrapolateRight: 'clamp', easing: easingSnap }
+  )
+  // Animate Y similarly by interpolating from previous-row position. For
+  // determinism we just snap-with-easing toward target from where we were
+  // a frame before the change.
+  const prevY =
+    focus.changedAt === 0
+      ? targetY
+      : HEADER_HEIGHT +
+        (resolveFocus(focus.changedAt - 1).row) * ROW_HEIGHT
+  const prevX =
+    focus.changedAt === 0
+      ? targetX
+      : colOffsets[resolveFocus(focus.changedAt - 1).col]
+  const animX = interpolate(
+    frame,
+    [focus.changedAt, focus.changedAt + Math.round(fps * 0.16)],
+    [prevX, targetX],
+    { extrapolateLeft: 'clamp', extrapolateRight: 'clamp', easing: easingSnap }
+  )
+  const animY = interpolate(
+    frame,
+    [focus.changedAt, focus.changedAt + Math.round(fps * 0.16)],
+    [prevY, targetY],
+    { extrapolateLeft: 'clamp', extrapolateRight: 'clamp', easing: easingSnap }
+  )
+  const animW = targetW
+
+  const inspectorOpen = focus.inspectorOpenAtFrame !== null
+  const inspectorAge = inspectorOpen
+    ? frame - (focus.inspectorOpenAtFrame as number)
+    : -1
+  const inspectorEntrance = inspectorOpen
+    ? Math.min(1, Math.max(0, inspectorAge / Math.round(fps * 0.22)))
+    : 0
+  const inspectorOpacity = inspectorEntrance
+  const inspectorTx = interpolate(inspectorEntrance, [0, 1], [40, 0])
+
+  const focusedCellValue = String(rows[focus.row][focus.col])
+  const focusedCol = columns[focus.col]
+  const focusedRow = rows[focus.row]
+
+  return (
+    <AbsoluteFill
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '0 60px',
+        gap: 16,
+      }}
+    >
+      <CyanGlow size={420} y="42%" delay={0} />
+
+      <KeyTicker lastKey={focus.lastKey} lastKeyFrame={focus.lastKeyFrame} frame={frame} fps={fps} />
+
+      <div
+        style={{
+          opacity: cardOpacity,
+          transform: `translateY(${cardTy}px)`,
+          display: 'flex',
+          gap: 20,
+          alignItems: 'flex-start',
+        }}
+      >
+        {/* Grid card */}
+        <div
+          style={{
+            width: TOTAL_GRID_WIDTH + 56,
+            backgroundColor: brand.surface,
+            borderRadius: 16,
+            border: `1px solid ${brand.border}`,
+            padding: 28,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 12,
+          }}
+        >
+          {/* Title bar */}
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 12,
+              paddingBottom: 12,
+              borderBottom: `1px solid ${brand.border}`,
+            }}
+          >
+            <Keyboard size={16} color={ACCENT} />
+            <code
+              style={{
+                fontFamily: 'Geist Mono, monospace',
+                fontSize: 14,
+                color: brand.textSecondary,
+                flex: 1,
+              }}
+            >
+              SELECT id, email, plan, created_at FROM users LIMIT 6
+            </code>
+            <span
+              style={{
+                fontFamily: 'Geist Mono, monospace',
+                fontSize: 12,
+                color: brand.textMuted,
+              }}
+            >
+              {rows.length} rows
+            </span>
+          </div>
+
+          {/* Grid + focus overlay */}
+          <div style={{ position: 'relative', width: TOTAL_GRID_WIDTH, height: HEADER_HEIGHT + ROW_COUNT * ROW_HEIGHT }}>
+            {/* Header */}
+            <div
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: TOTAL_GRID_WIDTH,
+                height: HEADER_HEIGHT,
+                display: 'flex',
+                borderBottom: `1px solid ${brand.border}`,
+                fontFamily: 'Geist Mono, monospace',
+                fontSize: 11,
+                color: brand.textMuted,
+                textTransform: 'uppercase',
+                letterSpacing: '0.08em',
+                alignItems: 'center',
+              }}
+            >
+              {columns.map((c, i) => (
+                <div
+                  key={c.name}
+                  style={{
+                    width: COLUMN_WIDTHS[i],
+                    paddingLeft: 10,
+                    paddingRight: 10,
+                  }}
+                >
+                  {c.name}
+                </div>
+              ))}
+            </div>
+
+            {/* Row stripe (focused row) */}
+            <div
+              style={{
+                position: 'absolute',
+                top: HEADER_HEIGHT + focus.row * ROW_HEIGHT,
+                left: 0,
+                width: TOTAL_GRID_WIDTH,
+                height: ROW_HEIGHT,
+                background: `${ACCENT}0d`,
+                transition: 'top 160ms',
+                pointerEvents: 'none',
+              }}
+            />
+
+            {/* Cells */}
+            {rows.map((r, ri) => (
+              <div
+                key={ri}
+                style={{
+                  position: 'absolute',
+                  top: HEADER_HEIGHT + ri * ROW_HEIGHT,
+                  left: 0,
+                  width: TOTAL_GRID_WIDTH,
+                  height: ROW_HEIGHT,
+                  display: 'flex',
+                  alignItems: 'center',
+                  fontFamily: 'Geist Mono, monospace',
+                  fontSize: 14,
+                  color: brand.textPrimary,
+                  borderBottom:
+                    ri === rows.length - 1
+                      ? 'none'
+                      : `1px solid ${brand.border}30`,
+                }}
+              >
+                {r.map((v, ci) => (
+                  <div
+                    key={ci}
+                    style={{
+                      width: COLUMN_WIDTHS[ci],
+                      paddingLeft: 10,
+                      paddingRight: 10,
+                      whiteSpace: 'nowrap',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      color:
+                        ci === 0
+                          ? brand.textMuted
+                          : ci === 2
+                            ? planColor(v as string)
+                            : brand.textSecondary,
+                    }}
+                  >
+                    {String(v)}
+                  </div>
+                ))}
+              </div>
+            ))}
+
+            {/* Focus ring overlay */}
+            <div
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: animW,
+                height: ROW_HEIGHT,
+                transform: `translate3d(${animX}px, ${animY}px, 0)`,
+                background: `${ACCENT}1f`,
+                boxShadow: `inset 0 0 0 1px ${ACCENT}40, 0 0 0 2px ${ACCENT}`,
+                borderRadius: 4,
+                pointerEvents: 'none',
+              }}
+            />
+          </div>
+        </div>
+
+        {/* Inspector */}
+        {inspectorOpen && (
+          <div
+            style={{
+              opacity: inspectorOpacity,
+              transform: `translateX(${inspectorTx}px)`,
+              width: 360,
+              backgroundColor: brand.surface,
+              borderRadius: 16,
+              border: `1px solid ${ACCENT}40`,
+              boxShadow: `0 0 0 1px ${ACCENT}1a`,
+              padding: 24,
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 14,
+              fontFamily: 'Geist Mono, monospace',
+            }}
+          >
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                paddingBottom: 10,
+                borderBottom: `1px solid ${brand.border}`,
+              }}
+            >
+              <span
+                style={{
+                  fontSize: 11,
+                  color: brand.textMuted,
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.1em',
+                }}
+              >
+                Inspector
+              </span>
+              <span
+                style={{
+                  fontSize: 11,
+                  color: brand.textMuted,
+                  padding: '3px 8px',
+                  border: `1px solid ${brand.border}`,
+                  borderRadius: 6,
+                }}
+              >
+                Esc to close
+              </span>
+            </div>
+
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+              <span
+                style={{
+                  fontSize: 11,
+                  color: brand.textMuted,
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.1em',
+                }}
+              >
+                {focusedCol.name}
+              </span>
+              <span style={{ fontSize: 11, color: ACCENT }}>{focusedCol.type}</span>
+            </div>
+
+            <div
+              style={{
+                fontSize: 15,
+                color: brand.textPrimary,
+                lineHeight: 1.4,
+                wordBreak: 'break-all',
+                padding: '12px 14px',
+                background: `${ACCENT}08`,
+                borderRadius: 8,
+                border: `1px solid ${brand.border}`,
+                minHeight: 60,
+              }}
+            >
+              {focusedCellValue}
+            </div>
+
+            <div
+              style={{
+                display: 'flex',
+                gap: 16,
+                fontSize: 11,
+                color: brand.textMuted,
+                paddingTop: 10,
+                borderTop: `1px solid ${brand.border}`,
+              }}
+            >
+              <span>
+                {focusedCellValue.length} chars
+              </span>
+              <span>·</span>
+              <span>{byteCount(focusedCellValue)} bytes</span>
+              <span style={{ marginLeft: 'auto', color: brand.textSecondary }}>
+                row {focus.row + 1} of {ROW_COUNT}
+              </span>
+            </div>
+          </div>
+        )}
+      </div>
+
+      <Caption frame={frame} fps={fps} />
+    </AbsoluteFill>
+  )
+}
+
+function easingSnap(t: number): number {
+  // cubic-bezier(0.32, 0.72, 0, 1) approximation — fast start, soft landing.
+  return 1 - Math.pow(1 - t, 3)
+}
+
+function planColor(plan: string): string {
+  if (plan === 'pro') return brand.accent
+  if (plan === 'enterprise') return brand.purple
+  return brand.textMuted
+}
+
+function byteCount(s: string): number {
+  // Approximation; for ASCII matches char count. Realistic for the demo data.
+  return new TextEncoder().encode(s).length
+}
+
+const KeyTicker: React.FC<{
+  lastKey: ArrowKey | null
+  lastKeyFrame: number
+  frame: number
+  fps: number
+}> = ({ lastKey, lastKeyFrame, frame, fps }) => {
+  const age = frame - lastKeyFrame
+  const visible = lastKey !== null && age >= 0 && age < fps * 0.7
+  const op = visible ? Math.max(0, 1 - age / (fps * 0.7)) : 0
+  const label =
+    lastKey === 'right'
+      ? '→'
+      : lastKey === 'down'
+        ? '↓'
+        : lastKey === 'enter'
+          ? 'Enter'
+          : ''
+
+  return (
+    <div
+      style={{
+        height: 40,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 10,
+        opacity: 0.95,
+      }}
+    >
+      <span
+        style={{
+          fontFamily: 'Geist Mono, monospace',
+          fontSize: 13,
+          color: brand.textMuted,
+          textTransform: 'uppercase',
+          letterSpacing: '0.1em',
+        }}
+      >
+        Keyboard
+      </span>
+      <span
+        style={{
+          fontFamily: 'Geist Mono, monospace',
+          fontSize: 16,
+          padding: '4px 12px',
+          minWidth: 56,
+          textAlign: 'center',
+          borderRadius: 6,
+          color: brand.accent,
+          background: `${brand.accent}14`,
+          border: `1px solid ${brand.accent}33`,
+          opacity: op,
+        }}
+      >
+        {label || ' '}
+      </span>
+    </div>
+  )
+}
+
+const Caption: React.FC<{ frame: number; fps: number }> = ({ frame, fps }) => {
+  const op = interpolate(frame, [10, 25], [0, 1], {
+    extrapolateLeft: 'clamp',
+    extrapolateRight: 'clamp',
+  })
+  return (
+    <div
+      style={{
+        opacity: op,
+        fontFamily: 'Geist Mono, monospace',
+        fontSize: 18,
+        color: brand.textMuted,
+        marginTop: 4,
+      }}
+    >
+      arrow keys move · Enter inspects · Cmd+C copies
+    </div>
+  )
+}

--- a/apps/video/src/compositions/ReleaseVideo023/CellGridScene.tsx
+++ b/apps/video/src/compositions/ReleaseVideo023/CellGridScene.tsx
@@ -7,19 +7,19 @@ import {
 } from 'remotion'
 import { brand } from '../../lib/colors'
 import { CyanGlow } from '../../components/CyanGlow'
-import { Keyboard } from 'lucide-react'
+import { Keyboard, Check } from 'lucide-react'
 
 /**
  * Cell-grid scene: a focused cell ring snaps between cells via deterministic
- * arrow-key choreography, then Enter docks an inspector that scrubs in
- * lockstep with the cursor. ~150 frames (5s).
+ * arrow-key choreography, Enter docks an inspector that tracks the focused
+ * cell, and ⌘C fires a "Copied" flash. 170 frames (~5.7s @ 30fps).
  */
 
-const COL_COUNT = 4
 const ROW_COUNT = 6
 const ROW_HEIGHT = 38
 const HEADER_HEIGHT = 36
 const COLUMN_WIDTHS = [70, 280, 110, 160] as const
+const COL_COUNT = COLUMN_WIDTHS.length
 const TOTAL_GRID_WIDTH = COLUMN_WIDTHS.reduce((a, b) => a + b, 0)
 
 const columns = [
@@ -39,17 +39,19 @@ const rows: Row[] = [
   [1847, 'billing@cmp.io', 'pro', '2026-04-15 12:18:47+00'],
 ]
 
-type ArrowKey = 'right' | 'down' | 'enter'
-type KeyEvent = { frame: number; key: ArrowKey }
+type KeyAction = 'right' | 'down' | 'enter' | 'copy'
+type KeyEvent = { frame: number; key: KeyAction }
 
-// Choreography — starts at (0,0), each event advances focus and (eventually) opens inspector.
+// Choreography — pairs are (col, row); starts at (0,0). Must stay frame-sorted
+// (resolveFocus stops at the first event past the current frame).
 const events: KeyEvent[] = [
-  { frame: 26, key: 'right' }, // (0,0) → (1,0) — long email cell
-  { frame: 42, key: 'down' }, // (1,0) → (1,1)
+  { frame: 26, key: 'right' }, // (0,0) → (1,0) — email column
+  { frame: 42, key: 'down' }, // (1,0) → (1,1) — the long, truncated email
   { frame: 58, key: 'enter' }, // open inspector at (1,1)
   { frame: 88, key: 'down' }, // (1,1) → (1,2)
   { frame: 104, key: 'right' }, // (1,2) → (2,2)
   { frame: 120, key: 'down' }, // (2,2) → (2,3)
+  { frame: 142, key: 'copy' }, // ⌘C — copy the focused cell (pays off the caption)
 ]
 
 interface FocusState {
@@ -57,7 +59,8 @@ interface FocusState {
   row: number
   changedAt: number
   inspectorOpenAtFrame: number | null
-  lastKey: ArrowKey | null
+  copyAtFrame: number | null
+  lastKey: KeyAction | null
   lastKeyFrame: number
 }
 
@@ -66,7 +69,8 @@ function resolveFocus(frame: number): FocusState {
   let row = 0
   let changedAt = 0
   let inspectorOpenAtFrame: number | null = null
-  let lastKey: ArrowKey | null = null
+  let copyAtFrame: number | null = null
+  let lastKey: KeyAction | null = null
   let lastKeyFrame = -100
   for (const ev of events) {
     if (ev.frame > frame) break
@@ -80,9 +84,11 @@ function resolveFocus(frame: number): FocusState {
       changedAt = ev.frame
     } else if (ev.key === 'enter' && inspectorOpenAtFrame === null) {
       inspectorOpenAtFrame = ev.frame
+    } else if (ev.key === 'copy' && copyAtFrame === null) {
+      copyAtFrame = ev.frame
     }
   }
-  return { col, row, changedAt, inspectorOpenAtFrame, lastKey, lastKeyFrame }
+  return { col, row, changedAt, inspectorOpenAtFrame, copyAtFrame, lastKey, lastKeyFrame }
 }
 
 const ACCENT = brand.accent
@@ -110,25 +116,14 @@ export const CellGridScene: React.FC = () => {
   const targetW = COLUMN_WIDTHS[focus.col]
   const targetY = HEADER_HEIGHT + focus.row * ROW_HEIGHT
 
-  // Snap interpolation — match the 160ms snap from the real grid.
-  const ringX = interpolate(
-    frame,
-    [focus.changedAt, focus.changedAt + Math.round(fps * 0.16)],
-    [colOffsets[focus.col === 0 ? 0 : Math.max(0, focus.col)], targetX],
-    { extrapolateLeft: 'clamp', extrapolateRight: 'clamp', easing: easingSnap }
-  )
-  // Animate Y similarly by interpolating from previous-row position. For
-  // determinism we just snap-with-easing toward target from where we were
-  // a frame before the change.
+  // Snap from where the ring sat a frame before the change toward the new
+  // target, eased over ~160ms — matches the real grid's snap.
   const prevY =
     focus.changedAt === 0
       ? targetY
-      : HEADER_HEIGHT +
-        (resolveFocus(focus.changedAt - 1).row) * ROW_HEIGHT
+      : HEADER_HEIGHT + resolveFocus(focus.changedAt - 1).row * ROW_HEIGHT
   const prevX =
-    focus.changedAt === 0
-      ? targetX
-      : colOffsets[resolveFocus(focus.changedAt - 1).col]
+    focus.changedAt === 0 ? targetX : colOffsets[resolveFocus(focus.changedAt - 1).col]
   const animX = interpolate(
     frame,
     [focus.changedAt, focus.changedAt + Math.round(fps * 0.16)],
@@ -141,21 +136,43 @@ export const CellGridScene: React.FC = () => {
     [prevY, targetY],
     { extrapolateLeft: 'clamp', extrapolateRight: 'clamp', easing: easingSnap }
   )
-  const animW = targetW
 
+  const inspectorAge =
+    focus.inspectorOpenAtFrame !== null ? frame - focus.inspectorOpenAtFrame : -1
   const inspectorOpen = focus.inspectorOpenAtFrame !== null
-  const inspectorAge = inspectorOpen
-    ? frame - (focus.inspectorOpenAtFrame as number)
-    : -1
   const inspectorEntrance = inspectorOpen
     ? Math.min(1, Math.max(0, inspectorAge / Math.round(fps * 0.22)))
     : 0
   const inspectorOpacity = inspectorEntrance
   const inspectorTx = interpolate(inspectorEntrance, [0, 1], [40, 0])
 
+  // Copy flash — a "Copied" pill rising from the focused cell + a brief ring
+  // pulse, paying off the "Cmd+C copies" caption.
+  const copyAge = focus.copyAtFrame !== null ? frame - focus.copyAtFrame : -1
+  const copyActive = copyAge >= 0
+  const copyRise = interpolate(copyAge, [0, Math.round(fps * 0.9)], [4, -18], {
+    extrapolateLeft: 'clamp',
+    extrapolateRight: 'clamp',
+  })
+  const copyOpacity = copyActive
+    ? interpolate(
+        copyAge,
+        [0, Math.round(fps * 0.12), Math.round(fps * 0.7), Math.round(fps * 0.95)],
+        [0, 1, 1, 0],
+        { extrapolateLeft: 'clamp', extrapolateRight: 'clamp' }
+      )
+    : 0
+  const copyPulse = copyActive
+    ? interpolate(copyAge, [0, Math.round(fps * 0.18)], [0.4, 0], {
+        extrapolateLeft: 'clamp',
+        extrapolateRight: 'clamp',
+      })
+    : 0
+  const copyPillTransform =
+    `translate3d(${animX + targetW / 2}px, ${animY + copyRise}px, 0) translate(-50%, -100%)`
+
   const focusedCellValue = String(rows[focus.row][focus.col])
   const focusedCol = columns[focus.col]
-  const focusedRow = rows[focus.row]
 
   return (
     <AbsoluteFill
@@ -170,7 +187,12 @@ export const CellGridScene: React.FC = () => {
     >
       <CyanGlow size={420} y="42%" delay={0} />
 
-      <KeyTicker lastKey={focus.lastKey} lastKeyFrame={focus.lastKeyFrame} frame={frame} fps={fps} />
+      <KeyTicker
+        lastKey={focus.lastKey}
+        lastKeyFrame={focus.lastKeyFrame}
+        frame={frame}
+        fps={fps}
+      />
 
       <div
         style={{
@@ -227,7 +249,13 @@ export const CellGridScene: React.FC = () => {
           </div>
 
           {/* Grid + focus overlay */}
-          <div style={{ position: 'relative', width: TOTAL_GRID_WIDTH, height: HEADER_HEIGHT + ROW_COUNT * ROW_HEIGHT }}>
+          <div
+            style={{
+              position: 'relative',
+              width: TOTAL_GRID_WIDTH,
+              height: HEADER_HEIGHT + ROW_COUNT * ROW_HEIGHT,
+            }}
+          >
             {/* Header */}
             <div
               style={{
@@ -260,16 +288,16 @@ export const CellGridScene: React.FC = () => {
               ))}
             </div>
 
-            {/* Row stripe (focused row) */}
+            {/* Row stripe (focused row) — glides with the ring via animY */}
             <div
               style={{
                 position: 'absolute',
-                top: HEADER_HEIGHT + focus.row * ROW_HEIGHT,
+                top: 0,
                 left: 0,
                 width: TOTAL_GRID_WIDTH,
                 height: ROW_HEIGHT,
+                transform: `translateY(${animY}px)`,
                 background: `${ACCENT}0d`,
-                transition: 'top 160ms',
                 pointerEvents: 'none',
               }}
             />
@@ -290,9 +318,7 @@ export const CellGridScene: React.FC = () => {
                   fontSize: 14,
                   color: brand.textPrimary,
                   borderBottom:
-                    ri === rows.length - 1
-                      ? 'none'
-                      : `1px solid ${brand.border}30`,
+                    ri === rows.length - 1 ? 'none' : `1px solid ${brand.border}30`,
                 }}
               >
                 {r.map((v, ci) => (
@@ -325,7 +351,7 @@ export const CellGridScene: React.FC = () => {
                 position: 'absolute',
                 top: 0,
                 left: 0,
-                width: animW,
+                width: targetW,
                 height: ROW_HEIGHT,
                 transform: `translate3d(${animX}px, ${animY}px, 0)`,
                 background: `${ACCENT}1f`,
@@ -334,6 +360,50 @@ export const CellGridScene: React.FC = () => {
                 pointerEvents: 'none',
               }}
             />
+
+            {/* Copy flash — ring pulse + "Copied" pill rising from the cell */}
+            {copyActive && (
+              <>
+                <div
+                  style={{
+                    position: 'absolute',
+                    top: 0,
+                    left: 0,
+                    width: targetW,
+                    height: ROW_HEIGHT,
+                    transform: `translate3d(${animX}px, ${animY}px, 0)`,
+                    background: ACCENT,
+                    opacity: copyPulse,
+                    borderRadius: 4,
+                    pointerEvents: 'none',
+                  }}
+                />
+                <div
+                  style={{
+                    position: 'absolute',
+                    top: 0,
+                    left: 0,
+                    transform: copyPillTransform,
+                    opacity: copyOpacity,
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 6,
+                    padding: '4px 10px',
+                    borderRadius: 999,
+                    background: brand.surfaceElevated,
+                    border: `1px solid ${brand.accent}55`,
+                    color: brand.accent,
+                    fontFamily: 'Geist Mono, monospace',
+                    fontSize: 12,
+                    whiteSpace: 'nowrap',
+                    pointerEvents: 'none',
+                  }}
+                >
+                  <Check size={12} color={brand.accent} />
+                  Copied
+                </div>
+              </>
+            )}
           </div>
         </div>
 
@@ -427,9 +497,7 @@ export const CellGridScene: React.FC = () => {
                 borderTop: `1px solid ${brand.border}`,
               }}
             >
-              <span>
-                {focusedCellValue.length} chars
-              </span>
+              <span>{focusedCellValue.length} chars</span>
               <span>·</span>
               <span>{byteCount(focusedCellValue)} bytes</span>
               <span style={{ marginLeft: 'auto', color: brand.textSecondary }}>
@@ -446,7 +514,7 @@ export const CellGridScene: React.FC = () => {
 }
 
 function easingSnap(t: number): number {
-  // cubic-bezier(0.32, 0.72, 0, 1) approximation — fast start, soft landing.
+  // ease-out-cubic — fast start, soft decelerating landing.
   return 1 - Math.pow(1 - t, 3)
 }
 
@@ -457,12 +525,12 @@ function planColor(plan: string): string {
 }
 
 function byteCount(s: string): number {
-  // Approximation; for ASCII matches char count. Realistic for the demo data.
+  // Exact UTF-8 byte length; equals char count for the ASCII-only demo data.
   return new TextEncoder().encode(s).length
 }
 
 const KeyTicker: React.FC<{
-  lastKey: ArrowKey | null
+  lastKey: KeyAction | null
   lastKeyFrame: number
   frame: number
   fps: number
@@ -477,7 +545,9 @@ const KeyTicker: React.FC<{
         ? '↓'
         : lastKey === 'enter'
           ? 'Enter'
-          : ''
+          : lastKey === 'copy'
+            ? '⌘C'
+            : ''
 
   return (
     <div

--- a/apps/video/src/compositions/ReleaseVideo023/index.tsx
+++ b/apps/video/src/compositions/ReleaseVideo023/index.tsx
@@ -8,6 +8,7 @@ import { Background } from '../../components/Background'
 import { Intro } from './Intro'
 import { WatchHero } from './WatchHero'
 import { SafetyGate } from './SafetyGate'
+import { CellGridScene } from './CellGridScene'
 import { Outro } from './Outro'
 import { ensureFonts } from '../../lib/fonts'
 
@@ -52,6 +53,11 @@ export const ReleaseVideo023: React.FC<ReleaseVideoProps> = ({ version }) => {
         <TransitionSeries.Transition presentation={slidePresentation} timing={fadeTiming} />
         <TransitionSeries.Sequence durationInFrames={150}>
           <SafetyGate />
+        </TransitionSeries.Sequence>
+
+        <TransitionSeries.Transition presentation={slidePresentation} timing={fadeTiming} />
+        <TransitionSeries.Sequence durationInFrames={170}>
+          <CellGridScene />
         </TransitionSeries.Sequence>
 
         <TransitionSeries.Transition presentation={fadePresentation} timing={fadeTiming} />


### PR DESCRIPTION
## Summary

Adds a **keyboard cell-grid scene** to the v0.23.0 release video (`ReleaseVideo023`) so the launch reel covers the release's *second* headline feature (arrow-key cell navigation + docked inspector) alongside Watch Mode.

- **`CellGridScene.tsx`** (new, ~170 frames): a focused cell ring snaps right/down between cells on a deterministic keystroke timeline, then `Enter` docks an inspector that scrubs in lockstep with the cursor. Uses the shared `brand` palette + `CyanGlow`, Geist Mono — matches the existing scenes.
- **`index.tsx`**: wires the scene in after `SafetyGate`, before `Outro`, with a slide transition.
- **`Root.tsx`**: bumps composition duration `604 → 774` frames.

## Note / possible follow-up
The duration bump is ~12 frames generous: a 170-frame sequence behind a 12-frame transition adds 158 frames of content, so `604 → 762` is exact — `774` leaves a ~0.4s hold on the Outro. Harmless, but `762` trims the tail if you want it tight. The rendered `out/*.mp4` isn't updated in this PR — re-render to produce the full cut.

## Test plan
- [x] `apps/video` typecheck clean (`pnpm --filter @data-peek/video typecheck`)
- [ ] Preview in Remotion Studio (`pnpm --filter @data-peek/video dev`) — check the scene timing + slide transition
- [ ] Re-render the full video and sanity-check the cell-grid section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new animated scene with grid-based navigation, keyboard-driven focus movement, a dynamic inspector panel showing focused cell details and content stats, key-ticker and copy feedback animations.

* **Updates**
  * Extended the release video duration to include the new scene and transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->