### PR TITLE
fix: preserve UTC timestamp values by disabling local timezone conversion

### DIFF
--- a/apps/desktop/src/main/__tests__/pg-pool-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/pg-pool-manager.test.ts
@@ -8,7 +8,11 @@ const { mockClient, mockPool, PoolCtor } = vi.hoisted(() => {
   return { mockClient, mockPool, PoolCtor }
 })
 
-vi.mock('pg', () => ({ Pool: PoolCtor }))
+vi.mock('pg', () => ({
+  Pool: PoolCtor,
+  // createPoolEntry registers a raw parser for timestamp (OID 1114).
+  types: { setTypeParser: vi.fn() }
+}))
 vi.mock('../ssh-tunnel-service', () => ({
   createTunnel: vi.fn(),
   closeTunnel: vi.fn()

--- a/apps/desktop/src/main/adapters/pg-pool-manager.ts
+++ b/apps/desktop/src/main/adapters/pg-pool-manager.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'crypto'
-import { Pool, type PoolClient } from 'pg'
+import { types as pgTypes, Pool, type PoolClient } from 'pg'
 import type { ConnectionConfig } from '@shared/index'
 import { closeTunnel, createTunnel, type TunnelSession } from '../ssh-tunnel-service'
 import { createLogger } from '../lib/logger'
@@ -62,6 +62,11 @@ async function createPoolEntry(config: ConnectionConfig, key: string): Promise<P
       idleTimeoutMillis: IDLE_TIMEOUT_MS,
       connectionTimeoutMillis: CONNECT_TIMEOUT_MS
     })
+
+    // Return timestamp (without tz) values as raw ISO strings so JavaScript's
+    // Date auto-conversion doesn't shift UTC-stored timestamps to local time.
+    // OID 1114 = timestamp, 1184 = timestamptz (timestamptz SHOULD be shifted).
+    pgTypes.setTypeParser(1114, (val: string) => val)
 
     // pg.Pool emits 'error' for idle clients that die between checkouts (e.g. server-side
     // timeout). Without a listener the process crashes on unhandled error.

--- a/apps/desktop/src/renderer/src/components/nav-actions.tsx
+++ b/apps/desktop/src/renderer/src/components/nav-actions.tsx
@@ -17,7 +17,7 @@ import { Button, Popover, PopoverContent, PopoverTrigger, Tooltip, TooltipConten
 
 import { useCopyToClipboard } from '@/hooks/use-copy-to-clipboard'
 import { formatSQL } from '@/lib/sql-formatter'
-import { useQueryStore, useConnectionStore } from '@/stores'
+import { useQueryStore, useConnectionStore, useTabStore } from '@/stores'
 import { exportToSQL } from '@/lib/export'
 
 export function NavActions() {
@@ -29,6 +29,12 @@ export function NavActions() {
   const setCurrentQuery = useQueryStore((s) => s.setCurrentQuery)
   const setIsExecuting = useQueryStore((s) => s.setIsExecuting)
   const addToHistory = useQueryStore((s) => s.addToHistory)
+
+  // For multi-statement queries, use the currently active result set
+  // instead of always exporting the first statement's result.
+  const activeTabId = useTabStore((s) => s.activeTabId)
+  const getActiveStatementResult = useTabStore((s) => s.getActiveStatementResult)
+  const exportResult = activeTabId ? (getActiveStatementResult(activeTabId) ?? result) : result
 
   const handleRunQuery = () => {
     if (!activeConnection || isExecuting || !currentQuery.trim()) return
@@ -71,7 +77,7 @@ export function NavActions() {
   }
 
   const handleExportCSV = () => {
-    if (!result) return
+    if (!exportResult) return
     // Generate CSV
     const headers = result.columns.map((c) => c.name).join(',')
     const rows = result.rows.map((row) =>
@@ -98,8 +104,8 @@ export function NavActions() {
   }
 
   const handleExportJSON = () => {
-    if (!result) return
-    const json = JSON.stringify(result.rows, null, 2)
+    if (!exportResult) return
+    const json = JSON.stringify(exportResult.rows, null, 2)
     const blob = new Blob([json], { type: 'application/json' })
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
@@ -111,10 +117,10 @@ export function NavActions() {
   }
 
   const handleExportSQL = () => {
-    if (!result) return
+    if (!exportResult) return
     const exportData = {
-      columns: result.columns,
-      rows: result.rows
+      columns: exportResult.columns,
+      rows: exportResult.rows
     }
     const sql = exportToSQL(exportData, { tableName: 'query_result' })
     const blob = new Blob([sql], { type: 'text/sql' })
@@ -128,7 +134,7 @@ export function NavActions() {
   }
 
   const canRun = activeConnection && currentQuery.trim() && !isExecuting
-  const hasResults = !!result
+  const hasResults = !!exportResult
 
   return (
     <div className="flex items-center gap-1.5">

--- a/apps/desktop/src/renderer/src/components/nav-actions.tsx
+++ b/apps/desktop/src/renderer/src/components/nav-actions.tsx
@@ -17,7 +17,7 @@ import { Button, Popover, PopoverContent, PopoverTrigger, Tooltip, TooltipConten
 
 import { useCopyToClipboard } from '@/hooks/use-copy-to-clipboard'
 import { formatSQL } from '@/lib/sql-formatter'
-import { useQueryStore, useConnectionStore, useTabStore } from '@/stores'
+import { useQueryStore, useConnectionStore } from '@/stores'
 import { exportToSQL } from '@/lib/export'
 
 export function NavActions() {
@@ -29,12 +29,6 @@ export function NavActions() {
   const setCurrentQuery = useQueryStore((s) => s.setCurrentQuery)
   const setIsExecuting = useQueryStore((s) => s.setIsExecuting)
   const addToHistory = useQueryStore((s) => s.addToHistory)
-
-  // For multi-statement queries, use the currently active result set
-  // instead of always exporting the first statement's result.
-  const activeTabId = useTabStore((s) => s.activeTabId)
-  const getActiveStatementResult = useTabStore((s) => s.getActiveStatementResult)
-  const exportResult = activeTabId ? (getActiveStatementResult(activeTabId) ?? result) : result
 
   const handleRunQuery = () => {
     if (!activeConnection || isExecuting || !currentQuery.trim()) return
@@ -77,7 +71,7 @@ export function NavActions() {
   }
 
   const handleExportCSV = () => {
-    if (!exportResult) return
+    if (!result) return
     // Generate CSV
     const headers = result.columns.map((c) => c.name).join(',')
     const rows = result.rows.map((row) =>
@@ -104,8 +98,8 @@ export function NavActions() {
   }
 
   const handleExportJSON = () => {
-    if (!exportResult) return
-    const json = JSON.stringify(exportResult.rows, null, 2)
+    if (!result) return
+    const json = JSON.stringify(result.rows, null, 2)
     const blob = new Blob([json], { type: 'application/json' })
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
@@ -117,10 +111,10 @@ export function NavActions() {
   }
 
   const handleExportSQL = () => {
-    if (!exportResult) return
+    if (!result) return
     const exportData = {
-      columns: exportResult.columns,
-      rows: exportResult.rows
+      columns: result.columns,
+      rows: result.rows
     }
     const sql = exportToSQL(exportData, { tableName: 'query_result' })
     const blob = new Blob([sql], { type: 'text/sql' })
@@ -134,7 +128,7 @@ export function NavActions() {
   }
 
   const canRun = activeConnection && currentQuery.trim() && !isExecuting
-  const hasResults = !!exportResult
+  const hasResults = !!result
 
   return (
     <div className="flex items-center gap-1.5">


### PR DESCRIPTION
The pg driver parses 'timestamp without time zone' (OID 1114) values as JavaScript Date objects, which automatically convert to local timezone. This means UTC-stored timestamps shift incorrectly — both 'DB time' and 'local' displayed the same wall-clock value.

Fix: register a type parser for OID 1114 on pg.types to return the raw string, so timestamps display exactly as stored.

Closes #197

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed timestamp values from the desktop app’s database layer being shifted to local time, so UTC-stored dates now display correctly.
  * Improved database connection setup to preserve raw timestamp strings and avoid unexpected time conversions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->