### PR TITLE
Fix nav exports for active result tab

### DIFF
--- a/apps/desktop/src/renderer/src/components/nav-actions.tsx
+++ b/apps/desktop/src/renderer/src/components/nav-actions.tsx
@@ -13,12 +13,29 @@ import {
   Sparkles
 } from 'lucide-react'
 
-import { Button, Popover, PopoverContent, PopoverTrigger, Tooltip, TooltipContent, TooltipTrigger, keys, Sidebar, SidebarContent, SidebarGroup, SidebarGroupContent, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@data-peek/ui'
+import {
+  Button,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+  keys,
+  Sidebar,
+  SidebarContent,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem
+} from '@data-peek/ui'
 
 import { useCopyToClipboard } from '@/hooks/use-copy-to-clipboard'
 import { formatSQL } from '@/lib/sql-formatter'
-import { useQueryStore, useConnectionStore } from '@/stores'
-import { exportToSQL } from '@/lib/export'
+import { useQueryStore, useConnectionStore, useTabStore } from '@/stores'
+import { downloadExport, generateExportFilename, type ExportFormat } from '@/lib/export'
+import { getExportDataForTab } from '@/lib/tab-export'
 
 export function NavActions() {
   const [isOpen, setIsOpen] = React.useState(false)
@@ -29,6 +46,14 @@ export function NavActions() {
   const setCurrentQuery = useQueryStore((s) => s.setCurrentQuery)
   const setIsExecuting = useQueryStore((s) => s.setIsExecuting)
   const addToHistory = useQueryStore((s) => s.addToHistory)
+  const activeTab = useTabStore((s) => s.getActiveTab())
+
+  const exportData = getExportDataForTab(activeTab)
+  const exportTableName = activeTab?.type === 'table-preview' ? activeTab.tableName : undefined
+  const sqlExportOptions =
+    activeTab?.type === 'table-preview'
+      ? { tableName: activeTab.tableName, schemaName: activeTab.schemaName }
+      : { tableName: 'query_result' }
 
   const handleRunQuery = () => {
     if (!activeConnection || isExecuting || !currentQuery.trim()) return
@@ -70,65 +95,29 @@ export function NavActions() {
     setIsOpen(false)
   }
 
-  const handleExportCSV = () => {
-    if (!result) return
-    // Generate CSV
-    const headers = result.columns.map((c) => c.name).join(',')
-    const rows = result.rows.map((row) =>
-      result.columns
-        .map((c) => {
-          const val = row[c.name]
-          if (val === null || val === undefined) return ''
-          const str = String(val)
-          return str.includes(',') || str.includes('"') ? `"${str.replace(/"/g, '""')}"` : str
-        })
-        .join(',')
+  const handleExport = (format: ExportFormat) => {
+    if (!exportData) return
+    downloadExport(
+      exportData,
+      format,
+      generateExportFilename(exportTableName),
+      format === 'sql' ? sqlExportOptions : undefined
     )
-    const csv = [headers, ...rows].join('\n')
-
-    // Download
-    const blob = new Blob([csv], { type: 'text/csv' })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = `query-results-${Date.now()}.csv`
-    a.click()
-    URL.revokeObjectURL(url)
     setIsOpen(false)
   }
 
+  const handleExportCSV = () => handleExport('csv')
+
   const handleExportJSON = () => {
-    if (!result) return
-    const json = JSON.stringify(result.rows, null, 2)
-    const blob = new Blob([json], { type: 'application/json' })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = `query-results-${Date.now()}.json`
-    a.click()
-    URL.revokeObjectURL(url)
-    setIsOpen(false)
+    handleExport('json')
   }
 
   const handleExportSQL = () => {
-    if (!result) return
-    const exportData = {
-      columns: result.columns,
-      rows: result.rows
-    }
-    const sql = exportToSQL(exportData, { tableName: 'query_result' })
-    const blob = new Blob([sql], { type: 'text/sql' })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = `query-results-${Date.now()}.sql`
-    a.click()
-    URL.revokeObjectURL(url)
-    setIsOpen(false)
+    handleExport('sql')
   }
 
   const canRun = activeConnection && currentQuery.trim() && !isExecuting
-  const hasResults = !!result
+  const hasResults = !!exportData
 
   return (
     <div className="flex items-center gap-1.5">

--- a/apps/desktop/src/renderer/src/lib/__tests__/tab-export.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/tab-export.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest'
+import { getExportDataForTab } from '../tab-export'
+import type { QueryTab, Tab } from '../../stores/tab-store'
+
+function queryTab(overrides: Partial<QueryTab> = {}): QueryTab {
+  return {
+    id: 'tab-1',
+    type: 'query',
+    title: 'New Query',
+    isPinned: false,
+    connectionId: 'conn-1',
+    createdAt: 0,
+    order: 0,
+    query: 'select 1',
+    savedQuery: 'select 1',
+    result: null,
+    multiResult: null,
+    activeResultIndex: 0,
+    error: null,
+    isExecuting: false,
+    executionId: null,
+    currentPage: 1,
+    pageSize: 100,
+    ...overrides
+  }
+}
+
+describe('getExportDataForTab', () => {
+  it('returns legacy single-result data for executable tabs', () => {
+    const result = {
+      columns: [{ name: 'id', dataType: 'integer' }],
+      rows: [{ id: 1 }],
+      rowCount: 1,
+      durationMs: 4
+    }
+
+    expect(getExportDataForTab(queryTab({ result }))).toBe(result)
+  })
+
+  it('uses the active statement instead of the first legacy result for multi-results', () => {
+    const data = getExportDataForTab(
+      queryTab({
+        activeResultIndex: 1,
+        result: {
+          columns: [{ name: 'first_id', dataType: 'integer' }],
+          rows: [{ first_id: 1 }],
+          rowCount: 1,
+          durationMs: 3
+        },
+        multiResult: {
+          statementCount: 2,
+          totalDurationMs: 9,
+          statements: [
+            {
+              statement: 'select 1 as first_id',
+              statementIndex: 0,
+              fields: [{ name: 'first_id', dataType: 'integer', dataTypeID: 23 }],
+              rows: [{ first_id: 1 }],
+              rowCount: 1,
+              durationMs: 3,
+              isDataReturning: true
+            },
+            {
+              statement: 'select 2 as second_id',
+              statementIndex: 1,
+              fields: [{ name: 'second_id', dataType: 'integer', dataTypeID: 23 }],
+              rows: [{ second_id: 2 }],
+              rowCount: 1,
+              durationMs: 6,
+              isDataReturning: true
+            }
+          ]
+        }
+      })
+    )
+
+    expect(data).toEqual({
+      columns: [{ name: 'second_id', dataType: 'integer' }],
+      rows: [{ second_id: 2 }]
+    })
+  })
+
+  it('returns null when a multi-result active index is no longer valid', () => {
+    expect(
+      getExportDataForTab(
+        queryTab({
+          activeResultIndex: 3,
+          multiResult: {
+            statementCount: 1,
+            totalDurationMs: 1,
+            statements: [
+              {
+                statement: 'select 1',
+                statementIndex: 0,
+                fields: [{ name: 'id', dataType: 'integer', dataTypeID: 23 }],
+                rows: [{ id: 1 }],
+                rowCount: 1,
+                durationMs: 1,
+                isDataReturning: true
+              }
+            ]
+          }
+        })
+      )
+    ).toBeNull()
+  })
+
+  it('returns null for non-executable tabs', () => {
+    const erdTab: Tab = {
+      id: 'erd-1',
+      type: 'erd',
+      title: 'ERD',
+      isPinned: false,
+      connectionId: 'conn-1',
+      createdAt: 0,
+      order: 0
+    }
+
+    expect(getExportDataForTab(erdTab)).toBeNull()
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/tab-export.ts
+++ b/apps/desktop/src/renderer/src/lib/tab-export.ts
@@ -6,7 +6,6 @@ export function getExportDataForTab(tab: Tab | null | undefined): ExportData | n
 
   if (tab.multiResult) {
     const statement = tab.multiResult.statements[tab.activeResultIndex ?? 0]
-    const statement = tab.multiResult.statements[tab.activeResultIndex ?? 0]
     if (!statement || !statement.isDataReturning) return null
 
     return {

--- a/apps/desktop/src/renderer/src/lib/tab-export.ts
+++ b/apps/desktop/src/renderer/src/lib/tab-export.ts
@@ -1,0 +1,21 @@
+import type { ExportData } from '@/lib/export'
+import { isExecutableTab, type Tab } from '@/stores/tab-store'
+
+export function getExportDataForTab(tab: Tab | null | undefined): ExportData | null {
+  if (!tab || !isExecutableTab(tab)) return null
+
+  if (tab.multiResult) {
+    const statement = tab.multiResult.statements[tab.activeResultIndex ?? 0]
+    if (!statement) return null
+
+    return {
+      columns: statement.fields.map((field) => ({
+        name: field.name,
+        dataType: field.dataType
+      })),
+      rows: statement.rows
+    }
+  }
+
+  return tab.result
+}

--- a/apps/desktop/src/renderer/src/lib/tab-export.ts
+++ b/apps/desktop/src/renderer/src/lib/tab-export.ts
@@ -6,7 +6,8 @@ export function getExportDataForTab(tab: Tab | null | undefined): ExportData | n
 
   if (tab.multiResult) {
     const statement = tab.multiResult.statements[tab.activeResultIndex ?? 0]
-    if (!statement) return null
+    const statement = tab.multiResult.statements[tab.activeResultIndex ?? 0]
+    if (!statement || !statement.isDataReturning) return null
 
     return {
       columns: statement.fields.map((field) => ({


### PR DESCRIPTION
﻿## Summary

- Fixes #196 by making the top navigation export actions read from the active tab instead of the legacy query result store.
- Uses the active multi-statement result index when preparing CSV, JSON, and SQL exports.
- Adds regression coverage for selecting the active statement export data.

## Validation

- `npx --yes pnpm@10.22.0 install --frozen-lockfile` - passed
- `npx --yes pnpm@10.22.0 --filter @data-peek/desktop exec vitest run src/renderer/src/lib/__tests__/tab-export.test.ts src/renderer/src/lib/__tests__/export.test.ts` - passed, 82 tests
- `npx --yes pnpm@10.22.0 --filter @data-peek/desktop run typecheck` - passed
- `npx --yes pnpm@10.22.0 --filter @data-peek/desktop exec eslint src/renderer/src/components/nav-actions.tsx src/renderer/src/lib/tab-export.ts src/renderer/src/lib/__tests__/tab-export.test.ts` - passed
- `npx --yes pnpm@10.22.0 --filter @data-peek/desktop test` - passed, 44 files and 886 tests
- `git diff --check` - passed, with Windows LF/CRLF warnings only

## Notes

- Fixes #196.
- No compatibility impact expected; exports now use the existing shared export serialization helpers.
- Full repo lint was not run; changed-file ESLint passed, and repo-wide hook lint cleanup is already being handled separately in #199.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Export downloads now use the active tab’s export-ready data, including table previews and multi-result query tabs.
  * CSV, JSON, and SQL exports now share consistent filename generation.

* **Bug Fixes**
  * Export actions enable/disable based on whether the active tab has exportable data.
  * Multi-result query exports use the currently selected result; invalid selections produce no export.
  * Export popovers close automatically after a download starts.

* **Tests**
  * Added test coverage for active-tab export data selection, including legacy, multi-result, and non-executable tabs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->