### PR TITLE
fix: repair repo-wide lint + hoist Watch Mode hooks (rules-of-hooks bug)

### DIFF
--- a/apps/desktop/eslint.config.mjs
+++ b/apps/desktop/eslint.config.mjs
@@ -39,5 +39,21 @@ export default defineConfig(
       ]
     }
   },
+  {
+    // Playwright fixtures use `async ({}, use) => {}` — the empty destructure
+    // and the `use` callback are framework idioms, not React hooks.
+    files: ['tests/**/*.{ts,tsx}'],
+    rules: {
+      'react-hooks/rules-of-hooks': 'off',
+      'no-empty-pattern': 'off'
+    }
+  },
+  {
+    // Ambient declaration files legitimately use triple-slash references.
+    files: ['**/*.d.ts'],
+    rules: {
+      '@typescript-eslint/triple-slash-reference': 'off'
+    }
+  },
   eslintConfigPrettier
 )

--- a/apps/desktop/eslint.config.mjs
+++ b/apps/desktop/eslint.config.mjs
@@ -42,7 +42,7 @@ export default defineConfig(
   {
     // Playwright fixtures use `async ({}, use) => {}` — the empty destructure
     // and the `use` callback are framework idioms, not React hooks.
-    files: ['tests/**/*.{ts,tsx}'],
+    files: ['tests/e2e/**/*.{ts,tsx}'],
     rules: {
       'react-hooks/rules-of-hooks': 'off',
       'no-empty-pattern': 'off'

--- a/apps/desktop/src/main/__tests__/step-session.test.ts
+++ b/apps/desktop/src/main/__tests__/step-session.test.ts
@@ -30,7 +30,9 @@ class MockClient {
   responses: Array<{ rows?: unknown[]; fields?: unknown[]; rowCount?: number; error?: Error }> = []
   ended = false
 
-  async connect() {}
+  async connect() {
+    /* no-op mock */
+  }
   async query(sql: string) {
     this.calls.push(sql)
     const response = this.responses.shift()

--- a/apps/desktop/src/renderer/src/components/tab-query-editor.tsx
+++ b/apps/desktop/src/renderer/src/components/tab-query-editor.tsx
@@ -1121,112 +1121,6 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
     }
   }, [handleRunQuery, tab, tabConnection])
 
-  if (!tab || tab.type === 'notebook') {
-    return null
-  }
-
-  if (!tabConnection) {
-    return (
-      <div className="flex flex-1 items-center justify-center">
-        <div className="text-center space-y-4">
-          <div className="size-16 rounded-full bg-muted/50 flex items-center justify-center mx-auto">
-            <Database className="size-8 text-muted-foreground" />
-          </div>
-          <div>
-            <h2 className="text-lg font-medium">No Connection</h2>
-            <p className="text-sm text-muted-foreground mt-1">
-              This tab&apos;s connection is no longer available.
-              <br />
-              Select a different connection from the sidebar.
-            </p>
-          </div>
-        </div>
-      </div>
-    )
-  }
-
-  // Render ERD visualization for ERD tabs
-  if (tab.type === 'erd') {
-    return (
-      <div className="flex flex-1 flex-col overflow-hidden">
-        <div className="flex items-center justify-between border-b border-border/40 bg-muted/20 px-3 py-2">
-          <span className="text-sm font-medium">Entity Relationship Diagram</span>
-          <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
-            <span
-              className={`size-1.5 rounded-full ${tabConnection.isConnected ? 'bg-green-500' : 'bg-yellow-500'}`}
-            />
-            {tabConnection.name}
-          </span>
-        </div>
-        <div className="flex-1">
-          <ERDVisualization schemas={schemas} />
-        </div>
-      </div>
-    )
-  }
-
-  // Render Table Designer for table-designer tabs
-  if (tab.type === 'table-designer') {
-    return <TableDesigner tabId={tabId} />
-  }
-
-  // Render Data Generator for data-generator tabs
-  if (tab.type === 'data-generator') {
-    return <DataGenerator tabId={tabId} />
-  }
-
-  // Render PG Notifications panel
-  if (tab.type === 'pg-notifications') {
-    return <PgNotificationsPanel tabId={tabId} />
-  }
-
-  // Render Health Monitor dashboard
-  if (tab.type === 'health-monitor') {
-    return <HealthMonitor tabId={tabId} />
-  }
-
-  // Render Schema Intel / diagnostics panel
-  if (tab.type === 'schema-intel') {
-    return <SchemaIntelPanel tabId={tabId} />
-  }
-
-  // Get statement results for multi-statement queries
-  const statementResults = getAllStatementResults(tabId)
-  const activeStatementResult = getActiveStatementResult(tabId)
-  const hasMultipleResults = statementResults.length > 1
-  // At this point, tab is guaranteed to be query or table-preview (not erd or table-designer)
-  const activeResultIndex = tab.activeResultIndex ?? 0
-
-  // For query tabs, pass all rows and let DataTable handle client-side pagination
-  // For table-preview tabs with server-side pagination, rows are already limited by SQL
-  const getAllRows = (): Record<string, unknown>[] => {
-    if (hasMultipleResults) {
-      const statement = tab.multiResult?.statements?.[tab.activeResultIndex]
-      return (statement?.rows ?? []) as Record<string, unknown>[]
-    }
-    return (tab.result?.rows ?? []) as Record<string, unknown>[]
-  }
-
-  // Only use store pagination for table-preview with server-side pagination (for backward compat display)
-  const paginatedRows = hasMultipleResults
-    ? getActiveResultPaginatedRows(tabId)
-    : getTabPaginatedRows(tabId)
-
-  // Get columns from active statement result (for multi-statement) or legacy result
-  const getActiveResultColumns = () => {
-    if (activeStatementResult) {
-      return activeStatementResult.fields.map((f) => ({
-        name: f.name,
-        dataType: f.dataType
-      }))
-    }
-    // tab is guaranteed to be query or table-preview at this point
-    if (tab.result) {
-      return tab.result.columns
-    }
-    return []
-  }
-
   // Watch Mode runner. The scheduler holds runnerRef from this object across
   // ticks. We read the latest query/connection from the store at runQuery time
   // so that an in-flight watch never sees stale closures.
@@ -1332,6 +1226,112 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
   }, [tabId, tabConnection, watchRunner])
 
   useEffect(() => window.api.menu.onToggleWatch(handleToggleWatch), [handleToggleWatch])
