### PR TITLE
fix(edit): serialize scalar JSON/JSONB values as JSON text (#194)

### DIFF
--- a/apps/desktop/src/main/__tests__/sql-builder.test.ts
+++ b/apps/desktop/src/main/__tests__/sql-builder.test.ts
@@ -119,6 +119,24 @@ describe('buildQuery', () => {
       expect(result.params).toEqual(['{"foo":"baz","extra":true}', 1])
     })
 
+    it('should serialize scalar JSON/JSONB values (string/number/boolean) as JSON text', () => {
+      const scalarUpdate: RowUpdate = {
+        type: 'update',
+        id: 'op-3b',
+        primaryKeys: [{ column: 'id', value: 1, dataType: 'integer' }],
+        changes: [
+          { column: 'a', oldValue: null, newValue: 'hello', dataType: 'jsonb' },
+          { column: 'b', oldValue: null, newValue: 42, dataType: 'jsonb' },
+          { column: 'c', oldValue: null, newValue: true, dataType: 'json' }
+        ],
+        originalRow: { id: 1 }
+      }
+      const result = buildQuery(scalarUpdate, createContext(), 'postgresql')
+      // A bare `hello` is invalid JSON input for a jsonb column — it must be
+      // sent as the JSON text `"hello"`. Same for numbers/booleans.
+      expect(result.params).toEqual(['"hello"', '42', 'true', 1])
+    })
+
     it('should handle boolean data types', () => {
       const boolUpdate: RowUpdate = {
         type: 'update',

--- a/apps/desktop/src/main/sql-builder.ts
+++ b/apps/desktop/src/main/sql-builder.ts
@@ -82,8 +82,11 @@ function serializeValue(value: unknown, dataType: string): unknown {
     return null
   }
 
-  // Handle JSON/JSONB - stringify objects
-  if ((dataType === 'json' || dataType === 'jsonb') && typeof value === 'object') {
+  // Handle JSON/JSONB. The cell editor hands us a parsed value (object, array,
+  // or scalar), so always serialize back to JSON text — a bare scalar like
+  // `hello` is invalid input for a json/jsonb column and must be sent as the
+  // quoted JSON text `"hello"`.
+  if (dataType === 'json' || dataType === 'jsonb') {
     return JSON.stringify(value)
   }
 


### PR DESCRIPTION
Closes #194.

## Root cause
Inline-editing a `json`/`jsonb` cell that holds a **scalar** (string, number, or boolean) failed. `serializeValue` only stringified when `typeof value === 'object'`:

```ts
if ((dataType === 'json' || dataType === 'jsonb') && typeof value === 'object') {
  return JSON.stringify(value)
}
```

The `JsonCellEditor` hands back a **parsed** value (`JSON.parse`), so a cell holding `"hello"` becomes the JS string `hello`, which fell through and was bound raw. A bare `hello` is invalid input for a json/jsonb column — Postgres (and MySQL) reject it (`invalid input syntax for type json`). Objects already worked because they hit the `typeof === 'object'` branch.

## Fix
Always serialize json/jsonb values to JSON text — objects, arrays, and scalars are all valid JSON, and the editor guarantees a parsed value (so there's no double-encoding risk). Scalars now bind as `"hello"` / `42` / `true`; objects/arrays are unchanged.

The `JsonCellEditor` already validates JSON (parse + inline error) before save, covering the issue's "accept and validate" ask.

## Scope
Dialect-agnostic `serializeValue`, so it fixes both Postgres and MySQL JSON columns. `json[]`/`jsonb[]` array columns are untouched (they hit the separate array branch).

## Verification
- New unit test for scalar json/jsonb (string/number/boolean) — written failing first, then green.
- Full suite: **906 passed**. Typecheck + lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of JSON/JSONB values in updates so scalar inputs like strings, numbers, and booleans are serialized as valid JSON text.
  * Fixed cases where these values could be passed through in an unexpected form, helping ensure database updates behave consistently.
  * Added test coverage for PostgreSQL update queries to verify JSON serialization works correctly for both scalar and object-like values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->