### PR TITLE
refactor(query-editor): split tab-query-editor into focused modules (#4)

### DIFF
--- a/apps/desktop/src/renderer/src/components/query-editor/masked-export-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/query-editor/masked-export-dialog.tsx
@@ -1,0 +1,59 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from '@data-peek/ui'
+import type { ExportData, ExportDestination, ExportFormat } from '@/lib/export'
+
+export interface PendingExport {
+  format: ExportFormat
+  destination: ExportDestination
+  data: ExportData
+  filename: string
+}
+
+interface MaskedExportDialogProps {
+  pendingExport: PendingExport | null
+  onOpenChange: (open: boolean) => void
+  onConfirm: () => void
+}
+
+/**
+ * Confirmation dialog shown before exporting/copying data that contains masked
+ * columns, warning that masked values are replaced with [MASKED] in the output.
+ */
+export function MaskedExportDialog({
+  pendingExport,
+  onOpenChange,
+  onConfirm
+}: MaskedExportDialogProps) {
+  const isClipboard = pendingExport?.destination === 'clipboard'
+
+  return (
+    <AlertDialog open={!!pendingExport} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            {isClipboard ? 'Copy with masked columns?' : 'Export with masked columns?'}
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            Some columns are currently masked. The exported data will contain{' '}
+            <code className="font-mono text-xs bg-muted px-1 py-0.5 rounded">[MASKED]</code> in
+            place of sensitive values. Do you want to continue?
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={onConfirm}>
+            {isClipboard ? 'Copy with [MASKED] values' : 'Export with [MASKED] values'}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/apps/desktop/src/renderer/src/components/query-editor/share-results-image.tsx
+++ b/apps/desktop/src/renderer/src/components/query-editor/share-results-image.tsx
@@ -1,0 +1,123 @@
+import { cn } from '@data-peek/ui'
+import { ShareImageDialog, type ShareImageTheme } from '@/components/share-image-dialog'
+import type { QueryResult } from '@/stores/query-store'
+import type { ConnectionConfig } from '@data-peek/shared'
+
+interface ShareResultsImageProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  result: QueryResult | null
+  connection: ConnectionConfig | null | undefined
+}
+
+/**
+ * Wraps ShareImageDialog with a themed table render of the current query results,
+ * capped at 25 rows / 10 columns for a shareable image.
+ */
+export function ShareResultsImage({
+  open,
+  onOpenChange,
+  result,
+  connection
+}: ShareResultsImageProps) {
+  return (
+    <ShareImageDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Share Results"
+      description="Generate a shareable image of your query results. Review data before sharing — the image may contain sensitive values."
+      filenamePrefix="query-results"
+    >
+      {(theme: ShareImageTheme) => {
+        if (!result || result.columns.length === 0) {
+          const mutedColor = theme === 'light' ? 'text-zinc-500' : 'text-zinc-400'
+          return <p className={cn('py-4 text-center text-xs', mutedColor)}>No results to share</p>
+        }
+
+        const textColor = theme === 'light' ? 'text-zinc-800' : 'text-zinc-100'
+        const mutedColor = theme === 'light' ? 'text-zinc-500' : 'text-zinc-400'
+        const headerColor = theme === 'light' ? 'text-zinc-700' : 'text-zinc-300'
+        const borderColor = theme === 'light' ? 'border-zinc-200' : 'border-zinc-700'
+        const maxRows = 25
+        const visibleRows = result.rows.slice(0, maxRows)
+        const visibleCols = result.columns.slice(0, 10)
+        const connLabel = connection?.name || connection?.host || ''
+
+        return (
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <p className={cn('text-sm font-semibold', textColor)}>
+                  {result.tableName || 'Query Results'}
+                </p>
+                <p className={cn('text-xs', mutedColor)}>
+                  {result.rowCount} rows &middot; {result.durationMs}ms
+                </p>
+              </div>
+              {connLabel && <p className={cn('text-xs', mutedColor)}>{connLabel}</p>}
+            </div>
+            <div className="overflow-hidden">
+              <table className="w-full text-xs" style={{ borderCollapse: 'collapse' }}>
+                <thead>
+                  <tr className={cn(borderColor)} style={{ borderBottom: '1px solid' }}>
+                    {visibleCols.map((col) => (
+                      <th
+                        key={col.name}
+                        className={cn('py-1.5 pr-3 text-left font-medium', headerColor)}
+                      >
+                        {col.name}
+                      </th>
+                    ))}
+                    {result.columns.length > 10 && (
+                      <th className={cn('py-1.5 text-left font-medium', mutedColor)}>
+                        +{result.columns.length - 10} more
+                      </th>
+                    )}
+                  </tr>
+                </thead>
+                <tbody>
+                  {visibleRows.map((row, rowIdx) => (
+                    <tr
+                      key={rowIdx}
+                      className={cn(borderColor)}
+                      style={{ borderBottom: '1px solid' }}
+                    >
+                      {visibleCols.map((col) => {
+                        const val = row[col.name]
+                        const display =
+                          val === null
+                            ? 'NULL'
+                            : typeof val === 'object'
+                              ? JSON.stringify(val)
+                              : String(val)
+                        return (
+                          <td
+                            key={col.name}
+                            className={cn(
+                              'max-w-[200px] truncate py-1.5 pr-3 font-mono',
+                              val === null ? mutedColor : textColor
+                            )}
+                          >
+                            {display.length > 50 ? display.slice(0, 50) + '...' : display}
+                          </td>
+                        )
+                      })}
+                      {result.columns.length > 10 && (
+                        <td className={cn('py-1.5 pr-3', mutedColor)}>...</td>
+                      )}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              {result.rows.length > maxRows && (
+                <p className={cn('mt-2 text-xs', mutedColor)}>
+                  Showing {maxRows} of {result.rows.length} rows
+                </p>
+              )}
+            </div>
+          </div>
+        )
+      }}
+    </ShareImageDialog>
+  )
+}

--- a/apps/desktop/src/renderer/src/components/query-editor/use-editable-result.ts
+++ b/apps/desktop/src/renderer/src/components/query-editor/use-editable-result.ts
@@ -1,0 +1,173 @@
+import { useCallback } from 'react'
+import type { ConnectionConfig, EditContext, TableInfo } from '@data-peek/shared'
+import { isExecutableTab, type Tab } from '@/stores/tab-store'
+import type { Schema } from '@/stores/connection-store'
+import type { DataTableColumn } from '@/components/data-table'
+import type { DataTableColumn as EditableDataTableColumn } from '@/components/editable-data-table'
+import { analyzeEditableSelect } from '@/lib/editable-select'
+
+/** Safely coerce a value to string[] or undefined. Handles pg driver returning array_agg as a raw string. */
+function ensureArray(value: unknown): string[] | undefined {
+  if (Array.isArray(value)) return value
+  if (typeof value === 'string' && value.startsWith('{') && value.endsWith('}')) {
+    const inner = value.slice(1, -1)
+    if (inner === '') return []
+    return inner.split(',').map((v) => v.trim().replace(/^"|"$/g, ''))
+  }
+  return undefined
+}
+
+interface UseEditableResultParams {
+  tab: Tab | undefined
+  schemas: Schema[]
+  tabConnection: ConnectionConfig | null | undefined
+  getEnumValues: (dataType: string) => string[] | undefined
+}
+
+/**
+ * Derives the editable-table metadata for the active result: FK column info, the
+ * resolved source table (parsed from the executed SQL), the editable column set, and
+ * the EditContext used to build INSERT/UPDATE/DELETE statements. Pure derivation over
+ * tab + schema state — no side effects.
+ */
+export function useEditableResult({
+  tab,
+  schemas,
+  tabConnection,
+  getEnumValues
+}: UseEditableResultParams) {
+  // Helper: Look up column info from schema (for FK details)
+  const getColumnsWithFKInfo = useCallback((): DataTableColumn[] => {
+    if (!tab || !isExecutableTab(tab) || !tab.result?.columns) return []
+
+    // For table-preview tabs, we can directly look up the columns from schema
+    if (tab.type === 'table-preview') {
+      const schema = schemas.find((s) => s.name === tab.schemaName)
+      const tableInfo = schema?.tables.find((t) => t.name === tab.tableName)
+
+      if (tableInfo) {
+        return tab.result.columns.map((col) => {
+          const schemaCol = tableInfo.columns.find((c) => c.name === col.name)
+          return {
+            name: col.name,
+            dataType: col.dataType,
+            foreignKey: schemaCol?.foreignKey
+          }
+        })
+      }
+    }
+
+    // For query tabs, try to match columns across all tables
+    // This is a simplified approach - won't work for aliased columns
+    return tab.result.columns.map((col) => {
+      // Search all schemas/tables for this column
+      for (const schema of schemas) {
+        for (const table of schema.tables) {
+          const schemaCol = table.columns.find((c) => c.name === col.name)
+          if (schemaCol?.foreignKey) {
+            return {
+              name: col.name,
+              dataType: col.dataType,
+              foreignKey: schemaCol.foreignKey
+            }
+          }
+        }
+      }
+      return { name: col.name, dataType: col.dataType }
+    })
+  }, [tab, schemas])
+
+  // Resolve the source table for editing by parsing the actually-executed SQL.
+  // Applies to both query and table-preview tabs: the tab's stored schemaName/tableName is
+  // only an initial hint — once the user changes the SQL, the executed query is the source of
+  // truth. This prevents UPDATEs from targeting the wrong table when a table-preview tab's
+  // query has been rewritten to query a different table.
+  const resolveEditSourceTable = useCallback((): {
+    schemaName: string
+    tableName: string
+    tableInfo: TableInfo
+  } | null => {
+    if (!tab || !isExecutableTab(tab) || !tabConnection) return null
+
+    const idx = tab.activeResultIndex ?? 0
+    const stmts = tab.multiResult?.statements
+    const sql = stmts?.[idx]?.statement ?? tab.savedQuery ?? tab.query
+    if (!sql) return null
+
+    const info = analyzeEditableSelect(sql, tabConnection.dbType)
+    if (!info) return null
+
+    const lower = (s: string) => s.toLowerCase()
+    const schemaCandidates = info.schema
+      ? schemas.filter((s) => lower(s.name) === lower(info.schema as string))
+      : schemas
+
+    let match: { schemaName: string; tableInfo: TableInfo } | null = null
+    for (const s of schemaCandidates) {
+      const t = s.tables.find((t) => lower(t.name) === lower(info.table) && t.type === 'table')
+      if (!t) continue
+      if (match) return null // ambiguous — bail rather than guess wrong
+      match = { schemaName: s.name, tableInfo: t }
+    }
+    if (!match) return null
+
+    const pkCols = match.tableInfo.columns.filter((c) => c.isPrimaryKey)
+    if (pkCols.length === 0) return null
+
+    if (info.projection.type === 'columns') {
+      const projLower = new Set(info.projection.names.map(lower))
+      for (const pk of pkCols) {
+        if (!projLower.has(lower(pk.name))) return null
+      }
+    }
+
+    return {
+      schemaName: match.schemaName,
+      tableName: match.tableInfo.name,
+      tableInfo: match.tableInfo
+    }
+  }, [tab, schemas, tabConnection])
+
+  // Helper: Get columns with full info including isPrimaryKey (for editable table)
+  const getColumnsForEditing = useCallback((): EditableDataTableColumn[] => {
+    const source = resolveEditSourceTable()
+    if (!source || !tab || !('result' in tab)) return []
+
+    const idx = tab.activeResultIndex ?? 0
+    const stmtFields = tab.multiResult?.statements?.[idx]?.fields
+    const resultCols = stmtFields
+      ? stmtFields.map((f) => ({ name: f.name, dataType: f.dataType }))
+      : (tab.result?.columns ?? [])
+
+    return resultCols.map((col) => {
+      const schemaCol = source.tableInfo.columns.find((c) => c.name === col.name)
+      return {
+        name: col.name,
+        dataType: col.dataType,
+        foreignKey: schemaCol?.foreignKey,
+        isPrimaryKey: schemaCol?.isPrimaryKey ?? false,
+        isNullable: schemaCol?.isNullable ?? true,
+        enumValues: ensureArray(schemaCol?.enumValues) ?? ensureArray(getEnumValues(col.dataType))
+      }
+    })
+  }, [resolveEditSourceTable, tab, getEnumValues])
+
+  // Helper: Build EditContext for the currently active result
+  const getEditContext = useCallback((): EditContext | null => {
+    const source = resolveEditSourceTable()
+    if (!source) return null
+
+    const primaryKeyColumns = source.tableInfo.columns
+      .filter((c) => c.isPrimaryKey)
+      .map((c) => c.name)
+
+    return {
+      schema: source.schemaName,
+      table: source.tableName,
+      primaryKeyColumns,
+      columns: source.tableInfo.columns
+    }
+  }, [resolveEditSourceTable])
+
+  return { getColumnsWithFKInfo, getColumnsForEditing, getEditContext }
+}

--- a/apps/desktop/src/renderer/src/components/tab-query-editor.tsx
+++ b/apps/desktop/src/renderer/src/components/tab-query-editor.tsx
@@ -1,16 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Database } from 'lucide-react'
-import {
-  cn,
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle
-} from '@data-peek/ui'
 import { useExecutionPlanResize } from '@/hooks/use-execution-plan-resize'
 import { usePanelCollapse } from '@/hooks/use-panel-collapse'
 
@@ -26,13 +15,7 @@ import {
 } from '@/stores'
 import { isExecutableTab, type Tab, type MultiQueryResult } from '@/stores/tab-store'
 import type { StatementResult } from '@data-peek/shared'
-import {
-  type DataTableFilter,
-  type DataTableSort,
-  type DataTableColumn
-} from '@/components/data-table'
-import { type DataTableColumn as EditableDataTableColumn } from '@/components/editable-data-table'
-import type { EditContext, TableInfo } from '@data-peek/shared'
+import { type DataTableFilter, type DataTableSort } from '@/components/data-table'
 import { analyzeEditableSelect, sqlMatchesStoredTable } from '@/lib/editable-select'
 import {
   resolveForRun,
@@ -57,6 +40,7 @@ import {
   buildCountQuery,
   quoteIdentifier
 } from '@/lib/sql-helpers'
+import { buildQueryWithFilters } from '@/lib/table-query-builder'
 import type { QueryResult as IpcQueryResult, ForeignKeyInfo, ColumnInfo } from '@data-peek/shared'
 import { FKPanelStack, type FKPanelItem } from '@/components/fk-panel-stack'
 import { ERDVisualization } from '@/components/erd-visualization'
@@ -68,7 +52,6 @@ import { HealthMonitor } from '@/components/health-monitor'
 import { SchemaIntelPanel } from '@/components/schema-intel'
 import { SaveQueryDialog } from '@/components/save-query-dialog'
 import { ShareQueryDialog } from '@/components/share-query-dialog'
-import { ShareImageDialog, type ShareImageTheme } from '@/components/share-image-dialog'
 import { ColumnStatsPanel } from '@/components/column-stats-panel'
 import { useColumnStatsStore } from '@/stores/column-stats-store'
 import type { DataTableColumn as DtColumn } from '@/components/data-table'
@@ -78,6 +61,9 @@ import { StepRibbon } from './step-ribbon'
 import { StepResultsTabs } from './step-results-tabs'
 import { EditorToolbar } from './query-editor/editor-toolbar'
 import { QueryResults } from './query-editor/query-results'
+import { MaskedExportDialog } from './query-editor/masked-export-dialog'
+import { ShareResultsImage } from './query-editor/share-results-image'
+import { useEditableResult } from './query-editor/use-editable-result'
 import { WatchButton } from '@/components/watch-button'
 import type { WatchRunner } from '@/lib/watch-scheduler'
 import { watchScheduler } from '@/lib/watch-scheduler'
@@ -86,17 +72,6 @@ import { gateForWatch } from '@/lib/watch-sql-gate'
 import { useStepStore } from '@/stores/step-store'
 import { DDL_KEYWORD_REGEX } from '@shared/index'
 import type { editor as monacoEditor } from 'monaco-editor'
-
-/** Safely coerce a value to string[] or undefined. Handles pg driver returning array_agg as a raw string. */
-function ensureArray(value: unknown): string[] | undefined {
-  if (Array.isArray(value)) return value
-  if (typeof value === 'string' && value.startsWith('{') && value.endsWith('}')) {
-    const inner = value.slice(1, -1)
-    if (inner === '') return []
-    return inner.split(',').map((v) => v.trim().replace(/^"|"$/g, ''))
-  }
-  return undefined
-}
 
 interface TabQueryEditorProps {
   tabId: string
@@ -920,138 +895,12 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
     return () => disposable.dispose()
   }, [stepSession, tabId, toggleBreakpoint])
 
-  // Helper: Look up column info from schema (for FK details)
-  const getColumnsWithFKInfo = useCallback((): DataTableColumn[] => {
-    if (!tab || !isExecutableTab(tab) || !tab.result?.columns) return []
-
-    // For table-preview tabs, we can directly look up the columns from schema
-    if (tab.type === 'table-preview') {
-      const schema = schemas.find((s) => s.name === tab.schemaName)
-      const tableInfo = schema?.tables.find((t) => t.name === tab.tableName)
-
-      if (tableInfo) {
-        return tab.result.columns.map((col) => {
-          const schemaCol = tableInfo.columns.find((c) => c.name === col.name)
-          return {
-            name: col.name,
-            dataType: col.dataType,
-            foreignKey: schemaCol?.foreignKey
-          }
-        })
-      }
-    }
-
-    // For query tabs, try to match columns across all tables
-    // This is a simplified approach - won't work for aliased columns
-    return tab.result.columns.map((col) => {
-      // Search all schemas/tables for this column
-      for (const schema of schemas) {
-        for (const table of schema.tables) {
-          const schemaCol = table.columns.find((c) => c.name === col.name)
-          if (schemaCol?.foreignKey) {
-            return {
-              name: col.name,
-              dataType: col.dataType,
-              foreignKey: schemaCol.foreignKey
-            }
-          }
-        }
-      }
-      return { name: col.name, dataType: col.dataType }
-    })
-  }, [tab, schemas])
-
-  // Resolve the source table for editing by parsing the actually-executed SQL.
-  // Applies to both query and table-preview tabs: the tab's stored schemaName/tableName is
-  // only an initial hint — once the user changes the SQL, the executed query is the source of
-  // truth. This prevents UPDATEs from targeting the wrong table when a table-preview tab's
-  // query has been rewritten to query a different table.
-  const resolveEditSourceTable = useCallback((): {
-    schemaName: string
-    tableName: string
-    tableInfo: TableInfo
-  } | null => {
-    if (!tab || !isExecutableTab(tab) || !tabConnection) return null
-
-    const idx = tab.activeResultIndex ?? 0
-    const stmts = tab.multiResult?.statements
-    const sql = stmts?.[idx]?.statement ?? tab.savedQuery ?? tab.query
-    if (!sql) return null
-
-    const info = analyzeEditableSelect(sql, tabConnection.dbType)
-    if (!info) return null
-
-    const lower = (s: string) => s.toLowerCase()
-    const schemaCandidates = info.schema
-      ? schemas.filter((s) => lower(s.name) === lower(info.schema as string))
-      : schemas
-
-    let match: { schemaName: string; tableInfo: TableInfo } | null = null
-    for (const s of schemaCandidates) {
-      const t = s.tables.find((t) => lower(t.name) === lower(info.table) && t.type === 'table')
-      if (!t) continue
-      if (match) return null // ambiguous — bail rather than guess wrong
-      match = { schemaName: s.name, tableInfo: t }
-    }
-    if (!match) return null
-
-    const pkCols = match.tableInfo.columns.filter((c) => c.isPrimaryKey)
-    if (pkCols.length === 0) return null
-
-    if (info.projection.type === 'columns') {
-      const projLower = new Set(info.projection.names.map(lower))
-      for (const pk of pkCols) {
-        if (!projLower.has(lower(pk.name))) return null
-      }
-    }
-
-    return {
-      schemaName: match.schemaName,
-      tableName: match.tableInfo.name,
-      tableInfo: match.tableInfo
-    }
-  }, [tab, schemas, tabConnection])
-
-  // Helper: Get columns with full info including isPrimaryKey (for editable table)
-  const getColumnsForEditing = useCallback((): EditableDataTableColumn[] => {
-    const source = resolveEditSourceTable()
-    if (!source || !tab || !('result' in tab)) return []
-
-    const idx = tab.activeResultIndex ?? 0
-    const stmtFields = tab.multiResult?.statements?.[idx]?.fields
-    const resultCols = stmtFields
-      ? stmtFields.map((f) => ({ name: f.name, dataType: f.dataType }))
-      : (tab.result?.columns ?? [])
-
-    return resultCols.map((col) => {
-      const schemaCol = source.tableInfo.columns.find((c) => c.name === col.name)
-      return {
-        name: col.name,
-        dataType: col.dataType,
-        foreignKey: schemaCol?.foreignKey,
-        isPrimaryKey: schemaCol?.isPrimaryKey ?? false,
-        isNullable: schemaCol?.isNullable ?? true,
-        enumValues: ensureArray(schemaCol?.enumValues) ?? ensureArray(getEnumValues(col.dataType))
-      }
-    })
-  }, [resolveEditSourceTable, tab, getEnumValues])
-
-  // Helper: Build EditContext for the currently active result
-  const getEditContext = useCallback((): EditContext | null => {
-    const source = resolveEditSourceTable()
-    if (!source) return null
-
-    const primaryKeyColumns = source.tableInfo.columns
-      .filter((c) => c.isPrimaryKey)
-      .map((c) => c.name)
-
-    return {
-      schema: source.schemaName,
-      table: source.tableName,
-      primaryKeyColumns,
-      columns: source.tableInfo.columns
-    }
-  }, [resolveEditSourceTable])
+  const { getColumnsWithFKInfo, getColumnsForEditing, getEditContext } = useEditableResult({
+    tab,
+    schemas,
+    tabConnection,
+    getEnumValues
+  })
 
   // FK Panel: Fetch data for a referenced row
   const fetchFKData = useCallback(
@@ -1240,101 +1089,14 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
       : null
 
   // Generate SQL WHERE clause from filters
-  const generateWhereClause = (filters: DataTableFilter[]): string => {
-    if (filters.length === 0) return ''
-    const dbType = tabConnection?.dbType
-    const conditions = filters.map((f) => {
-      const escapedValue = f.value.replace(/'/g, "''")
-      const quotedCol = quoteIdentifier(f.column, dbType)
-      if (dbType === 'mssql' || dbType === 'mysql') {
-        return `${quotedCol} LIKE '%${escapedValue}%'`
-      }
-      return `${quotedCol} ILIKE '%${escapedValue}%'`
-    })
-    return `WHERE ${conditions.join(' AND ')}`
-  }
-
-  const generateOrderByClause = (sorting: DataTableSort[]): string => {
-    if (sorting.length === 0) return ''
-    const dbType = tabConnection?.dbType
-    const orders = sorting.map(
-      (s) => `${quoteIdentifier(s.column, dbType)} ${s.direction.toUpperCase()}`
-    )
-    return `ORDER BY ${orders.join(', ')}`
-  }
-
-  // Build a new query with filters/sorting applied
-  const buildQueryWithFilters = (): string => {
-    if (!tab || !isExecutableTab(tab)) return ''
-
-    // For table preview tabs, rebuild from the stored table — but only when the
-    // user hasn't rewritten the editor SQL to query something else. Otherwise we'd
-    // silently throw away their query and run a filtered statement against a
-    // different table than the one they've been looking at.
-    if (
-      tab.type === 'table-preview' &&
-      tabConnection &&
-      sqlMatchesStoredTable(
-        tab.savedQuery ?? tab.query,
-        { schema: tab.schemaName, table: tab.tableName },
-        tabConnection.dbType
-      )
-    ) {
-      const tableRef = buildQualifiedTableRef(tab.schemaName, tab.tableName, tabConnection?.dbType)
-      const wherePart = generateWhereClause(tableFilters)
-      const orderPart = generateOrderByClause(tableSorting)
-      return buildSelectQuery(tableRef, tabConnection?.dbType, {
-        where: wherePart,
-        orderBy: orderPart,
-        limit: 100
-      })
-        .replace(/\s+/g, ' ')
-        .trim()
-    }
-    // Fallthrough — when SQL has been rewritten, treat the tab as a query tab
-    // and inject WHERE/ORDER BY into the user's SQL.
-
-    // For query tabs, try to inject WHERE/ORDER BY
-    // This is simplified - a full implementation would parse the SQL AST
-    let baseQuery = tab.query.trim()
-
-    // Remove trailing semicolon
-    if (baseQuery.endsWith(';')) {
-      baseQuery = baseQuery.slice(0, -1)
-    }
-
-    // Remove existing LIMIT (PostgreSQL/MySQL) or TOP (MSSQL) for re-adding
-    // LIMIT is at the end: SELECT * FROM table LIMIT 100
-    // TOP is after SELECT: SELECT TOP 100 * FROM table
-    const limitMatch = baseQuery.match(/\s+LIMIT\s+\d+\s*$/i)
-    const topMatch = baseQuery.match(/^(SELECT)\s+(TOP\s+\d+)\s+/i)
-    let limitClause = ''
-    let topClause = ''
-
-    if (limitMatch) {
-      limitClause = limitMatch[0]
-      baseQuery = baseQuery.slice(0, -limitMatch[0].length)
-    }
-    if (topMatch) {
-      topClause = topMatch[2] + ' '
-      baseQuery = baseQuery.replace(/^SELECT\s+TOP\s+\d+\s+/i, 'SELECT ')
-    }
-
-    const wherePart = generateWhereClause(tableFilters)
-    const orderPart = generateOrderByClause(tableSorting)
-
-    // Re-add TOP after SELECT for MSSQL, or LIMIT at the end for others
-    let result = baseQuery
-    if (topClause) {
-      result = result.replace(/^SELECT\s+/i, `SELECT ${topClause}`)
-    }
-    result = `${result} ${wherePart} ${orderPart}${limitClause};`.replace(/\s+/g, ' ').trim()
-    return result
-  }
-
   const handleApplyToQuery = () => {
     if (!tab || (tableFilters.length === 0 && tableSorting.length === 0)) return
-    const newQuery = buildQueryWithFilters()
+    const newQuery = buildQueryWithFilters({
+      tab,
+      dbType: tabConnection?.dbType,
+      filters: tableFilters,
+      sorting: tableSorting
+    })
     updateTabQuery(tabId, formatSQL(newQuery))
     // Automatically run the new query
     setTimeout(() => handleRunQuery(), 100)
@@ -1778,143 +1540,29 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
       />
 
       {/* Share Results Image Dialog */}
-      <ShareImageDialog
+      <ShareResultsImage
         open={shareResultsOpen}
         onOpenChange={setShareResultsOpen}
-        title="Share Results"
-        description="Generate a shareable image of your query results. Review data before sharing — the image may contain sensitive values."
-        filenamePrefix="query-results"
-      >
-        {(theme: ShareImageTheme) => {
-          const result = tab.result
-          if (!result || result.columns.length === 0) {
-            const mutedColor = theme === 'light' ? 'text-zinc-500' : 'text-zinc-400'
-            return <p className={cn('py-4 text-center text-xs', mutedColor)}>No results to share</p>
-          }
-
-          const textColor = theme === 'light' ? 'text-zinc-800' : 'text-zinc-100'
-          const mutedColor = theme === 'light' ? 'text-zinc-500' : 'text-zinc-400'
-          const headerColor = theme === 'light' ? 'text-zinc-700' : 'text-zinc-300'
-          const borderColor = theme === 'light' ? 'border-zinc-200' : 'border-zinc-700'
-          const maxRows = 25
-          const visibleRows = result.rows.slice(0, maxRows)
-          const visibleCols = result.columns.slice(0, 10)
-          const connLabel = tabConnection?.name || tabConnection?.host || ''
-
-          return (
-            <div className="space-y-3">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-2">
-                  <p className={cn('text-sm font-semibold', textColor)}>
-                    {result.tableName || 'Query Results'}
-                  </p>
-                  <p className={cn('text-xs', mutedColor)}>
-                    {result.rowCount} rows &middot; {result.durationMs}ms
-                  </p>
-                </div>
-                {connLabel && <p className={cn('text-xs', mutedColor)}>{connLabel}</p>}
-              </div>
-              <div className="overflow-hidden">
-                <table className="w-full text-xs" style={{ borderCollapse: 'collapse' }}>
-                  <thead>
-                    <tr className={cn(borderColor)} style={{ borderBottom: '1px solid' }}>
-                      {visibleCols.map((col) => (
-                        <th
-                          key={col.name}
-                          className={cn('py-1.5 pr-3 text-left font-medium', headerColor)}
-                        >
-                          {col.name}
-                        </th>
-                      ))}
-                      {result.columns.length > 10 && (
-                        <th className={cn('py-1.5 text-left font-medium', mutedColor)}>
-                          +{result.columns.length - 10} more
-                        </th>
-                      )}
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {visibleRows.map((row, rowIdx) => (
-                      <tr
-                        key={rowIdx}
-                        className={cn(borderColor)}
-                        style={{ borderBottom: '1px solid' }}
-                      >
-                        {visibleCols.map((col) => {
-                          const val = row[col.name]
-                          const display =
-                            val === null
-                              ? 'NULL'
-                              : typeof val === 'object'
-                                ? JSON.stringify(val)
-                                : String(val)
-                          return (
-                            <td
-                              key={col.name}
-                              className={cn(
-                                'max-w-[200px] truncate py-1.5 pr-3 font-mono',
-                                val === null ? mutedColor : textColor
-                              )}
-                            >
-                              {display.length > 50 ? display.slice(0, 50) + '...' : display}
-                            </td>
-                          )
-                        })}
-                        {result.columns.length > 10 && (
-                          <td className={cn('py-1.5 pr-3', mutedColor)}>...</td>
-                        )}
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-                {result.rows.length > maxRows && (
-                  <p className={cn('mt-2 text-xs', mutedColor)}>
-                    Showing {maxRows} of {result.rows.length} rows
-                  </p>
-                )}
-              </div>
-            </div>
-          )
-        }}
-      </ShareImageDialog>
+        result={tab.result}
+        connection={tabConnection}
+      />
 
       {/* Export with masked columns confirmation */}
-      <AlertDialog open={!!pendingExport} onOpenChange={(open) => !open && setPendingExport(null)}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>
-              {pendingExport?.destination === 'clipboard'
-                ? 'Copy with masked columns?'
-                : 'Export with masked columns?'}
-            </AlertDialogTitle>
-            <AlertDialogDescription>
-              Some columns are currently masked. The exported data will contain{' '}
-              <code className="font-mono text-xs bg-muted px-1 py-0.5 rounded">[MASKED]</code> in
-              place of sensitive values. Do you want to continue?
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={() => {
-                if (!pendingExport) return
-                const maskedData = buildMaskedExportData(pendingExport.data)
-                void doExport(
-                  pendingExport.format,
-                  pendingExport.destination,
-                  maskedData,
-                  pendingExport.filename
-                )
-                setPendingExport(null)
-              }}
-            >
-              {pendingExport?.destination === 'clipboard'
-                ? 'Copy with [MASKED] values'
-                : 'Export with [MASKED] values'}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <MaskedExportDialog
+        pendingExport={pendingExport}
+        onOpenChange={(open) => !open && setPendingExport(null)}
+        onConfirm={() => {
+          if (!pendingExport) return
+          const maskedData = buildMaskedExportData(pendingExport.data)
+          void doExport(
+            pendingExport.format,
+            pendingExport.destination,
+            maskedData,
+            pendingExport.filename
+          )
+          setPendingExport(null)
+        }}
+      />
     </div>
   )
 }

--- a/apps/desktop/src/renderer/src/lib/__tests__/table-query-builder.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/table-query-builder.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest'
+import {
+  generateWhereClause,
+  generateOrderByClause,
+  buildQueryWithFilters
+} from '@/lib/table-query-builder'
+import type { Tab } from '@/stores/tab-store'
+
+describe('generateWhereClause', () => {
+  it('returns an empty string when there are no filters', () => {
+    expect(generateWhereClause([], 'postgresql')).toBe('')
+  })
+
+  it('builds a case-insensitive ILIKE clause for postgres', () => {
+    expect(generateWhereClause([{ column: 'name', value: 'foo' }], 'postgresql')).toBe(
+      `WHERE "name" ILIKE '%foo%'`
+    )
+  })
+
+  it('uses LIKE and backtick quoting for mysql', () => {
+    expect(generateWhereClause([{ column: 'name', value: 'foo' }], 'mysql')).toBe(
+      "WHERE `name` LIKE '%foo%'"
+    )
+  })
+
+  it('uses LIKE and bracket quoting for mssql', () => {
+    expect(generateWhereClause([{ column: 'name', value: 'foo' }], 'mssql')).toBe(
+      `WHERE [name] LIKE '%foo%'`
+    )
+  })
+
+  it('escapes single quotes in the value', () => {
+    expect(generateWhereClause([{ column: 'name', value: "O'Brien" }], 'postgresql')).toBe(
+      `WHERE "name" ILIKE '%O''Brien%'`
+    )
+  })
+
+  it('joins multiple filters with AND', () => {
+    expect(
+      generateWhereClause(
+        [
+          { column: 'a', value: '1' },
+          { column: 'b', value: '2' }
+        ],
+        'postgresql'
+      )
+    ).toBe(`WHERE "a" ILIKE '%1%' AND "b" ILIKE '%2%'`)
+  })
+})
+
+describe('generateOrderByClause', () => {
+  it('returns an empty string when there is no sorting', () => {
+    expect(generateOrderByClause([], 'postgresql')).toBe('')
+  })
+
+  it('builds an ORDER BY with the direction uppercased', () => {
+    expect(generateOrderByClause([{ column: 'age', direction: 'desc' }], 'postgresql')).toBe(
+      `ORDER BY "age" DESC`
+    )
+  })
+
+  it('joins multiple sorts with commas', () => {
+    expect(
+      generateOrderByClause(
+        [
+          { column: 'a', direction: 'asc' },
+          { column: 'b', direction: 'desc' }
+        ],
+        'postgresql'
+      )
+    ).toBe(`ORDER BY "a" ASC, "b" DESC`)
+  })
+})
+
+describe('buildQueryWithFilters', () => {
+  const queryTab = (query: string): Tab => ({ type: 'query', query }) as unknown as Tab
+
+  it('returns an empty string for a non-executable tab', () => {
+    const erd = { type: 'erd' } as unknown as Tab
+    expect(
+      buildQueryWithFilters({ tab: erd, dbType: 'postgresql', filters: [], sorting: [] })
+    ).toBe('')
+  })
+
+  it('injects WHERE/ORDER BY into a query tab and preserves an existing LIMIT', () => {
+    const result = buildQueryWithFilters({
+      tab: queryTab('SELECT * FROM users LIMIT 100'),
+      dbType: 'postgresql',
+      filters: [{ column: 'name', value: 'foo' }],
+      sorting: [{ column: 'age', direction: 'desc' }]
+    })
+    expect(result).toBe(
+      `SELECT * FROM users WHERE "name" ILIKE '%foo%' ORDER BY "age" DESC LIMIT 100;`
+    )
+  })
+
+  it('preserves a leading TOP clause for mssql', () => {
+    const result = buildQueryWithFilters({
+      tab: queryTab('SELECT TOP 100 * FROM users'),
+      dbType: 'mssql',
+      filters: [{ column: 'name', value: 'foo' }],
+      sorting: [{ column: 'age', direction: 'desc' }]
+    })
+    expect(result).toBe(
+      `SELECT TOP 100 * FROM users WHERE [name] LIKE '%foo%' ORDER BY [age] DESC;`
+    )
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/table-query-builder.ts
+++ b/apps/desktop/src/renderer/src/lib/table-query-builder.ts
@@ -1,0 +1,123 @@
+import type { DatabaseType } from '@data-peek/shared'
+import type { DataTableFilter, DataTableSort } from '@/components/data-table'
+import { isExecutableTab, type Tab } from '@/stores/tab-store'
+import { sqlMatchesStoredTable } from '@/lib/editable-select'
+import { buildQualifiedTableRef, buildSelectQuery, quoteIdentifier } from '@/lib/sql-helpers'
+
+/**
+ * Build a WHERE clause from client-side data-table filters. Values are escaped and
+ * matched case-insensitively (ILIKE on Postgres/SQLite, LIKE on MySQL/MSSQL).
+ * Returns an empty string when there are no filters.
+ */
+export function generateWhereClause(
+  filters: DataTableFilter[],
+  dbType: DatabaseType | undefined
+): string {
+  if (filters.length === 0) return ''
+  const conditions = filters.map((f) => {
+    const escapedValue = f.value.replace(/'/g, "''")
+    const quotedCol = quoteIdentifier(f.column, dbType)
+    if (dbType === 'mssql' || dbType === 'mysql') {
+      return `${quotedCol} LIKE '%${escapedValue}%'`
+    }
+    return `${quotedCol} ILIKE '%${escapedValue}%'`
+  })
+  return `WHERE ${conditions.join(' AND ')}`
+}
+
+/**
+ * Build an ORDER BY clause from client-side data-table sorting. Returns an empty
+ * string when there is no sorting.
+ */
+export function generateOrderByClause(
+  sorting: DataTableSort[],
+  dbType: DatabaseType | undefined
+): string {
+  if (sorting.length === 0) return ''
+  const orders = sorting.map(
+    (s) => `${quoteIdentifier(s.column, dbType)} ${s.direction.toUpperCase()}`
+  )
+  return `ORDER BY ${orders.join(', ')}`
+}
+
+/**
+ * Produce a new query with the current filters/sorting applied.
+ *
+ * For a table-preview tab whose editor SQL still targets the stored table, the query
+ * is rebuilt from that table. Otherwise (the user rewrote the SQL) WHERE/ORDER BY are
+ * injected into their statement, preserving an existing LIMIT/TOP. Returns an empty
+ * string for non-executable tabs.
+ */
+export function buildQueryWithFilters(params: {
+  tab: Tab
+  dbType: DatabaseType | undefined
+  filters: DataTableFilter[]
+  sorting: DataTableSort[]
+}): string {
+  const { tab, dbType, filters, sorting } = params
+  if (!isExecutableTab(tab)) return ''
+
+  // For table preview tabs, rebuild from the stored table — but only when the
+  // user hasn't rewritten the editor SQL to query something else. Otherwise we'd
+  // silently throw away their query and run a filtered statement against a
+  // different table than the one they've been looking at.
+  if (
+    tab.type === 'table-preview' &&
+    dbType &&
+    sqlMatchesStoredTable(
+      tab.savedQuery ?? tab.query,
+      { schema: tab.schemaName, table: tab.tableName },
+      dbType
+    )
+  ) {
+    const tableRef = buildQualifiedTableRef(tab.schemaName, tab.tableName, dbType)
+    const wherePart = generateWhereClause(filters, dbType)
+    const orderPart = generateOrderByClause(sorting, dbType)
+    return buildSelectQuery(tableRef, dbType, {
+      where: wherePart,
+      orderBy: orderPart,
+      limit: 100
+    })
+      .replace(/\s+/g, ' ')
+      .trim()
+  }
+  // Fallthrough — when SQL has been rewritten, treat the tab as a query tab
+  // and inject WHERE/ORDER BY into the user's SQL.
+
+  // For query tabs, try to inject WHERE/ORDER BY
+  // This is simplified - a full implementation would parse the SQL AST
+  let baseQuery = tab.query.trim()
+
+  // Remove trailing semicolon
+  if (baseQuery.endsWith(';')) {
+    baseQuery = baseQuery.slice(0, -1)
+  }
+
+  // Remove existing LIMIT (PostgreSQL/MySQL) or TOP (MSSQL) for re-adding
+  // LIMIT is at the end: SELECT * FROM table LIMIT 100
+  // TOP is after SELECT: SELECT TOP 100 * FROM table
+  const limitMatch = baseQuery.match(/\s+LIMIT\s+\d+\s*$/i)
+  const topMatch = baseQuery.match(/^(SELECT)\s+(TOP\s+\d+)\s+/i)
+  let limitClause = ''
+  let topClause = ''
+
+  if (limitMatch) {
+    limitClause = limitMatch[0]
+    baseQuery = baseQuery.slice(0, -limitMatch[0].length)
+  }
+  if (topMatch) {
+    topClause = topMatch[2] + ' '
+    baseQuery = baseQuery.replace(/^SELECT\s+TOP\s+\d+\s+/i, 'SELECT ')
+  }
+
+  const wherePart = generateWhereClause(filters, dbType)
+  const orderPart = generateOrderByClause(sorting, dbType)
+
+  // Re-add TOP after SELECT for MSSQL, or LIMIT at the end for others
+  let result = baseQuery
+  if (topClause) {
+    result = result.replace(/^SELECT\s+/i, `SELECT ${topClause}`)
+  }
+  result = `${result} ${wherePart} ${orderPart}${limitClause};`.replace(/\s+/g, ' ').trim()
+  return result
+}


### PR DESCRIPTION
## Summary

First, low-risk pass at decomposing the 1,920-line `tab-query-editor.tsx` (review finding #4, renderer half). Pure logic and self-contained UI/derivation move into focused modules. **No behavior change** — same props, same logic, just relocated. Container drops to **1,568 lines** (−352).

| New module | What moved | Lines |
|---|---|---|
| `lib/table-query-builder.ts` | `generateWhereClause` / `generateOrderByClause` / `buildQueryWithFilters` (pure) — **now unit-tested, 12 tests** | ~130 |
| `query-editor/use-editable-result.ts` | `getColumnsWithFKInfo` / `resolveEditSourceTable` / `getColumnsForEditing` / `getEditContext` derivation hook | ~140 |
| `query-editor/share-results-image.tsx` | the inline share-results image render | ~100 |
| `query-editor/masked-export-dialog.tsx` | the masked-export confirm `AlertDialog` | ~40 |

Also removed now-dead imports (`@data-peek/ui` `AlertDialog` family + `cn`, `ShareImageDialog`, and several types).

## Approach
Incremental and verification-driven, safest first: pure logic → presentational components → pure-derivation hook. The riskier **behavioral** hooks (`use-query-execution` with store writes, `use-step-decorations` Monaco effects, `use-fk-drilldown`, `use-watch-runner`) are intentionally **not** in this PR — they warrant their own change with e2e validation between steps.

## Verification
- ✅ `typecheck:node` + `typecheck:web` clean
- ✅ **862 tests pass** (+12 from the new builder tests)
- ✅ No new lint problems

## Known pre-existing issue (not introduced here)
`tab-query-editor.tsx` has **3 pre-existing `react-hooks/rules-of-hooks` errors** (the watch hooks are declared after an early return) — confirmed identical in the original file. Left for a dedicated fix since correcting hook ordering is behavioral and belongs in the `use-watch-runner` extraction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added masked export dialog for safely exporting data with sensitive columns—masked values are replaced with `[MASKED]` in output
  * Added ability to share query results as formatted images with connection details and result counts
  * Improved query filtering and sorting with enhanced database-specific SQL generation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->