### PR TITLE
fix(postgres): show timestamp/date as raw DB strings (#197)

### DIFF
--- a/apps/desktop/src/main/__tests__/pg-pool-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/pg-pool-manager.test.ts
@@ -8,7 +8,14 @@ const { mockClient, mockPool, PoolCtor } = vi.hoisted(() => {
   return { mockClient, mockPool, PoolCtor }
 })
 
-vi.mock('pg', () => ({ Pool: PoolCtor }))
+vi.mock('pg', () => ({
+  Pool: PoolCtor,
+  // pg-client-config registers global type parsers on import.
+  types: {
+    setTypeParser: vi.fn(),
+    builtins: { TIMESTAMP: 1114, TIMESTAMPTZ: 1184, DATE: 1082 }
+  }
+}))
 vi.mock('../ssh-tunnel-service', () => ({
   createTunnel: vi.fn(),
   closeTunnel: vi.fn()

--- a/apps/desktop/src/main/adapters/__tests__/pg-type-parsers.test.ts
+++ b/apps/desktop/src/main/adapters/__tests__/pg-type-parsers.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import { types } from 'pg'
+import { configurePgTypeParsers } from '../pg-type-parsers'
+
+describe('configurePgTypeParsers', () => {
+  it('returns timestamp / timestamptz / date as raw DB strings instead of JS Dates', () => {
+    configurePgTypeParsers()
+
+    const timestamp = types.getTypeParser(types.builtins.TIMESTAMP)
+    const timestamptz = types.getTypeParser(types.builtins.TIMESTAMPTZ)
+    const date = types.getTypeParser(types.builtins.DATE)
+
+    // No JS Date reinterpretation: the value the database sent is the value we show.
+    expect(timestamp('2026-01-02 09:08:00')).toBe('2026-01-02 09:08:00')
+    expect(timestamptz('2026-01-02 09:08:00+00')).toBe('2026-01-02 09:08:00+00')
+    expect(date('2026-01-02')).toBe('2026-01-02')
+
+    expect(timestamp('2026-01-02 09:08:00')).not.toBeInstanceOf(Date)
+  })
+})

--- a/apps/desktop/src/main/adapters/pg-client-config.ts
+++ b/apps/desktop/src/main/adapters/pg-client-config.ts
@@ -1,6 +1,11 @@
 import { readFileSync } from 'fs'
 import type { ClientConfig } from 'pg'
 import type { ConnectionConfig } from '@shared/index'
+import { configurePgTypeParsers } from './pg-type-parsers'
+
+// Register raw date/time parsers once, on the connection path, before any query
+// runs. setTypeParser mutates the process-global pg-types registry.
+configurePgTypeParsers()
 
 /**
  * Build pg ClientConfig from a ConnectionConfig.

--- a/apps/desktop/src/main/adapters/pg-type-parsers.ts
+++ b/apps/desktop/src/main/adapters/pg-type-parsers.ts
@@ -1,0 +1,22 @@
+import { types } from 'pg'
+
+/**
+ * Return Postgres date/time values as the raw string the database sent, rather
+ * than letting node-postgres reinterpret them through a JS `Date`.
+ *
+ * By default `pg` parses `timestamp without time zone` (and `date`) in the
+ * Node process's local timezone, so a value stored as UTC silently gains a
+ * phantom offset — and the same instant then renders differently in the grid
+ * (`String(date)`, local) versus the cell inspector (`toISOString()`, UTC).
+ * Showing the literal DB value removes both problems and matches what a data
+ * client should do: report exactly what's stored.
+ *
+ * `setTypeParser` mutates the process-global pg-types registry, so this only
+ * needs to run once; it is idempotent and safe to call repeatedly.
+ */
+export function configurePgTypeParsers(): void {
+  const raw = (value: string): string => value
+  types.setTypeParser(types.builtins.TIMESTAMP, raw) // 1114 — timestamp without time zone
+  types.setTypeParser(types.builtins.TIMESTAMPTZ, raw) // 1184 — timestamp with time zone
+  types.setTypeParser(types.builtins.DATE, raw) // 1082 — date
+}


### PR DESCRIPTION
Closes #197.

## Root cause
node-postgres parses `timestamp without time zone` (and `date`) in the **Node process's local timezone** — no `setTypeParser` was configured. So a UTC-stored value silently picked up a phantom offset (the reporter's *"offset has not been updated"*). Compounding it, the same instant rendered two different ways: the result grid does `String(date)` (→ local) while the cell inspector does `date.toISOString()` (→ UTC).

## Fix
Register global pg type parsers for `timestamp` (1114), `timestamptz` (1184), and `date` (1082) that return the **literal string** Postgres sends — so data-peek shows exactly what's stored, with no JS `Date` reinterpretation. This is what TablePlus/DBeaver do, and it fits the project's "honest" brand.

Because timestamp values are now strings everywhere, the grid and inspector render identically — the rendering inconsistency disappears for free.

Registered on the connection path (`pg-client-config.ts`, an explicit module-level call so it isn't tree-shaken) before any query runs. `setTypeParser` mutates the process-global pg-types registry, so it only needs to run once.

## Downstream safety (verified)
- **Inline editing**: the edit row-identity key falls through `Date` → string branch (consistent within a session); SQL generation uses bind parameters, so a timestamp string binds fine.
- **Watch mode**: diff/keying compare by value, no `Date` dependency.

## Scope
PostgreSQL only — that's what #197 reported. MySQL (`mysql2`) and MSSQL have the same class of issue and can follow separately if wanted.

## Verification
- New unit test (`pg-type-parsers.test.ts`) asserts raw-string parsing — written failing first, then green.
- Updated the `pg` mock in `pg-pool-manager.test.ts` (the module now reads `types` on the connection path).
- Full suite: **883 passed**. Typecheck clean. Lint green (0 errors).

---
Note: #196 (export targets wrong result tab) from the same batch was already fixed on `main` — closed with an end-to-end trace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of PostgreSQL date and time values so they stay in their original text form instead of being converted into JavaScript dates.
  * This helps keep database values consistent and avoids unexpected date/time formatting or parsing issues.

* **Tests**
  * Added coverage to verify date and time values are returned as raw strings.
  * Expanded mock support so the database-related tests run with the expected interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->