### PR TITLE
Test coverage: DB adapters, query handler, scheduler, command search (#2, #9, #10)

### DIFF
--- a/apps/desktop/src/main/__tests__/mssql-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/mssql-adapter.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { ConnectionConfig } from '@shared/index'
+
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+}))
+vi.mock('../ssh-tunnel-service', () => ({
+  createTunnel: vi.fn(),
+  closeTunnel: vi.fn(),
+  TunnelSession: class {}
+}))
+
+import {
+  resolveMSSQLType,
+  inferTypeFromValue,
+  isDataReturningStatement,
+  toMSSQLConfig
+} from '../adapters/mssql-adapter'
+
+function makeConfig(overrides: Partial<ConnectionConfig> = {}): ConnectionConfig {
+  return {
+    id: 's1',
+    name: 'test-mssql',
+    host: 'db.example.com',
+    port: 1433,
+    database: 'app',
+    user: 'u',
+    password: 'p',
+    dbType: 'mssql',
+    dstPort: 1433,
+    ...overrides
+  }
+}
+
+describe('resolveMSSQLType', () => {
+  it('falls back to unknown(id) for unmapped type ids', () => {
+    expect(resolveMSSQLType(-1)).toBe('unknown(-1)')
+  })
+})
+
+describe('inferTypeFromValue', () => {
+  it('null/undefined infer nvarchar', () => {
+    expect(inferTypeFromValue(null)).toEqual({ dataType: 'nvarchar', dataTypeID: 231 })
+    expect(inferTypeFromValue(undefined)).toEqual({ dataType: 'nvarchar', dataTypeID: 231 })
+  })
+
+  it('distinguishes integer from float', () => {
+    expect(inferTypeFromValue(5)).toEqual({ dataType: 'int', dataTypeID: 56 })
+    expect(inferTypeFromValue(5.5)).toEqual({ dataType: 'float', dataTypeID: 62 })
+  })
+
+  it('maps boolean to bit, Date to datetime, objects to nvarchar', () => {
+    expect(inferTypeFromValue(true)).toEqual({ dataType: 'bit', dataTypeID: 104 })
+    expect(inferTypeFromValue(new Date())).toEqual({ dataType: 'datetime', dataTypeID: 61 })
+    expect(inferTypeFromValue({ a: 1 })).toEqual({ dataType: 'nvarchar', dataTypeID: 231 })
+  })
+})
+
+describe('isDataReturningStatement (mssql)', () => {
+  it.each([
+    ['SELECT 1', true],
+    ['WITH cte AS (SELECT 1) SELECT * FROM cte', true],
+    ['EXEC sp_who', true],
+    ['EXECUTE sp_who', true],
+    ['EXECUTE AS CALLER', false],
+    ['INSERT INTO t OUTPUT inserted.id VALUES (1)', true],
+    ['INSERT INTO t VALUES (1)', false],
+    ['UPDATE t SET a = 1', false]
+  ])('%s -> %s', (sql, expected) => {
+    expect(isDataReturningStatement(sql)).toBe(expected)
+  })
+})
+
+describe('toMSSQLConfig', () => {
+  it('SQL auth maps server/port/database and credentials', () => {
+    const cfg = toMSSQLConfig(makeConfig())
+    expect(cfg.server).toBe('db.example.com')
+    expect(cfg.port).toBe(1433)
+    expect(cfg.database).toBe('app')
+    expect(cfg.user).toBe('u')
+    expect(cfg.password).toBe('p')
+  })
+
+  it('applies tunnel host/port overrides', () => {
+    const cfg = toMSSQLConfig(makeConfig(), { host: '127.0.0.1', port: 14333 })
+    expect(cfg.server).toBe('127.0.0.1')
+    expect(cfg.port).toBe(14333)
+  })
+
+  it('Azure AD Integrated sets azure auth and omits user/password', () => {
+    const cfg = toMSSQLConfig(
+      makeConfig({ mssqlOptions: { authentication: 'ActiveDirectoryIntegrated' } })
+    )
+    expect(cfg.authentication).toEqual({ type: 'azure-active-directory-default', options: {} })
+    expect(cfg.user).toBeUndefined()
+    expect(cfg.password).toBeUndefined()
+    // trustServerCertificate is intentionally not set for Azure AD
+    expect(cfg.options?.trustServerCertificate).toBeUndefined()
+  })
+
+  it('without ssl defaults trustServerCertificate to true', () => {
+    const cfg = toMSSQLConfig(makeConfig({ ssl: false }))
+    expect(cfg.options?.trustServerCertificate).toBe(true)
+  })
+
+  it('with ssl enables encrypt', () => {
+    const cfg = toMSSQLConfig(makeConfig({ ssl: true }))
+    expect(cfg.options?.encrypt).toBe(true)
+  })
+
+  it('defaults requestTimeout to 0 (no timeout) for long-running queries', () => {
+    const cfg = toMSSQLConfig(makeConfig())
+    expect(cfg.options?.requestTimeout).toBe(0)
+  })
+})