+
+  if (!tab || tab.type === 'notebook') {
+    return null
+  }
+
+  if (!tabConnection) {
+    return (
+      <div className="flex flex-1 items-center justify-center">
+        <div className="text-center space-y-4">
+          <div className="size-16 rounded-full bg-muted/50 flex items-center justify-center mx-auto">
+            <Database className="size-8 text-muted-foreground" />
+          </div>
+          <div>
+            <h2 className="text-lg font-medium">No Connection</h2>
+            <p className="text-sm text-muted-foreground mt-1">
+              This tab&apos;s connection is no longer available.
+              <br />
+              Select a different connection from the sidebar.
+            </p>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  // Render ERD visualization for ERD tabs
+  if (tab.type === 'erd') {
+    return (
+      <div className="flex flex-1 flex-col overflow-hidden">
+        <div className="flex items-center justify-between border-b border-border/40 bg-muted/20 px-3 py-2">
+          <span className="text-sm font-medium">Entity Relationship Diagram</span>
+          <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            <span
+              className={`size-1.5 rounded-full ${tabConnection.isConnected ? 'bg-green-500' : 'bg-yellow-500'}`}
+            />
+            {tabConnection.name}
+          </span>
+        </div>
+        <div className="flex-1">
+          <ERDVisualization schemas={schemas} />
+        </div>
+      </div>
+    )
+  }
+
+  // Render Table Designer for table-designer tabs
+  if (tab.type === 'table-designer') {
+    return <TableDesigner tabId={tabId} />
+  }
+
+  // Render Data Generator for data-generator tabs
+  if (tab.type === 'data-generator') {
+    return <DataGenerator tabId={tabId} />
+  }
+
+  // Render PG Notifications panel
+  if (tab.type === 'pg-notifications') {
+    return <PgNotificationsPanel tabId={tabId} />
+  }
+
+  // Render Health Monitor dashboard
+  if (tab.type === 'health-monitor') {
+    return <HealthMonitor tabId={tabId} />
+  }
+
+  // Render Schema Intel / diagnostics panel
+  if (tab.type === 'schema-intel') {
+    return <SchemaIntelPanel tabId={tabId} />
+  }
+
+  // Get statement results for multi-statement queries
+  const statementResults = getAllStatementResults(tabId)
+  const activeStatementResult = getActiveStatementResult(tabId)
+  const hasMultipleResults = statementResults.length > 1
+  // At this point, tab is guaranteed to be query or table-preview (not erd or table-designer)
+  const activeResultIndex = tab.activeResultIndex ?? 0
+
+  // For query tabs, pass all rows and let DataTable handle client-side pagination
+  // For table-preview tabs with server-side pagination, rows are already limited by SQL
+  const getAllRows = (): Record<string, unknown>[] => {
+    if (hasMultipleResults) {
+      const statement = tab.multiResult?.statements?.[tab.activeResultIndex]
+      return (statement?.rows ?? []) as Record<string, unknown>[]
+    }
+    return (tab.result?.rows ?? []) as Record<string, unknown>[]
+  }
+
+  // Only use store pagination for table-preview with server-side pagination (for backward compat display)
+  const paginatedRows = hasMultipleResults
+    ? getActiveResultPaginatedRows(tabId)
+    : getTabPaginatedRows(tabId)
+
+  // Get columns from active statement result (for multi-statement) or legacy result
+  const getActiveResultColumns = () => {
+    if (activeStatementResult) {
+      return activeStatementResult.fields.map((f) => ({
+        name: f.name,
+        dataType: f.dataType
+      }))
+    }
+    // tab is guaranteed to be query or table-preview at this point
+    if (tab.result) {
+      return tab.result.columns
+    }
+    return []
+  }
 
   return (
     <div className="flex flex-1 flex-col overflow-hidden">

--- a/apps/desktop/src/renderer/src/lib/editable-select.ts
+++ b/apps/desktop/src/renderer/src/lib/editable-select.ts
@@ -257,7 +257,7 @@ function tokenize(sql: string, dbType: DatabaseType): Tok[] {
 
     // Numbers
     if (c >= '0' && c <= '9') {
-      while (i < n && /[\d.eE+\-]/.test(sql[i])) i++
+      while (i < n && /[\d.eE+-]/.test(sql[i])) i++
       toks.push({ type: 'NUMBER' })
       continue
     }

--- a/apps/desktop/src/renderer/src/lib/editable-select.ts
+++ b/apps/desktop/src/renderer/src/lib/editable-select.ts
@@ -255,9 +255,12 @@ function tokenize(sql: string, dbType: DatabaseType): Tok[] {
       continue
     }
 
-    // Numbers
+    // Numbers — only consume a well-formed literal so `1+2`, `1-2`, and
+    // `1-- comment` don't collapse into a single NUMBER token (the sign is
+    // only part of the literal inside an exponent).
     if (c >= '0' && c <= '9') {
-      while (i < n && /[\d.eE+-]/.test(sql[i])) i++
+      const match = /^\d+(?:\.\d+)?(?:[eE][+-]?\d+)?/.exec(sql.slice(i))
+      i += match ? match[0].length : 1
       toks.push({ type: 'NUMBER' })
       continue
     }

--- a/apps/web/src/app/databases/page.tsx
+++ b/apps/web/src/app/databases/page.tsx
@@ -78,7 +78,7 @@ export default function DatabasesPage() {
             {/* Hero Section */}
             <section className="text-center mb-20 sm:mb-32">
               <p className="text-[12px] uppercase tracking-[0.4em] text-(--color-accent) mb-6 font-bold font-mono">
-                // Ecosystem
+                {'// Ecosystem'}
               </p>
               <h1
                 className="text-5xl sm:text-7xl md:text-8xl font-bold tracking-tighter leading-[0.9] mb-8 text-white font-mono uppercase"

--- a/apps/webapp/eslint.config.mjs
+++ b/apps/webapp/eslint.config.mjs
@@ -1,0 +1,19 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import nextVitals from "eslint-config-next/core-web-vitals";
+import nextTs from "eslint-config-next/typescript";
+
+const eslintConfig = defineConfig([
+  ...nextVitals,
+  ...nextTs,
+  // Override default ignores of eslint-config-next.
+  globalIgnores([
+    // Default ignores of eslint-config-next:
+    ".next/**",
+    "out/**",
+    "build/**",
+    "next-env.d.ts",
+    "drizzle/**",
+  ]),
+]);
+
+export default eslintConfig;

--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -52,6 +52,8 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "drizzle-kit": "^0.31.7",
+    "eslint": "^9",
+    "eslint-config-next": "16.0.5",
     "tailwindcss": "^4",
     "typescript": "^5"
   }

--- a/apps/webapp/src/components/query/results-table.tsx
+++ b/apps/webapp/src/components/query/results-table.tsx
@@ -133,6 +133,38 @@ const CellValue = memo(function CellValue({ value, dataType }: { value: unknown;
   )
 })
 
+function ActiveCellInput({
+  initialValue,
+  onCommit,
+  onCancel
+}: {
+  initialValue: string
+  onCommit: (value: string) => void
+  onCancel: () => void
+}) {
+  // State is seeded once on mount via the initializer. The input is only
+  // mounted while its cell is active, so a fresh edit always starts from the
+  // current cell value without syncing through an effect.
+  const [editValue, setEditValue] = useState(() => initialValue)
+
+  return (
+    <input
+      autoFocus
+      value={editValue}
+      onChange={(e) => setEditValue(e.target.value)}
+      onBlur={() => onCommit(editValue)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') {
+          onCommit(editValue)
+        } else if (e.key === 'Escape') {
+          onCancel()
+        }
+      }}
+      className="w-full h-6 bg-background border border-accent/50 rounded px-1 text-xs outline-none focus:border-accent"
+    />
+  )
+}
+
 function EditableCell({
   value,
   dataType,
@@ -154,13 +186,6 @@ function EditableCell({
   const isActiveCell = tabEdit?.editingCell?.rowIndex === rowIndex && tabEdit?.editingCell?.columnName === columnName
   const isModified = isCellModified(tabId, rowIndex, columnName)
   const displayValue = isModified ? getModifiedCellValue(tabId, rowIndex, columnName) : value
-  const [editValue, setEditValue] = useState('')
-
-  useEffect(() => {
-    if (isActiveCell) {
-      setEditValue(displayValue === null || displayValue === undefined ? '' : String(displayValue))
-    }
-  }, [isActiveCell, displayValue])
 
   if (!isEditing) {
     return <CellValue value={value} dataType={dataType} />
@@ -168,23 +193,13 @@ function EditableCell({
 
   if (isActiveCell) {
     return (
-      <input
-        autoFocus
-        value={editValue}
-        onChange={(e) => setEditValue(e.target.value)}
-        onBlur={() => {
+      <ActiveCellInput
+        initialValue={displayValue === null || displayValue === undefined ? '' : String(displayValue)}
+        onCommit={(editValue) => {
           const newValue = editValue === '' ? null : editValue
           updateCellValue(tabId, rowIndex, columnName, newValue, row)
         }}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter') {
-            const newValue = editValue === '' ? null : editValue
-            updateCellValue(tabId, rowIndex, columnName, newValue, row)
-          } else if (e.key === 'Escape') {
-            cancelCellEdit(tabId)
-          }
-        }}
-        className="w-full h-6 bg-background border border-accent/50 rounded px-1 text-xs outline-none focus:border-accent"
+        onCancel={() => cancelCellEdit(tabId)}
       />
     )
   }

--- a/apps/webapp/src/components/query/results-table.tsx
+++ b/apps/webapp/src/components/query/results-table.tsx
@@ -147,17 +147,34 @@ function ActiveCellInput({
   // current cell value without syncing through an effect.
   const [editValue, setEditValue] = useState(() => initialValue)
 
+  // A keyboard action (Enter/Escape) unmounts the focused input, which also
+  // fires onBlur. Without this guard, Escape would still commit via the blur
+  // and Enter would commit twice. Finalize exactly once.
+  const finalizedRef = useRef(false)
+  const commit = () => {
+    if (finalizedRef.current) return
+    finalizedRef.current = true
+    onCommit(editValue)
+  }
+  const cancel = () => {
+    if (finalizedRef.current) return
+    finalizedRef.current = true
+    onCancel()
+  }
+
   return (
     <input
       autoFocus
       value={editValue}
       onChange={(e) => setEditValue(e.target.value)}
-      onBlur={() => onCommit(editValue)}
+      onBlur={commit}
       onKeyDown={(e) => {
         if (e.key === 'Enter') {
-          onCommit(editValue)
+          e.preventDefault()
+          commit()
         } else if (e.key === 'Escape') {
-          onCancel()
+          e.preventDefault()
+          cancel()
         }
       }}
       className="w-full h-6 bg-background border border-accent/50 rounded px-1 text-xs outline-none focus:border-accent"

--- a/apps/webapp/src/components/schema-explorer/schema-explorer.tsx
+++ b/apps/webapp/src/components/schema-explorer/schema-explorer.tsx
@@ -103,7 +103,7 @@ export function SchemaExplorer() {
         })}
         {filteredSchemas.length === 0 && search && (
           <div className="px-3 py-4 text-xs text-muted-foreground text-center">
-            No tables or columns match "{search}"
+            No tables or columns match &ldquo;{search}&rdquo;
           </div>
         )}
       </div>

--- a/apps/webapp/src/hooks/use-saved-queries.ts
+++ b/apps/webapp/src/hooks/use-saved-queries.ts
@@ -10,9 +10,7 @@ export function useSavedQueries(connectionId?: string, search?: string) {
   const queries = useLiveQuery(async () => {
     if (!userId) return []
     const db = getDB(userId)
-    let collection = db.savedQueries
-      .where('_syncStatus')
-      .notEqual('deleted')
+    const collection = db.savedQueries.where('_syncStatus').notEqual('deleted')
 
     let results = await collection.reverse().sortBy('updatedAt')
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -692,6 +692,12 @@ importers:
       drizzle-kit:
         specifier: ^0.31.7
         version: 0.31.7
+      eslint:
+        specifier: ^9
+        version: 9.39.1(jiti@2.6.1)
+      eslint-config-next:
+        specifier: 16.0.5
+        version: 16.0.5(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       tailwindcss:
         specifier: ^4
         version: 4.1.17
@@ -16836,8 +16842,28 @@ snapshots:
       '@next/eslint-plugin-next': 16.0.5
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.1(jiti@2.6.1))
+      eslint-plugin-react: 7.37.5(eslint@9.39.1(jiti@2.6.1))
+      eslint-plugin-react-hooks: 7.0.1(eslint@9.39.1(jiti@2.6.1))
+      globals: 16.4.0
+      typescript-eslint: 8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@typescript-eslint/parser'
+      - eslint-import-resolver-webpack
+      - eslint-plugin-import-x
+      - supports-color
+
+  eslint-config-next@16.0.5(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3):
+    dependencies:
+      '@next/eslint-plugin-next': 16.0.5
+      eslint: 9.39.1(jiti@2.6.1)
+      eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.1(jiti@2.6.1))
@@ -16863,7 +16889,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -16878,11 +16904,36 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1)):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3
+      eslint: 9.39.1(jiti@2.6.1)
+      get-tsconfig: 4.13.0
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.15
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 9.39.1(jiti@2.6.1)
+      eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1)):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
@@ -16900,7 +16951,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -16913,6 +16964,33 @@ snapshots:
       tsconfig-paths: 3.15.0
     optionalDependencies:
       '@typescript-eslint/parser': 8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1)):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.9
+      array.prototype.findlastindex: 1.2.6
+      array.prototype.flat: 1.3.3
+      array.prototype.flatmap: 1.3.3
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 9.39.1(jiti@2.6.1)
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
+      hasown: 2.0.2
+      is-core-module: 2.16.1
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.1
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.9
+      tsconfig-paths: 3.15.0
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack


### PR DESCRIPTION
## What

Two related fixes that came out of a repo maintenance pass.

### 🐛 `fix(query-editor)`: conditional Watch Mode hooks
In `tab-query-editor.tsx`, the Watch Mode `useMemo`/`useCallback`/`useEffect` were declared **after** eight conditional early-returns (notebook, erd, table-designer, data-generator, pg-notifications, health-monitor, schema-intel, missing-connection). That violates the rules of hooks: when a mounted editor instance switches tab type the hook count changes between renders, which crashes React with *"rendered more/fewer hooks than during the previous render"*.

The hooks only depend on `tabId`, `tabConnection` and store getters — all available before the guards — so the block moves up unchanged. **No behaviour change.**

### 🔧 `fix(lint)`: repair the lint pipeline
`turbo run lint` was failing entirely because `apps/webapp` had a `lint` script but no eslint config or dependency. This adds a flat config (mirroring `apps/web`) + `eslint`/`eslint-config-next`, then clears the surfaced errors:
- **webapp**: editing cell refactored to a child component seeded via a `useState` initializer (instead of setState-in-effect); escaped quote entities; `prefer-const`
- **web**: wrapped a literal `//` comment textnode in braces
- **desktop**: scoped `react-hooks` rules out of Playwright e2e fixtures, allow triple-slash refs in `.d.ts`, dropped an unnecessary regex escape, gave an empty mock method a body

## Verification
- `pnpm lint` → green across desktop, web, webapp (0 errors)
- `pnpm --filter @data-peek/desktop typecheck` → clean
- Desktop test suite → **882 passed**

## Note
~174 pre-existing prettier *warnings* in desktop are left untouched (they don't block lint and a 40-file reformat would conflict with in-flight branches). Suggest enforcing prettier in CI/pre-commit, then a one-shot format later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved inline editing in query results, with better commit/cancel behavior and correct handling of empty values.
  * Added a visible “// Ecosystem” label to the Databases page.

* **Bug Fixes**
  * Improved Schema Explorer empty-state messaging (properly encoded quotes) and refined saved-query filtering for deleted items.
  * Tightened SQL numeric literal parsing to prevent incorrect token boundaries.
  * Stabilized query editor behavior so watch-mode setup initializes before early-render paths.

* **Chores**
  * Updated linting configuration and minor test mock cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->