--- a/apps/desktop/src/main/__tests__/mysql-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/mysql-adapter.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { ConnectionConfig } from '@shared/index'
+
+// The adapter reaches electron via lib/logger (through query-tracker) and pulls in
+// ssh2 via ssh-tunnel-service; neither is needed to exercise the pure helpers.
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+}))
+vi.mock('../ssh-tunnel-service', () => ({
+  createTunnel: vi.fn(),
+  closeTunnel: vi.fn(),
+  TunnelSession: class {}
+}))
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>()
+  return { ...actual, readFileSync: vi.fn(() => 'CA_CERT_CONTENT') }
+})
+
+import {
+  resolveMySQLType,
+  normalizeRow,
+  isDataReturningStatement,
+  toMySQLConfig
+} from '../adapters/mysql-adapter'
+
+function makeConfig(overrides: Partial<ConnectionConfig> = {}): ConnectionConfig {
+  return {
+    id: 'm1',
+    name: 'test-mysql',
+    host: 'db.example.com',
+    port: 3306,
+    database: 'app',
+    user: 'u',
+    password: 'p',
+    dbType: 'mysql',
+    dstPort: 3306,
+    ...overrides
+  }
+}
+
+describe('resolveMySQLType', () => {
+  it('maps known type codes to names', () => {
+    expect(resolveMySQLType(254)).toBe('string')
+    expect(resolveMySQLType(255)).toBe('geometry')
+  })
+
+  it('falls back to unknown(code) for unmapped codes', () => {
+    expect(resolveMySQLType(9999)).toBe('unknown(9999)')
+  })
+})
+
+describe('normalizeRow', () => {
+  it('lowercases every key', () => {
+    expect(normalizeRow({ ID: 1, Name: 'x', EMAIL: 'a@b' })).toEqual({
+      id: 1,
+      name: 'x',
+      email: 'a@b'
+    })
+  })
+
+  it('preserves values including null and 0', () => {
+    expect(normalizeRow({ A: null, B: 0 })).toEqual({ a: null, b: 0 })
+  })
+})
+
+describe('isDataReturningStatement (mysql)', () => {
+  it.each([
+    ['SELECT * FROM t', true],
+    ['  select 1', true],
+    ['SHOW TABLES', true],
+    ['DESCRIBE t', true],
+    ['DESC t', true],
+    ['EXPLAIN SELECT 1', true],
+    ['INSERT INTO t VALUES (1) RETURNING id', true],
+    ['INSERT INTO t VALUES (1)', false],
+    ['UPDATE t SET a = 1', false],
+    ['DELETE FROM t', false]
+  ])('%s -> %s', (sql, expected) => {
+    expect(isDataReturningStatement(sql)).toBe(expected)
+  })
+})
+
+describe('toMySQLConfig', () => {
+  it('maps basic fields and applies tunnel host/port overrides', () => {
+    const cfg = toMySQLConfig(makeConfig(), { host: '127.0.0.1', port: 13306 })
+    expect(cfg).toMatchObject({
+      host: '127.0.0.1',
+      port: 13306,
+      user: 'u',
+      password: 'p',
+      database: 'app'
+    })
+    expect(cfg.ssl).toBeUndefined()
+  })
+
+  it('without ssl sets no ssl options', () => {
+    const cfg = toMySQLConfig(makeConfig({ ssl: false }))
+    expect(cfg.host).toBe('db.example.com')
+    expect(cfg.ssl).toBeUndefined()
+  })
+
+  it('ssl without a CA defaults rejectUnauthorized to false (cloud-friendly)', () => {
+    const cfg = toMySQLConfig(makeConfig({ ssl: true }))
+    expect(cfg.ssl).toEqual({ rejectUnauthorized: false })
+  })
+
+  it('ssl with rejectUnauthorized:true opts into strict verification', () => {
+    const cfg = toMySQLConfig(makeConfig({ ssl: true, sslOptions: { rejectUnauthorized: true } }))
+    expect(cfg.ssl).toEqual({ rejectUnauthorized: true })
+  })
+
+  it('ssl with a CA path reads the cert and defaults rejectUnauthorized to true', () => {
+    const cfg = toMySQLConfig(makeConfig({ ssl: true, sslOptions: { ca: '/certs/rds-ca.pem' } }))
+    expect(cfg.ssl).toEqual({ rejectUnauthorized: true, ca: 'CA_CERT_CONTENT' })
+  })
+})

--- a/apps/desktop/src/main/__tests__/postgres-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/postgres-adapter.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { ConnectionConfig } from '@shared/index'
+
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+}))
+vi.mock('../ssh-tunnel-service', () => ({
+  createTunnel: vi.fn(),
+  closeTunnel: vi.fn(),
+  TunnelSession: class {}
+}))
+
+// Mock the pool manager so getTableDDL runs against a fake client whose query()
+// results we program per call. Resolves to the same module the adapter imports.
+const { withPgClient, fakeClient } = vi.hoisted(() => {
+  const fakeClient = { query: vi.fn() }
+  const withPgClient = vi.fn(async (_cfg: unknown, fn: (c: typeof fakeClient) => unknown) =>
+    fn(fakeClient)
+  )
+  return { withPgClient, fakeClient }
+})
+vi.mock('../adapters/pg-pool-manager', () => ({ withPgClient, withPgTransaction: vi.fn() }))
+
+import {
+  parsePostgresArray,
+  isDataReturningStatement,
+  PostgresAdapter
+} from '../adapters/postgres-adapter'
+
+function makeConfig(overrides: Partial<ConnectionConfig> = {}): ConnectionConfig {
+  return {
+    id: 'pg1',
+    name: 'test-pg',
+    host: 'localhost',
+    port: 5432,
+    database: 'db',
+    user: 'u',
+    password: 'p',
+    dbType: 'postgresql',
+    dstPort: 5432,
+    ...overrides
+  }
+}
+
+describe('parsePostgresArray', () => {
+  it('parses a simple {a,b} literal', () => {
+    expect(parsePostgresArray('{a,b}')).toEqual(['a', 'b'])
+  })
+
+  it('returns an empty array for {}', () => {
+    expect(parsePostgresArray('{}')).toEqual([])
+  })
+
+  it('strips surrounding quotes from quoted elements', () => {
+    expect(parsePostgresArray('{"x","y"}')).toEqual(['x', 'y'])
+  })
+
+  it('passes through values that are already arrays', () => {
+    expect(parsePostgresArray(['already', 'array'])).toEqual(['already', 'array'])
+  })
+
+  it('returns an empty array for non-array, non-brace strings and other types', () => {
+    expect(parsePostgresArray('not an array')).toEqual([])
+    expect(parsePostgresArray(null)).toEqual([])
+    expect(parsePostgresArray(42)).toEqual([])
+  })
+})
+
+describe('isDataReturningStatement (postgres)', () => {
+  it.each([
+    ['SELECT * FROM t', true],
+    ['  select 1', true],
+    ['WITH cte AS (SELECT 1) SELECT * FROM cte', true],
+    ['TABLE users', true],
+    ['VALUES (1), (2)', true],
+    ['INSERT INTO t VALUES (1) RETURNING id', true],
+    ['SHOW search_path', true],
+    ['EXPLAIN SELECT 1', true],
+    ['INSERT INTO t VALUES (1)', false],
+    ['UPDATE t SET a = 1', false],
+    ['DELETE FROM t', false]
+  ])('%s -> %s', (sql, expected) => {
+    expect(isDataReturningStatement(sql)).toBe(expected)
+  })
+})
+
+describe('PostgresAdapter.getTableDDL', () => {
+  beforeEach(() => {
+    fakeClient.query.mockReset()
+    withPgClient.mockClear()
+  })
+
+  // getTableDDL issues four queries in this order: columns, constraints, indexes, comment.
+  it('maps columns, skips the PK constraint, flags unique columns, and reads the comment', async () => {
+    fakeClient.query
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            column_name: 'id',
+            udt_name: 'int4',
+            is_nullable: 'NO',
+            column_default: "nextval('users_id_seq')",
+            ordinal_position: 1,
+            numeric_precision: 32,
+            numeric_scale: 0,
+            character_maximum_length: null,
+            is_primary_key: true,
+            column_comment: null,
+            collation_name: null
+          },
+          {
+            column_name: 'email',
+            udt_name: 'varchar',
+            is_nullable: 'NO',
+            ordinal_position: 2,
+            character_maximum_length: 255,
+            numeric_precision: null,
+            numeric_scale: null,
+            column_default: null,
+            is_primary_key: false,
+            column_comment: 'user email',
+            collation_name: null
+          }
+        ]
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          { constraint_name: 'users_pkey', constraint_type: 'PRIMARY KEY', column_name: 'id' },
+          { constraint_name: 'users_email_key', constraint_type: 'UNIQUE', column_name: 'email' }
+        ]
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            index_name: 'idx_users_email',
+            is_unique: true,
+            index_method: 'btree',
+            columns: ['email'],
+            where_clause: null,
+            index_definition: 'CREATE UNIQUE INDEX idx_users_email ON public.users (email)',
+            is_expression_index: false
+          }
+        ]
+      })
+      .mockResolvedValueOnce({ rows: [{ comment: 'application users' }] })
+
+    const def = await new PostgresAdapter().getTableDDL(makeConfig(), 'public', 'users')
+
+    expect(def.schema).toBe('public')
+    expect(def.name).toBe('users')
+
+    const id = def.columns.find((c) => c.name === 'id')
+    expect(id).toMatchObject({ dataType: 'int4', isPrimaryKey: true, isNullable: false })
+
+    const email = def.columns.find((c) => c.name === 'email')
+    expect(email).toMatchObject({ length: 255, isUnique: true, comment: 'user email' })
+
+    // PK is handled at the column level and excluded from constraints
+    expect(def.constraints).toHaveLength(1)
+    expect(def.constraints[0]).toMatchObject({
+      name: 'users_email_key',
+      type: 'unique',
+      columns: ['email']
+    })
+
+    expect(def.indexes).toHaveLength(1)
+    expect(def.indexes[0]).toMatchObject({
+      name: 'idx_users_email',
+      isUnique: true,
+      method: 'btree',
+      columns: [{ name: 'email' }]
+    })
+
+    expect(def.comment).toBe('application users')
+    expect(withPgClient).toHaveBeenCalledTimes(1)
+  })
+
+  it('extracts the expression of an expression index when no columns are reported', async () => {
+    fakeClient.query
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            column_name: 'email',
+            udt_name: 'varchar',
+            is_nullable: 'NO',
+            ordinal_position: 1,
+            is_primary_key: false
+          }
+        ]
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            index_name: 'idx_lower_email',
+            is_unique: false,
+            index_method: 'btree',
+            columns: [null],
+            where_clause: null,
+            is_expression_index: true,
+            index_definition:
+              'CREATE INDEX idx_lower_email ON public.users USING btree (lower(email))'
+          }
+        ]
+      })
+      .mockResolvedValueOnce({ rows: [{ comment: null }] })
+
+    const def = await new PostgresAdapter().getTableDDL(makeConfig(), 'public', 'users')
+
+    expect(def.indexes[0].columns).toEqual([{ name: 'lower(email)' }])
+    expect(def.comment).toBeUndefined()
+  })
+})

--- a/apps/desktop/src/main/__tests__/query-handlers.test.ts
+++ b/apps/desktop/src/main/__tests__/query-handlers.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { ConnectionConfig } from '@shared/index'
+
+type Handler = (event: unknown, ...args: unknown[]) => unknown
+
+const { handlers, queryMultiple } = vi.hoisted(() => ({
+  handlers: new Map<string, Handler>(),
+  queryMultiple: vi.fn()
+}))
+
+// Capture handlers as they register, and stub the collaborators db:query touches.
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, handler: Handler) => {
+      handlers.set(channel, handler)
+    }
+  }
+}))
+vi.mock('../db-adapter', () => ({ getAdapter: () => ({ queryMultiple }) }))
+vi.mock('../schema-cache', () => ({
+  getCachedSchema: vi.fn(),
+  isCacheValid: vi.fn(),
+  getOrFetchCachedSchema: vi.fn(),
+  invalidateSchemaCache: vi.fn()
+}))
+vi.mock('../lib/ssl-error', () => ({ annotateSslError: (e: Error) => e }))
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}))
+
+import { registerQueryHandlers } from '../ipc/query-handlers'
+
+interface QueryResponse {
+  success: boolean
+  error?: string
+  data?: {
+    rows: unknown[]
+    fields: unknown[]
+    rowCount: number
+    statementCount: number
+  }
+}
+
+const config = { id: 'c1', dbType: 'postgresql' } as unknown as ConnectionConfig
+
+function runQuery(query: string): Promise<QueryResponse> {
+  return handlers.get('db:query')!(null, { config, query }) as Promise<QueryResponse>
+}
+
+beforeEach(() => {
+  handlers.clear()
+  queryMultiple.mockReset()
+  registerQueryHandlers()
+})
+
+describe('db:query legacy field selection', () => {
+  it('returns rows/fields/rowCount from the first data-returning statement, not statement 0', async () => {
+    queryMultiple.mockResolvedValue({
+      totalDurationMs: 12,
+      results: [
+        { isDataReturning: false, rows: [], fields: [], rowCount: 3 },
+        { isDataReturning: true, rows: [{ id: 7 }], fields: [{ name: 'id' }], rowCount: 1 }
+      ]
+    })
+
+    const res = await runQuery('update x set a = 1; select * from x')
+
+    expect(res.success).toBe(true)
+    expect(res.data?.rows).toEqual([{ id: 7 }])
+    expect(res.data?.fields).toEqual([{ name: 'id' }])
+    expect(res.data?.rowCount).toBe(1)
+    expect(res.data?.statementCount).toBe(2)
+  })
+
+  it('falls back to the first statement when none are data-returning', async () => {
+    queryMultiple.mockResolvedValue({
+      totalDurationMs: 4,
+      results: [
+        {
+          isDataReturning: false,
+          rows: [{ changes: 2 }],
+          fields: [{ name: 'changes' }],
+          rowCount: 2
+        }
+      ]
+    })
+
+    const res = await runQuery('update x set a = 1')
+
+    expect(res.data?.rows).toEqual([{ changes: 2 }])
+    expect(res.data?.rowCount).toBe(2)
+  })
+
+  it('uses empty defaults when there are no results at all', async () => {
+    queryMultiple.mockResolvedValue({ totalDurationMs: 1, results: [] })
+
+    const res = await runQuery('-- noop')
+
+    expect(res.success).toBe(true)
+    expect(res.data?.rows).toEqual([])
+    expect(res.data?.fields).toEqual([])
+    expect(res.data?.rowCount).toBe(0)
+    expect(res.data?.statementCount).toBe(0)
+  })
+})
+
+describe('db:query error handling', () => {
+  it('maps an adapter Error to { success: false, error }', async () => {
+    queryMultiple.mockRejectedValue(new Error('boom'))
+
+    const res = await runQuery('select 1')
+
+    expect(res).toEqual({ success: false, error: 'boom' })
+  })
+
+  it('stringifies non-Error throwables', async () => {
+    queryMultiple.mockRejectedValue('plain string failure')
+
+    const res = await runQuery('select 1')
+
+    expect(res.success).toBe(false)
+    expect(res.error).toBe('plain string failure')
+  })
+})

--- a/apps/desktop/src/main/__tests__/scheduler-service.test.ts
+++ b/apps/desktop/src/main/__tests__/scheduler-service.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from 'vitest'
+
+// scheduler-service pulls in electron (Notification), the storage facade, the db
+// adapter, and the logger at module load; none are needed for the pure cron helpers.
+vi.mock('electron', () => ({ Notification: class {} }))
+vi.mock('../storage', () => ({ DpStorage: { create: vi.fn() } }))
+vi.mock('../db-adapter', () => ({ getAdapter: vi.fn() }))
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}))
+
+import { validateCronExpression, getNextRunTimes } from '../scheduler-service'
+
+describe('validateCronExpression', () => {
+  it('accepts a valid hourly expression', () => {
+    expect(validateCronExpression('0 * * * *')).toEqual({ valid: true })
+  })
+
+  it('accepts an every-minute expression', () => {
+    expect(validateCronExpression('* * * * *').valid).toBe(true)
+  })
+
+  it('rejects a malformed expression with a non-empty error message', () => {
+    const result = validateCronExpression('not a cron')
+    expect(result.valid).toBe(false)
+    expect(result.error && result.error.length).toBeGreaterThan(0)
+  })
+
+  it('rejects an out-of-range field', () => {
+    expect(validateCronExpression('99 * * * *').valid).toBe(false)
+  })
+})
+
+describe('getNextRunTimes', () => {
+  it('returns the requested number of strictly increasing future timestamps', () => {
+    const times = getNextRunTimes('0 * * * *', 3)
+    expect(times).toHaveLength(3)
+    expect(times[0]).toBeLessThan(times[1])
+    expect(times[1]).toBeLessThan(times[2])
+  })
+
+  it('defaults to five upcoming run times', () => {
+    expect(getNextRunTimes('0 0 * * *')).toHaveLength(5)
+  })
+
+  it('returns an empty array for an unparseable expression', () => {
+    expect(getNextRunTimes('not a cron')).toEqual([])
+  })
+})

--- a/apps/desktop/src/main/adapters/mssql-adapter.ts
+++ b/apps/desktop/src/main/adapters/mssql-adapter.ts
@@ -94,11 +94,11 @@ const SYSTEM_SCHEMAS = [
   'db_denydatawriter'
 ]
 
-function resolveMSSQLType(dataTypeID: number): string {
+export function resolveMSSQLType(dataTypeID: number): string {
   return MSSQL_TYPE_MAP[dataTypeID] ?? `unknown(${dataTypeID})`
 }
 
-function inferTypeFromValue(value: unknown): { dataType: string; dataTypeID: number } {
+export function inferTypeFromValue(value: unknown): { dataType: string; dataTypeID: number } {
   if (value === null || value === undefined) return { dataType: 'nvarchar', dataTypeID: 231 }
   if (typeof value === 'number') {
     return Number.isInteger(value)
@@ -129,7 +129,7 @@ function bindParameter(request: sql.Request, paramName: string, value: unknown):
 /**
  * Create MSSQL connection config from our ConnectionConfig
  */
-function toMSSQLConfig(
+export function toMSSQLConfig(
   config: ConnectionConfig,
   overrides?: { host: string; port: number }
 ): sql.config {
@@ -216,7 +216,7 @@ function toMSSQLConfig(
 /**
  * Check if a SQL statement is data-returning (SELECT, etc.)
  */
-function isDataReturningStatement(sqlText: string): boolean {
+export function isDataReturningStatement(sqlText: string): boolean {
   const normalized = sqlText.trim().toUpperCase()
   if (normalized.startsWith('SELECT')) return true
   if (normalized.startsWith('WITH') && normalized.includes('SELECT')) return true

--- a/apps/desktop/src/main/adapters/mysql-adapter.ts
+++ b/apps/desktop/src/main/adapters/mysql-adapter.ts
@@ -82,7 +82,7 @@ const MYSQL_TYPE_MAP: Record<number, string> = {
 /**
  * Resolve MySQL type code to human-readable type name
  */
-function resolveMySQLType(typeCode: number): string {
+export function resolveMySQLType(typeCode: number): string {
   return MYSQL_TYPE_MAP[typeCode] ?? `unknown(${typeCode})`
 }
 
@@ -90,7 +90,7 @@ function resolveMySQLType(typeCode: number): string {
  * Create MySQL connection config from our ConnectionConfig
  * Properly handles SSL options for cloud databases like AWS RDS
  */
-function toMySQLConfig(
+export function toMySQLConfig(
   config: ConnectionConfig,
   overrides?: { host: string; port: number }
 ): mysql.ConnectionOptions {
@@ -134,7 +134,7 @@ function toMySQLConfig(
  * Normalize row from MySQL query to lowercase keys
  * MySQL can return column names in different cases depending on configuration
  */
-function normalizeRow<T extends Record<string, unknown>>(row: Record<string, unknown>): T {
+export function normalizeRow<T extends Record<string, unknown>>(row: Record<string, unknown>): T {
   const normalized: Record<string, unknown> = {}
   for (const [key, value] of Object.entries(row)) {
     normalized[key.toLowerCase()] = value
@@ -145,7 +145,7 @@ function normalizeRow<T extends Record<string, unknown>>(row: Record<string, unk
 /**
  * Check if a SQL statement is data-returning (SELECT, SHOW, etc.)
  */
-function isDataReturningStatement(sql: string): boolean {
+export function isDataReturningStatement(sql: string): boolean {
   const normalized = sql.trim().toUpperCase()
   if (normalized.startsWith('SELECT')) return true
   if (normalized.startsWith('SHOW')) return true

--- a/apps/desktop/src/main/adapters/postgres-adapter.ts
+++ b/apps/desktop/src/main/adapters/postgres-adapter.ts
@@ -51,7 +51,7 @@ const splitPgStatements = (sql: string) => splitStatements(sql, 'postgresql')
  * The pg driver sometimes returns array_agg results as raw strings instead of
  * parsed JS arrays (especially for name[] / _name type).
  */
-function parsePostgresArray(value: unknown): string[] {
+export function parsePostgresArray(value: unknown): string[] {
   if (Array.isArray(value)) return value
   if (typeof value === 'string') {
     const trimmed = value.trim()
@@ -67,7 +67,7 @@ function parsePostgresArray(value: unknown): string[] {
 /**
  * Check if a SQL statement is data-returning (SELECT, RETURNING, etc.)
  */
-function isDataReturningStatement(sql: string): boolean {
+export function isDataReturningStatement(sql: string): boolean {
   const normalized = sql.trim().toUpperCase()
   // SELECT statements return data
   if (normalized.startsWith('SELECT')) return true

--- a/apps/desktop/src/renderer/src/components/command-palette.tsx
+++ b/apps/desktop/src/renderer/src/components/command-palette.tsx
@@ -25,8 +25,22 @@ import { DatabaseIcon } from '@/components/database-icons'
 import { useConnectionStore, useTabStore } from '@/stores'
 import { useSavedQueryStore } from '@/stores/saved-queries-store'
 import { useAIStore } from '@/stores/ai-store'
-import { cn, keys, useSidebar, Command, CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandSeparator, CommandShortcut } from '@data-peek/ui'
+import {
+  cn,
+  keys,
+  useSidebar,
+  Command,
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+  CommandShortcut
+} from '@data-peek/ui'
 import type { SavedQuery } from '@shared/index'
+import { fuzzyFilter, getQueryType } from '@/lib/command-search'
 
 // Page types for navigation
 type CommandPage =
@@ -43,105 +57,6 @@ interface CommandPaletteProps {
   onOpenAddConnection?: () => void
   onOpenEditConnection?: (id: string) => void
   initialPage?: CommandPage
-}
-
-// Custom fuzzy filter for cmdk with smart scoring
-function fuzzyFilter(value: string, search: string, keywords?: string[]): number {
-  if (!search) return 1
-
-  const searchLower = search.toLowerCase()
-  const valueLower = value.toLowerCase()
-
-  // Combine value with keywords for searching
-  const keywordsLower = keywords?.map((k) => k.toLowerCase()).join(' ') || ''
-  const searchableText = `${valueLower} ${keywordsLower}`
-
-  // Exact match - highest priority
-  if (valueLower === searchLower) return 1
-
-  // Starts with - very high priority
-  if (valueLower.startsWith(searchLower)) return 0.95
-
-  // Acronym match (e.g., "nqt" matches "New Query Tab")
-  const words = value.split(/\s+/)
-  const acronym = words.map((w) => w[0]?.toLowerCase() || '').join('')
-  if (acronym.startsWith(searchLower)) return 0.9
-  if (acronym.includes(searchLower)) return 0.85
-
-  // Contains as substring - good match
-  if (valueLower.includes(searchLower)) return 0.8
-  if (keywordsLower.includes(searchLower)) return 0.75
-
-  // Smart fuzzy match with scoring based on character proximity
-  const fuzzyScore = calculateFuzzyScore(searchableText, searchLower)
-  if (fuzzyScore > 0) return fuzzyScore
-
-  return 0
-}
-
-// Calculate fuzzy match score with bonuses for consecutive matches and word boundaries
-function calculateFuzzyScore(text: string, search: string): number {
-  let textIndex = 0
-  let searchIndex = 0
-  let score = 0
-  let consecutiveBonus = 0
-  let lastMatchIndex = -2 // Start at -2 so first match doesn't get consecutive bonus
-  const matchPositions: number[] = []
-
-  while (textIndex < text.length && searchIndex < search.length) {
-    if (text[textIndex] === search[searchIndex]) {
-      matchPositions.push(textIndex)
-
-      // Bonus for consecutive characters (e.g., "feed" in "feedback")
-      if (textIndex === lastMatchIndex + 1) {
-        consecutiveBonus += 0.05
-      }
-
-      // Bonus for matching at word boundaries (start of word)
-      if (
-        textIndex === 0 ||
-        text[textIndex - 1] === ' ' ||
-        text[textIndex - 1] === '-' ||
-        text[textIndex - 1] === '_'
-      ) {
-        score += 0.03
-      }
-
-      lastMatchIndex = textIndex
-      searchIndex++
-    }
-    textIndex++
-  }
-
-  // Did we match all search characters?
-  if (searchIndex !== search.length) return 0
-
-  // Base score for matching all characters
-  const baseScore = 0.6
-
-  // Bonus for shorter text (more relevant match)
-  const lengthBonus = Math.max(0, 0.1 - (text.length - search.length) * 0.005)
-
-  // Bonus for matches being close together
-  const spread =
-    matchPositions.length > 1 ? matchPositions[matchPositions.length - 1] - matchPositions[0] : 0
-  const compactnessBonus = Math.max(0, 0.1 - spread * 0.01)
-
-  return Math.min(0.7, baseScore + consecutiveBonus + lengthBonus + compactnessBonus + score)
-}
-
-// Get query type from SQL
-function getQueryType(sql: string): string {
-  const trimmed = sql.trim().toUpperCase()
-  if (trimmed.startsWith('SELECT')) return 'SELECT'
-  if (trimmed.startsWith('INSERT')) return 'INSERT'
-  if (trimmed.startsWith('UPDATE')) return 'UPDATE'
-  if (trimmed.startsWith('DELETE')) return 'DELETE'
-  if (trimmed.startsWith('CREATE')) return 'CREATE'
-  if (trimmed.startsWith('ALTER')) return 'ALTER'
-  if (trimmed.startsWith('DROP')) return 'DROP'
-  if (trimmed.startsWith('EXPLAIN')) return 'EXPLAIN'
-  return 'SQL'
 }
 
 // Query type badge colors

--- a/apps/desktop/src/renderer/src/lib/__tests__/command-search.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/command-search.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+import { fuzzyFilter, calculateFuzzyScore, getQueryType } from '@/lib/command-search'
+
+describe('getQueryType', () => {
+  it.each([
+    ['SELECT * FROM t', 'SELECT'],
+    ['  insert into t values (1)', 'INSERT'],
+    ['UPDATE t SET a = 1', 'UPDATE'],
+    ['DELETE FROM t', 'DELETE'],
+    ['CREATE TABLE t (id int)', 'CREATE'],
+    ['ALTER TABLE t ADD c int', 'ALTER'],
+    ['DROP TABLE t', 'DROP'],
+    ['EXPLAIN SELECT 1', 'EXPLAIN'],
+    ['BEGIN', 'SQL'],
+    ['', 'SQL']
+  ])('%s -> %s', (sql, expected) => {
+    expect(getQueryType(sql)).toBe(expected)
+  })
+})
+
+describe('fuzzyFilter', () => {
+  it('returns 1 for empty search (everything matches)', () => {
+    expect(fuzzyFilter('Anything', '')).toBe(1)
+  })
+
+  it('returns 1 for an exact case-insensitive match', () => {
+    expect(fuzzyFilter('New Query Tab', 'new query tab')).toBe(1)
+  })
+
+  it('returns 0.95 for a prefix match', () => {
+    expect(fuzzyFilter('New Query Tab', 'new')).toBe(0.95)
+  })
+
+  it('scores an acronym match (nqt -> New Query Tab) at 0.9', () => {
+    expect(fuzzyFilter('New Query Tab', 'nqt')).toBe(0.9)
+  })
+
+  it('scores a substring match at 0.8', () => {
+    expect(fuzzyFilter('New Query Tab', 'query')).toBe(0.8)
+  })
+
+  it('returns 0 when nothing matches', () => {
+    expect(fuzzyFilter('New Query Tab', 'zzz')).toBe(0)
+  })
+
+  it('ranks exact > prefix > acronym > substring', () => {
+    const exact = fuzzyFilter('New Query Tab', 'new query tab')
+    const prefix = fuzzyFilter('New Query Tab', 'new')
+    const acronym = fuzzyFilter('New Query Tab', 'nqt')
+    const substring = fuzzyFilter('New Query Tab', 'query')
+    expect(exact).toBeGreaterThan(prefix)
+    expect(prefix).toBeGreaterThan(acronym)
+    expect(acronym).toBeGreaterThan(substring)
+  })
+})
+
+describe('calculateFuzzyScore', () => {
+  it('returns 0 unless every search char is present in order', () => {
+    expect(calculateFuzzyScore('abc', 'xyz')).toBe(0)
+    expect(calculateFuzzyScore('abc', 'acb')).toBe(0)
+  })
+
+  it('returns a positive score when all chars match in order', () => {
+    expect(calculateFuzzyScore('feedback', 'feed')).toBeGreaterThan(0)
+  })
+
+  it('never exceeds the 0.7 cap', () => {
+    expect(calculateFuzzyScore('feedback', 'feedback')).toBeLessThanOrEqual(0.7)
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/command-search.ts
+++ b/apps/desktop/src/renderer/src/lib/command-search.ts
@@ -1,0 +1,104 @@
+/**
+ * Search and ranking helpers for the command palette. Extracted from
+ * command-palette.tsx so the scoring logic can be unit-tested without importing
+ * the React component (and its cmdk / store dependencies).
+ */
+
+// Calculate fuzzy match score with bonuses for consecutive matches and word boundaries
+export function calculateFuzzyScore(text: string, search: string): number {
+  let textIndex = 0
+  let searchIndex = 0
+  let score = 0
+  let consecutiveBonus = 0
+  let lastMatchIndex = -2 // Start at -2 so first match doesn't get consecutive bonus
+  const matchPositions: number[] = []
+
+  while (textIndex < text.length && searchIndex < search.length) {
+    if (text[textIndex] === search[searchIndex]) {
+      matchPositions.push(textIndex)
+
+      // Bonus for consecutive characters (e.g., "feed" in "feedback")
+      if (textIndex === lastMatchIndex + 1) {
+        consecutiveBonus += 0.05
+      }
+
+      // Bonus for matching at word boundaries (start of word)
+      if (
+        textIndex === 0 ||
+        text[textIndex - 1] === ' ' ||
+        text[textIndex - 1] === '-' ||
+        text[textIndex - 1] === '_'
+      ) {
+        score += 0.03
+      }
+
+      lastMatchIndex = textIndex
+      searchIndex++
+    }
+    textIndex++
+  }
+
+  // Did we match all search characters?
+  if (searchIndex !== search.length) return 0
+
+  // Base score for matching all characters
+  const baseScore = 0.6
+
+  // Bonus for shorter text (more relevant match)
+  const lengthBonus = Math.max(0, 0.1 - (text.length - search.length) * 0.005)
+
+  // Bonus for matches being close together
+  const spread =
+    matchPositions.length > 1 ? matchPositions[matchPositions.length - 1] - matchPositions[0] : 0
+  const compactnessBonus = Math.max(0, 0.1 - spread * 0.01)
+
+  return Math.min(0.7, baseScore + consecutiveBonus + lengthBonus + compactnessBonus + score)
+}
+
+// Custom fuzzy filter for cmdk with smart scoring
+export function fuzzyFilter(value: string, search: string, keywords?: string[]): number {
+  if (!search) return 1
+
+  const searchLower = search.toLowerCase()
+  const valueLower = value.toLowerCase()
+
+  // Combine value with keywords for searching
+  const keywordsLower = keywords?.map((k) => k.toLowerCase()).join(' ') || ''
+  const searchableText = `${valueLower} ${keywordsLower}`
+
+  // Exact match - highest priority
+  if (valueLower === searchLower) return 1
+
+  // Starts with - very high priority
+  if (valueLower.startsWith(searchLower)) return 0.95
+
+  // Acronym match (e.g., "nqt" matches "New Query Tab")
+  const words = value.split(/\s+/)
+  const acronym = words.map((w) => w[0]?.toLowerCase() || '').join('')
+  if (acronym.startsWith(searchLower)) return 0.9
+  if (acronym.includes(searchLower)) return 0.85
+
+  // Contains as substring - good match
+  if (valueLower.includes(searchLower)) return 0.8
+  if (keywordsLower.includes(searchLower)) return 0.75
+
+  // Smart fuzzy match with scoring based on character proximity
+  const fuzzyScore = calculateFuzzyScore(searchableText, searchLower)
+  if (fuzzyScore > 0) return fuzzyScore
+
+  return 0
+}
+
+// Get query type from SQL
+export function getQueryType(sql: string): string {
+  const trimmed = sql.trim().toUpperCase()
+  if (trimmed.startsWith('SELECT')) return 'SELECT'
+  if (trimmed.startsWith('INSERT')) return 'INSERT'
+  if (trimmed.startsWith('UPDATE')) return 'UPDATE'
+  if (trimmed.startsWith('DELETE')) return 'DELETE'
+  if (trimmed.startsWith('CREATE')) return 'CREATE'
+  if (trimmed.startsWith('ALTER')) return 'ALTER'
+  if (trimmed.startsWith('DROP')) return 'DROP'
+  if (trimmed.startsWith('EXPLAIN')) return 'EXPLAIN'
+  return 'SQL'
+}

--- a/apps/desktop/vitest.config.ts
+++ b/apps/desktop/vitest.config.ts
@@ -14,6 +14,12 @@ export default defineConfig({
         'src/main/sql-builder.ts',
         'src/main/ddl-builder.ts',
         'src/main/sql-utils.ts',
+        'src/main/adapters/postgres-adapter.ts',
+        'src/main/adapters/mysql-adapter.ts',
+        'src/main/adapters/mssql-adapter.ts',
+        'src/main/ipc/query-handlers.ts',
+        'src/renderer/src/lib/command-search.ts',
+        'packages/shared/src/type-maps.ts',
         'src/renderer/src/stores/**/*.ts'
       ],
       exclude: ['**/node_modules/**', '**/__tests__/**']


### PR DESCRIPTION
## Summary

Follow-up to #187 — adds the first unit-test coverage for the codebase-review findings on testing. **+87 tests (763 → 850).** No production behavior changes beyond `export`-ing pure helpers and extracting command-palette ranking logic into a `lib` module.

Branched off `main`, so it's independent of #187 (can merge in either order).

### #2 — Core DB adapter tests (56 tests)
Only SQLite had tests before; postgres/mysql/mssql (~4,600 LOC) had none.
- **Pure helpers** (no DB, no mocks): type resolution, `isDataReturningStatement` per dialect, `normalizeRow`, `inferTypeFromValue`, and the security-relevant SSL/auth config builders (`toMySQLConfig` cloud-SSL defaults + CA read, `toMSSQLConfig` Azure-AD vs SQL-auth, encrypt/trust defaults).
- **`PostgresAdapter.getTableDDL`** against a mocked pool (`vi.mock('../adapters/pg-pool-manager')`): column/constraint/index/comment mapping, PK-constraint exclusion, unique-column flagging, and expression-index extraction.

### #10 — Orchestration hot paths (12 tests)
- **`db:query`** — the funnel every query passes through — using the existing `ipcMain`-map + module-mock pattern: legacy field selection picks the first **data-returning** statement (not statement 0), falls back correctly, and maps adapter failures to `{ success: false, error }` (Error + non-Error).
- **scheduler** `validateCronExpression` / `getNextRunTimes` (valid/invalid/out-of-range, strictly-increasing future times).

### #9 — Component logic (20 tests)
Vitest runs in a `node` env (no jsdom), so the established pattern is *extract logic → test it*. Pulled `fuzzyFilter` / `calculateFuzzyScore` / `getQueryType` out of `command-palette.tsx` into `lib/command-search.ts` (component now imports them) and tested scoring + ranking invariants (exact > prefix > acronym > substring, all-chars-in-order, 0.7 cap).

## Coverage
Added the three adapters, `query-handlers.ts`, `command-search.ts`, and `type-maps.ts` to `coverage.include` (they weren't measured before).

## Verification
- ✅ `typecheck:node` + `typecheck:web` clean
- ✅ **850/850 tests pass** (41 files)
- ✅ 0 lint errors in touched files

## Not yet covered (noted for a future pass)
- mssql `bindParameter` (needs a `sql.Request` spy), Docker-gated integration suites, dashboard `executeWidget`, ai-service `migrateLegacyConfig`, and the larger `tab-query-editor` hook extraction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for database adapters (MSSQL, MySQL, PostgreSQL), query handlers, and scheduler services.
  * Enhanced test configuration for improved code coverage tracking.

* **Refactor**
  * Reorganized command search utilities into a shared library for improved code reuse.
  * Exposed internal helper functions for better modularity across adapter modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->