### PR TITLE
feat: Time Machine — snapshot, scrub, and diff query results

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ A minimal, fast SQL client desktop application with AI-powered querying. Built f
 - **Pause when window hidden** - Background tabs don't burn CPU or pound the database
 - **Tab-bar pulse indicator** - Switch tabs and the amber dot keeps pulsing on watched ones
 
+### Time Machine
+- **Every query gets a memory** - Successful SELECT results are snapshotted locally; a timeline strip (`Cmd/Ctrl+Shift+H`) scrubs back through past runs
+- **View any past run read-only** - Load an old result into the grid with a clear "viewing the past" banner and row-count sparkline
+- **Diff any two runs** - Cell-level highlights show what changed between runs, plus added/removed row counts, keyed the same way Watch Mode diffs
+- **Privacy-aware by construction** - Masked columns are stored redacted, storage is capped (50 runs per query, 512 MB global budget), and Settings has a one-click wipe
+
 ### Data Management
 - **Schema Explorer** - Browse tables, views, stored procedures, and functions
 - **Inline Editing** - Edit table data directly with INSERT/UPDATE/DELETE

--- a/apps/desktop/src/main/__tests__/register-all-handlers.test.ts
+++ b/apps/desktop/src/main/__tests__/register-all-handlers.test.ts
@@ -171,7 +171,7 @@ describe('registerAllHandlers', () => {
     const stores = makeStores()
     const fakeNotebookStorage = {} as NotebookStorage
 
-    registerAllHandlers(stores, fakeNotebookStorage, stubStepSessionRegistry)
+    registerAllHandlers(stores, fakeNotebookStorage, null, stubStepSessionRegistry)
 
     expect(hoisted.registerQueryHandlers).toHaveBeenCalledTimes(1)
     expect(hoisted.registerConnectionHandlers).toHaveBeenCalledWith(stores.connections)
@@ -185,9 +185,7 @@ describe('registerAllHandlers', () => {
     // whole handler registration sequence.
     const stores = makeStores()
 
-    expect(() =>
-      registerAllHandlers(stores, null, stubStepSessionRegistry)
-    ).not.toThrow()
+    expect(() => registerAllHandlers(stores, null, null, stubStepSessionRegistry)).not.toThrow()
 
     expect(hoisted.registerQueryHandlers).toHaveBeenCalledTimes(1)
     expect(hoisted.registerConnectionHandlers).toHaveBeenCalledTimes(1)
@@ -205,7 +203,7 @@ describe('registerAllHandlers', () => {
   it('registers every non-notebook handler regardless of notebookStorage availability', () => {
     const stores = makeStores()
 
-    registerAllHandlers(stores, null, stubStepSessionRegistry)
+    registerAllHandlers(stores, null, null, stubStepSessionRegistry)
 
     expect(hoisted.registerConnectionHandlers).toHaveBeenCalled()
     expect(hoisted.registerQueryHandlers).toHaveBeenCalled()

--- a/apps/desktop/src/main/__tests__/time-machine-handlers.test.ts
+++ b/apps/desktop/src/main/__tests__/time-machine-handlers.test.ts
@@ -129,7 +129,12 @@ describe('time-machine:capture', () => {
   it.each([
     ['missing connectionId', payload({ connectionId: '' })],
     ['missing sql', payload({ sql: '' })],
-    ['non-array rows', { ...payload(), rows: 'nope' } as unknown as TimeMachineCapturePayload]
+    ['non-array rows', { ...payload(), rows: 'nope' } as unknown as TimeMachineCapturePayload],
+    ['missing capturedAt', { ...payload(), capturedAt: undefined } as unknown as TimeMachineCapturePayload],
+    ['invalid durationMs', { ...payload(), durationMs: -1 } as unknown as TimeMachineCapturePayload],
+    ['invalid keyStrategy', { ...payload(), keyStrategy: 'other' } as unknown as TimeMachineCapturePayload],
+    ['non-array keyColumns', { ...payload(), keyColumns: 'id' } as unknown as TimeMachineCapturePayload],
+    ['non-array columns', { ...payload(), columns: 'id' } as unknown as TimeMachineCapturePayload]
   ])('rejects invalid payloads: %s', (_label, invalid) => {
     const storage = makeStorage()
     registerTimeMachineHandlers(storage as unknown as TimeMachineStorage)

--- a/apps/desktop/src/main/__tests__/time-machine-handlers.test.ts
+++ b/apps/desktop/src/main/__tests__/time-machine-handlers.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { TimeMachineCapturePayload, TimeMachineRunMeta } from '@shared/index'
+
+type Handler = (event: unknown, ...args: unknown[]) => unknown
+
+const { handlers } = vi.hoisted(() => ({
+  handlers: new Map<string, Handler>()
+}))
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: Handler) => {
+      handlers.set(channel, handler)
+    })
+  }
+}))
+
+import { registerTimeMachineHandlers } from '../ipc/time-machine-handlers'
+import { fingerprintQuery } from '../lib/query-fingerprint'
+import type { TimeMachineStorage } from '../time-machine-storage'
+
+const CHANNELS = [
+  'time-machine:capture',
+  'time-machine:list-runs',
+  'time-machine:get-snapshot',
+  'time-machine:delete-run',
+  'time-machine:clear-query',
+  'time-machine:clear-all',
+  'time-machine:stats'
+]
+
+function meta(overrides: Partial<TimeMachineRunMeta> = {}): TimeMachineRunMeta {
+  return {
+    id: 'run-1',
+    connectionId: 'conn-1',
+    fingerprint: 'fp-1',
+    sql: 'SELECT 1',
+    capturedAt: 1000,
+    durationMs: 5,
+    rowCount: 1,
+    storedRowCount: 1,
+    truncated: false,
+    contentHash: 'hash',
+    keyStrategy: 'primary_key',
+    keyColumns: ['id'],
+    hasRows: true,
+    ...overrides
+  }
+}
+
+function payload(overrides: Partial<TimeMachineCapturePayload> = {}): TimeMachineCapturePayload {
+  return {
+    connectionId: 'conn-1',
+    sql: 'SELECT * FROM t WHERE id = 1',
+    capturedAt: 1000,
+    durationMs: 5,
+    rowCount: 1,
+    truncated: false,
+    keyStrategy: 'primary_key',
+    keyColumns: ['id'],
+    columns: [{ name: 'id', dataType: 'integer' }],
+    rows: [[1]],
+    ...overrides
+  }
+}
+
+function makeStorage() {
+  return {
+    insertRun: vi.fn((_payload: TimeMachineCapturePayload, fingerprint: string) =>
+      meta({ fingerprint })
+    ),
+    listRuns: vi.fn(() => [meta()]),
+    getSnapshot: vi.fn(() => ({ ...meta(), columns: [], rows: [] })),
+    deleteRun: vi.fn(),
+    clearQuery: vi.fn(),
+    clearAll: vi.fn(),
+    stats: vi.fn(() => ({ runCount: 0, queryCount: 0, totalBytes: 0, oldestCapturedAt: null }))
+  }
+}
+
+beforeEach(() => {
+  handlers.clear()
+})
+
+describe('registration', () => {
+  it('registers all time-machine channels', () => {
+    registerTimeMachineHandlers(makeStorage() as unknown as TimeMachineStorage)
+    for (const channel of CHANNELS) {
+      expect(handlers.has(channel)).toBe(true)
+    }
+  })
+
+  it('registers nothing when storage is null', () => {
+    registerTimeMachineHandlers(null)
+    expect(handlers.size).toBe(0)
+  })
+})
+
+describe('time-machine:capture', () => {
+  it('fingerprints the sql and returns the inserted meta', () => {
+    const storage = makeStorage()
+    registerTimeMachineHandlers(storage as unknown as TimeMachineStorage)
+
+    const input = payload()
+    const result = handlers.get('time-machine:capture')!(null, input) as {
+      success: boolean
+      data: TimeMachineRunMeta
+    }
+
+    expect(result.success).toBe(true)
+    expect(storage.insertRun).toHaveBeenCalledWith(input, fingerprintQuery(input.sql))
+    expect(result.data.fingerprint).toBe(fingerprintQuery(input.sql))
+  })
+
+  it('normalizes literals into a shared fingerprint', () => {
+    const storage = makeStorage()
+    registerTimeMachineHandlers(storage as unknown as TimeMachineStorage)
+    const capture = handlers.get('time-machine:capture')!
+
+    capture(null, payload({ sql: 'SELECT * FROM t WHERE id = 1' }))
+    capture(null, payload({ sql: 'SELECT * FROM t WHERE id = 2' }))
+    capture(null, payload({ sql: 'SELECT * FROM other WHERE id = 1' }))
+
+    const fingerprints = storage.insertRun.mock.calls.map((call) => call[1])
+    expect(fingerprints[0]).toBe(fingerprints[1])
+    expect(fingerprints[2]).not.toBe(fingerprints[0])
+  })
+
+  it.each([
+    ['missing connectionId', payload({ connectionId: '' })],
+    ['missing sql', payload({ sql: '' })],
+    ['non-array rows', { ...payload(), rows: 'nope' } as unknown as TimeMachineCapturePayload]
+  ])('rejects invalid payloads: %s', (_label, invalid) => {
+    const storage = makeStorage()
+    registerTimeMachineHandlers(storage as unknown as TimeMachineStorage)
+
+    const result = handlers.get('time-machine:capture')!(null, invalid) as {
+      success: boolean
+      error: string
+    }
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('Invalid capture payload')
+    expect(storage.insertRun).not.toHaveBeenCalled()
+  })
+
+  it('returns an error envelope when the storage throws', () => {
+    const storage = makeStorage()
+    storage.insertRun.mockImplementation(() => {
+      throw new Error('disk full')
+    })
+    registerTimeMachineHandlers(storage as unknown as TimeMachineStorage)
+
+    const result = handlers.get('time-machine:capture')!(null, payload()) as {
+      success: boolean
+      error: string
+    }
+
+    expect(result).toEqual({ success: false, error: 'disk full' })
+  })
+})
+
+describe('time-machine:list-runs', () => {
+  it('fingerprints the sql and returns fingerprint plus runs', () => {
+    const storage = makeStorage()
+    registerTimeMachineHandlers(storage as unknown as TimeMachineStorage)
+
+    const sql = 'SELECT * FROM t WHERE id = 42'
+    const result = handlers.get('time-machine:list-runs')!(null, {
+      connectionId: 'conn-1',
+      sql
+    }) as { success: boolean; data: { fingerprint: string; runs: TimeMachineRunMeta[] } }
+
+    expect(result.success).toBe(true)
+    expect(result.data.fingerprint).toBe(fingerprintQuery(sql))
+    expect(result.data.runs).toHaveLength(1)
+    expect(storage.listRuns).toHaveBeenCalledWith('conn-1', fingerprintQuery(sql))
+  })
+})
+
+describe('time-machine:get-snapshot', () => {
+  it('returns the snapshot', () => {
+    const storage = makeStorage()
+    registerTimeMachineHandlers(storage as unknown as TimeMachineStorage)
+
+    const result = handlers.get('time-machine:get-snapshot')!(null, 'run-1') as {
+      success: boolean
+      data: { id: string }
+    }
+
+    expect(result.success).toBe(true)
+    expect(result.data.id).toBe('run-1')
+    expect(storage.getSnapshot).toHaveBeenCalledWith('run-1')
+  })
+
+  it('returns the storage error for metadata-only runs', () => {
+    const storage = makeStorage()
+    storage.getSnapshot.mockImplementation(() => {
+      throw new Error('Snapshot payload was not stored (over size cap)')
+    })
+    registerTimeMachineHandlers(storage as unknown as TimeMachineStorage)
+
+    const result = handlers.get('time-machine:get-snapshot')!(null, 'run-1') as {
+      success: boolean
+      error: string
+    }
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Snapshot payload was not stored (over size cap)'
+    })
+  })
+})
+
+describe('time-machine:delete-run', () => {
+  it('deletes by id', () => {
+    const storage = makeStorage()
+    registerTimeMachineHandlers(storage as unknown as TimeMachineStorage)
+
+    const result = handlers.get('time-machine:delete-run')!(null, 'run-1') as { success: boolean }
+
+    expect(result.success).toBe(true)
+    expect(storage.deleteRun).toHaveBeenCalledWith('run-1')
+  })
+})
+
+describe('time-machine:clear-query', () => {
+  it('fingerprints the sql before clearing', () => {
+    const storage = makeStorage()
+    registerTimeMachineHandlers(storage as unknown as TimeMachineStorage)
+
+    const sql = 'SELECT * FROM t WHERE id = 7'
+    const result = handlers.get('time-machine:clear-query')!(null, {
+      connectionId: 'conn-1',
+      sql
+    }) as { success: boolean }
+
+    expect(result.success).toBe(true)
+    expect(storage.clearQuery).toHaveBeenCalledWith('conn-1', fingerprintQuery(sql))
+  })
+})
+
+describe('time-machine:clear-all', () => {
+  it('clears one connection when given an id', () => {
+    const storage = makeStorage()
+    registerTimeMachineHandlers(storage as unknown as TimeMachineStorage)
+
+    handlers.get('time-machine:clear-all')!(null, 'conn-1')
+    expect(storage.clearAll).toHaveBeenCalledWith('conn-1')
+  })
+
+  it('clears everything when given no id', () => {
+    const storage = makeStorage()
+    registerTimeMachineHandlers(storage as unknown as TimeMachineStorage)
+
+    const result = handlers.get('time-machine:clear-all')!(null) as { success: boolean }
+    expect(result.success).toBe(true)
+    expect(storage.clearAll).toHaveBeenCalledWith(undefined)
+  })
+})
+
+describe('time-machine:stats', () => {
+  it('returns storage stats', () => {
+    const storage = makeStorage()
+    registerTimeMachineHandlers(storage as unknown as TimeMachineStorage)
+
+    const result = handlers.get('time-machine:stats')!(null) as {
+      success: boolean
+      data: { runCount: number }
+    }
+
+    expect(result.success).toBe(true)
+    expect(result.data.runCount).toBe(0)
+  })
+
+  it('returns an error envelope when stats throws', () => {
+    const storage = makeStorage()
+    storage.stats.mockImplementation(() => {
+      throw new Error('db closed')
+    })
+    registerTimeMachineHandlers(storage as unknown as TimeMachineStorage)
+
+    const result = handlers.get('time-machine:stats')!(null) as {
+      success: boolean
+      error: string
+    }
+
+    expect(result).toEqual({ success: false, error: 'db closed' })
+  })
+})

--- a/apps/desktop/src/main/__tests__/time-machine-storage.test.ts
+++ b/apps/desktop/src/main/__tests__/time-machine-storage.test.ts
@@ -85,7 +85,7 @@ describe.skipIf(!sqliteAvailable)('TimeMachineStorage', () => {
       expect(meta.id).toBeDefined()
       expect(meta.connectionId).toBe('conn-1')
       expect(meta.fingerprint).toBe('fp-1')
-      expect(meta.sql).toBe('SELECT * FROM users WHERE id = 1')
+      expect(meta.sql).toBe('fp-1')
       expect(meta.capturedAt).toBe(1000)
       expect(meta.durationMs).toBe(12)
       expect(meta.rowCount).toBe(2)

--- a/apps/desktop/src/main/__tests__/time-machine-storage.test.ts
+++ b/apps/desktop/src/main/__tests__/time-machine-storage.test.ts
@@ -1,0 +1,308 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as fs from 'fs'
+import * as path from 'path'
+import * as os from 'os'
+import Database from 'better-sqlite3'
+import type { TimeMachineCapturePayload } from '@shared/index'
+import { TM_MAX_RUNS_PER_QUERY } from '@shared/index'
+
+vi.mock('electron-log/main', () => ({
+  default: {
+    initialize: vi.fn(),
+    transports: {
+      console: { level: 'debug' },
+      file: { level: 'debug', maxSize: 0, format: '' }
+    },
+    scope: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn()
+    })
+  }
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: false
+  }
+}))
+
+import { TimeMachineStorage } from '../time-machine-storage'
+
+// better-sqlite3 is compiled for Electron's ABI; under plain node the whole
+// suite skips (mirrors the vitest.config.ts exclusion of notebook-storage).
+// Run for real via: ELECTRON_RUN_AS_NODE=1 electron node_modules/vitest/vitest.mjs run <file>
+const sqliteAvailable = (() => {
+  try {
+    new Database(':memory:').close()
+    return true
+  } catch {
+    return false
+  }
+})()
+
+function payload(overrides: Partial<TimeMachineCapturePayload> = {}): TimeMachineCapturePayload {
+  return {
+    connectionId: 'conn-1',
+    sql: 'SELECT * FROM users WHERE id = 1',
+    capturedAt: 1000,
+    durationMs: 12,
+    rowCount: 2,
+    truncated: false,
+    keyStrategy: 'primary_key',
+    keyColumns: ['id'],
+    columns: [
+      { name: 'id', dataType: 'integer' },
+      { name: 'name', dataType: 'text' }
+    ],
+    rows: [
+      [1, 'Alice'],
+      [2, 'Bob']
+    ],
+    ...overrides
+  }
+}
+
+describe.skipIf(!sqliteAvailable)('TimeMachineStorage', () => {
+  let storage: TimeMachineStorage
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'time-machine-storage-test-'))
+    storage = new TimeMachineStorage(tmpDir)
+  })
+
+  afterEach(() => {
+    storage.close()
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  describe('insertRun and listRuns', () => {
+    it('returns the inserted run meta', () => {
+      const meta = storage.insertRun(payload(), 'fp-1')
+
+      expect(meta.id).toBeDefined()
+      expect(meta.connectionId).toBe('conn-1')
+      expect(meta.fingerprint).toBe('fp-1')
+      expect(meta.sql).toBe('SELECT * FROM users WHERE id = 1')
+      expect(meta.capturedAt).toBe(1000)
+      expect(meta.durationMs).toBe(12)
+      expect(meta.rowCount).toBe(2)
+      expect(meta.storedRowCount).toBe(2)
+      expect(meta.truncated).toBe(false)
+      expect(meta.contentHash).toMatch(/^[0-9a-f]{64}$/)
+      expect(meta.keyStrategy).toBe('primary_key')
+      expect(meta.keyColumns).toEqual(['id'])
+      expect(meta.hasRows).toBe(true)
+    })
+
+    it('lists runs newest-first without payloads', () => {
+      const a = storage.insertRun(payload({ capturedAt: 1000 }), 'fp-1')
+      const b = storage.insertRun(payload({ capturedAt: 3000 }), 'fp-1')
+      const c = storage.insertRun(payload({ capturedAt: 2000 }), 'fp-1')
+
+      const runs = storage.listRuns('conn-1', 'fp-1')
+      expect(runs.map((r) => r.id)).toEqual([b.id, c.id, a.id])
+      expect(runs.every((r) => !('rows' in r))).toBe(true)
+    })
+
+    it('keeps timelines separate by connection and fingerprint', () => {
+      storage.insertRun(payload({ connectionId: 'conn-1' }), 'fp-1')
+      storage.insertRun(payload({ connectionId: 'conn-2' }), 'fp-1')
+      storage.insertRun(payload({ connectionId: 'conn-1' }), 'fp-2')
+
+      expect(storage.listRuns('conn-1', 'fp-1')).toHaveLength(1)
+      expect(storage.listRuns('conn-2', 'fp-1')).toHaveLength(1)
+      expect(storage.listRuns('conn-1', 'fp-2')).toHaveLength(1)
+    })
+
+    it('gives identical payloads the same content hash', () => {
+      const a = storage.insertRun(payload({ capturedAt: 1000 }), 'fp-1')
+      const b = storage.insertRun(payload({ capturedAt: 2000 }), 'fp-1')
+      const c = storage.insertRun(payload({ capturedAt: 3000, rows: [[9, 'Zed']] }), 'fp-1')
+
+      expect(a.contentHash).toBe(b.contentHash)
+      expect(c.contentHash).not.toBe(a.contentHash)
+    })
+  })
+
+  describe('per-query cap', () => {
+    it('evicts the oldest runs beyond TM_MAX_RUNS_PER_QUERY', () => {
+      for (let i = 1; i <= TM_MAX_RUNS_PER_QUERY + 5; i++) {
+        storage.insertRun(payload({ capturedAt: i }), 'fp-1')
+      }
+
+      const runs = storage.listRuns('conn-1', 'fp-1')
+      expect(runs).toHaveLength(TM_MAX_RUNS_PER_QUERY)
+      expect(runs[0].capturedAt).toBe(TM_MAX_RUNS_PER_QUERY + 5)
+      expect(runs[runs.length - 1].capturedAt).toBe(6)
+    })
+
+    it('does not evict runs from other timelines', () => {
+      const other = storage.insertRun(payload({ connectionId: 'conn-2', capturedAt: 1 }), 'fp-1')
+      for (let i = 1; i <= TM_MAX_RUNS_PER_QUERY + 1; i++) {
+        storage.insertRun(payload({ capturedAt: i }), 'fp-1')
+      }
+
+      expect(storage.listRuns('conn-2', 'fp-1').map((r) => r.id)).toEqual([other.id])
+    })
+  })
+
+  describe('global budget', () => {
+    it('evicts oldest runs globally until under budget', () => {
+      const small = new TimeMachineStorage(tmpDir, { globalBudgetBytes: 100 })
+      // Each payload serializes to ~40 bytes, so the budget holds two runs.
+      const rows = [['xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx']]
+      const a = small.insertRun(payload({ capturedAt: 1, rows }), 'fp-1')
+      const b = small.insertRun(payload({ capturedAt: 2, rows }), 'fp-1')
+      const c = small.insertRun(payload({ capturedAt: 3, rows }), 'fp-1')
+
+      const runs = small.listRuns('conn-1', 'fp-1')
+      expect(runs.map((r) => r.id)).toEqual([c.id, b.id])
+      expect(runs.map((r) => r.id)).not.toContain(a.id)
+      small.close()
+    })
+
+    it('never evicts the run just inserted, even when it alone exceeds the budget', () => {
+      const small = new TimeMachineStorage(tmpDir, { globalBudgetBytes: 50 })
+      const big = small.insertRun(payload({ capturedAt: 1, rows: [['y'.repeat(200)]] }), 'fp-1')
+
+      expect(small.listRuns('conn-1', 'fp-1').map((r) => r.id)).toEqual([big.id])
+      small.close()
+    })
+
+    it('evicts across timelines, oldest first', () => {
+      const small = new TimeMachineStorage(tmpDir, { globalBudgetBytes: 100 })
+      const rows = [['xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx']]
+      small.insertRun(payload({ connectionId: 'conn-2', capturedAt: 1, rows }), 'fp-2')
+      small.insertRun(payload({ capturedAt: 2, rows }), 'fp-1')
+      small.insertRun(payload({ capturedAt: 3, rows }), 'fp-1')
+
+      expect(small.listRuns('conn-2', 'fp-2')).toHaveLength(0)
+      expect(small.listRuns('conn-1', 'fp-1')).toHaveLength(2)
+      small.close()
+    })
+  })
+
+  describe('payload byte cap', () => {
+    it('stores metadata only when the payload exceeds the cap', () => {
+      const capped = new TimeMachineStorage(tmpDir, { maxPayloadBytes: 10 })
+      const meta = capped.insertRun(payload(), 'fp-1')
+
+      expect(meta.hasRows).toBe(false)
+      expect(meta.storedRowCount).toBe(0)
+      expect(meta.rowCount).toBe(2)
+      expect(capped.listRuns('conn-1', 'fp-1')[0].hasRows).toBe(false)
+      expect(() => capped.getSnapshot(meta.id)).toThrow(
+        'Snapshot payload was not stored (over size cap)'
+      )
+      capped.close()
+    })
+  })
+
+  describe('getSnapshot', () => {
+    it('round-trips the columnar payload', () => {
+      const input = payload({
+        columns: [
+          { name: 'id', dataType: 'integer' },
+          { name: 'meta', dataType: 'jsonb' },
+          { name: 'note', dataType: 'text' }
+        ],
+        rows: [
+          [1, { nested: [1, 2, 3] }, null],
+          [2, { nested: [] }, 'it’s "quoted"']
+        ]
+      })
+      const meta = storage.insertRun(input, 'fp-1')
+
+      const snapshot = storage.getSnapshot(meta.id)
+      expect(snapshot.id).toBe(meta.id)
+      expect(snapshot.columns).toEqual(input.columns)
+      expect(snapshot.rows).toEqual(input.rows)
+      expect(snapshot.keyColumns).toEqual(['id'])
+    })
+
+    it('throws for an unknown id', () => {
+      expect(() => storage.getSnapshot('nope')).toThrow('Snapshot not found')
+    })
+  })
+
+  describe('deleteRun, clearQuery, clearAll', () => {
+    it('deletes a single run', () => {
+      const a = storage.insertRun(payload({ capturedAt: 1 }), 'fp-1')
+      const b = storage.insertRun(payload({ capturedAt: 2 }), 'fp-1')
+
+      storage.deleteRun(a.id)
+      expect(storage.listRuns('conn-1', 'fp-1').map((r) => r.id)).toEqual([b.id])
+    })
+
+    it('clears one timeline only', () => {
+      storage.insertRun(payload(), 'fp-1')
+      storage.insertRun(payload(), 'fp-2')
+
+      storage.clearQuery('conn-1', 'fp-1')
+      expect(storage.listRuns('conn-1', 'fp-1')).toHaveLength(0)
+      expect(storage.listRuns('conn-1', 'fp-2')).toHaveLength(1)
+    })
+
+    it('clears one connection when given an id', () => {
+      storage.insertRun(payload({ connectionId: 'conn-1' }), 'fp-1')
+      storage.insertRun(payload({ connectionId: 'conn-2' }), 'fp-1')
+
+      storage.clearAll('conn-1')
+      expect(storage.listRuns('conn-1', 'fp-1')).toHaveLength(0)
+      expect(storage.listRuns('conn-2', 'fp-1')).toHaveLength(1)
+    })
+
+    it('clears everything when given no id', () => {
+      storage.insertRun(payload({ connectionId: 'conn-1' }), 'fp-1')
+      storage.insertRun(payload({ connectionId: 'conn-2' }), 'fp-2')
+
+      storage.clearAll()
+      expect(storage.stats().runCount).toBe(0)
+    })
+  })
+
+  describe('stats', () => {
+    it('reports zeros for an empty store', () => {
+      expect(storage.stats()).toEqual({
+        runCount: 0,
+        queryCount: 0,
+        totalBytes: 0,
+        oldestCapturedAt: null
+      })
+    })
+
+    it('counts runs, distinct query timelines, bytes and oldest capture', () => {
+      storage.insertRun(payload({ connectionId: 'conn-1', capturedAt: 500 }), 'fp-1')
+      storage.insertRun(payload({ connectionId: 'conn-1', capturedAt: 900 }), 'fp-1')
+      storage.insertRun(payload({ connectionId: 'conn-2', capturedAt: 700 }), 'fp-1')
+      storage.insertRun(payload({ connectionId: 'conn-1', capturedAt: 800 }), 'fp-2')
+
+      const stats = storage.stats()
+      expect(stats.runCount).toBe(4)
+      expect(stats.queryCount).toBe(3)
+      expect(stats.totalBytes).toBeGreaterThan(0)
+      expect(stats.oldestCapturedAt).toBe(500)
+    })
+  })
+
+  describe('persistence and close', () => {
+    it('sets incremental auto_vacuum at creation', () => {
+      const raw = new Database(path.join(tmpDir, 'time-machine.db'))
+      expect(raw.pragma('auto_vacuum', { simple: true })).toBe(2)
+      raw.close()
+    })
+
+    it('persists runs across close and reopen', () => {
+      const meta = storage.insertRun(payload(), 'fp-1')
+      storage.close()
+
+      storage = new TimeMachineStorage(tmpDir)
+      const runs = storage.listRuns('conn-1', 'fp-1')
+      expect(runs.map((r) => r.id)).toEqual([meta.id])
+      expect(storage.getSnapshot(meta.id).rows).toEqual(payload().rows)
+    })
+  })
+})

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -18,6 +18,7 @@ import {
   type PersistentStore
 } from './storage'
 import { NotebookStorage } from './notebook-storage'
+import { TimeMachineStorage } from './time-machine-storage'
 import { initSchemaCache } from './schema-cache'
 import { registerAllHandlers } from './ipc'
 import { setForceQuit } from './app-state'
@@ -36,6 +37,7 @@ let store: PersistentStore<{ connections: ConnectionConfig[] }>
 let savedQueriesStore: DpStorage<{ savedQueries: SavedQuery[] }>
 let snippetsStore: DpStorage<{ snippets: Snippet[] }>
 let queryHistoryStore: DpStorage<{ queryHistory: QueryHistoryEntry[] }>
+let timeMachineStorage: TimeMachineStorage | null = null
 
 const stepSessionRegistry = new StepSessionRegistry()
 
@@ -210,6 +212,14 @@ app.whenReady().then(async () => {
     console.error('Failed to initialize NotebookStorage:', error)
   }
 
+  // Same native-module caveat as NotebookStorage — degrade to null so handler
+  // registration below is always reached.
+  try {
+    timeMachineStorage = new TimeMachineStorage(app.getPath('userData'))
+  } catch (error) {
+    log.warn('Failed to initialize TimeMachineStorage:', error)
+  }
+
   try {
     stepSessionRegistry.startCleanupTimer()
   } catch (error) {
@@ -226,6 +236,7 @@ app.whenReady().then(async () => {
       queryHistory: queryHistoryStore
     },
     notebookStorage,
+    timeMachineStorage,
     stepSessionRegistry
   )
 
@@ -272,6 +283,11 @@ app.on('before-quit', (event) => {
     .catch((err) => log.error('cleanupAll failed during quit:', err))
     .finally(() => {
       stepSessionRegistry.stopCleanupTimer()
+      try {
+        timeMachineStorage?.close()
+      } catch (err) {
+        log.warn('TimeMachineStorage close failed during quit:', err)
+      }
       app.quit()
     })
 })

--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -23,7 +23,9 @@ import { registerPgExportImportHandlers } from './pg-export-import-handlers'
 import { registerNotebookHandlers } from './notebook-handlers'
 import { registerIntelHandlers } from './intel-handlers'
 import { registerStepHandlers } from './step-handlers'
+import { registerTimeMachineHandlers } from './time-machine-handlers'
 import type { StepSessionRegistry } from '../step-session'
+import type { TimeMachineStorage } from '../time-machine-storage'
 
 const log = createLogger('ipc')
 
@@ -42,6 +44,7 @@ export interface IpcStores {
 export function registerAllHandlers(
   stores: IpcStores,
   notebookStorage: NotebookStorage | null,
+  timeMachineStorage: TimeMachineStorage | null,
   stepSessionRegistry: StepSessionRegistry
 ): void {
   // Connection CRUD operations
@@ -106,6 +109,13 @@ export function registerAllHandlers(
     log.warn('NotebookStorage unavailable; notebook handlers not registered')
   }
 
+  // Time Machine result snapshots — same degrade-to-null contract as notebooks.
+  if (timeMachineStorage) {
+    registerTimeMachineHandlers(timeMachineStorage)
+  } else {
+    log.warn('TimeMachineStorage unavailable; time machine handlers not registered')
+  }
+
   // Schema Intel / diagnostics
   registerIntelHandlers()
 
@@ -134,3 +144,4 @@ export { registerPgExportImportHandlers } from './pg-export-import-handlers'
 export { registerNotebookHandlers } from './notebook-handlers'
 export { registerIntelHandlers } from './intel-handlers'
 export { registerStepHandlers } from './step-handlers'
+export { registerTimeMachineHandlers } from './time-machine-handlers'

--- a/apps/desktop/src/main/ipc/time-machine-handlers.ts
+++ b/apps/desktop/src/main/ipc/time-machine-handlers.ts
@@ -3,6 +3,35 @@ import type { TimeMachineCapturePayload } from '@shared/index'
 import type { TimeMachineStorage } from '../time-machine-storage'
 import { fingerprintQuery } from '../lib/query-fingerprint'
 
+function isValidCapturePayload(payload: unknown): payload is TimeMachineCapturePayload {
+  if (!payload || typeof payload !== 'object') return false
+  const p = payload as Record<string, unknown>
+
+  if (typeof p.connectionId !== 'string' || p.connectionId.length === 0) return false
+  if (typeof p.sql !== 'string' || p.sql.length === 0) return false
+  if (typeof p.capturedAt !== 'number' || !Number.isFinite(p.capturedAt)) return false
+  if (typeof p.durationMs !== 'number' || !Number.isFinite(p.durationMs) || p.durationMs < 0)
+    return false
+  if (typeof p.rowCount !== 'number' || !Number.isFinite(p.rowCount) || p.rowCount < 0) return false
+  if (typeof p.truncated !== 'boolean') return false
+  if (p.keyStrategy !== 'primary_key' && p.keyStrategy !== 'row_position') return false
+  if (!Array.isArray(p.keyColumns) || p.keyColumns.some((c) => typeof c !== 'string')) return false
+  if (
+    !Array.isArray(p.columns) ||
+    p.columns.some(
+      (c) =>
+        !c ||
+        typeof c !== 'object' ||
+        typeof (c as Record<string, unknown>).name !== 'string' ||
+        typeof (c as Record<string, unknown>).dataType !== 'string'
+    )
+  )
+    return false
+  if (!Array.isArray(p.rows) || p.rows.some((row) => !Array.isArray(row))) return false
+
+  return true
+}
+
 /**
  * Register Time Machine result-snapshot handlers.
  *
@@ -16,14 +45,7 @@ export function registerTimeMachineHandlers(storage: TimeMachineStorage | null):
 
   ipcMain.handle('time-machine:capture', (_, payload: TimeMachineCapturePayload) => {
     try {
-      if (
-        !payload ||
-        typeof payload.connectionId !== 'string' ||
-        payload.connectionId.length === 0 ||
-        typeof payload.sql !== 'string' ||
-        payload.sql.length === 0 ||
-        !Array.isArray(payload.rows)
-      ) {
+      if (!isValidCapturePayload(payload)) {
         return { success: false, error: 'Invalid capture payload' }
       }
       const fingerprint = fingerprintQuery(payload.sql)

--- a/apps/desktop/src/main/ipc/time-machine-handlers.ts
+++ b/apps/desktop/src/main/ipc/time-machine-handlers.ts
@@ -1,0 +1,99 @@
+import { ipcMain } from 'electron'
+import type { TimeMachineCapturePayload } from '@shared/index'
+import type { TimeMachineStorage } from '../time-machine-storage'
+import { fingerprintQuery } from '../lib/query-fingerprint'
+
+/**
+ * Register Time Machine result-snapshot handlers.
+ *
+ * The renderer always sends raw SQL; fingerprinting happens here so
+ * query-fingerprint.ts stays in the main process. Runs are keyed by
+ * (connectionId, fingerprint) where the fingerprint is the full
+ * normalized-SQL string — literal changes share a timeline.
+ */
+export function registerTimeMachineHandlers(storage: TimeMachineStorage | null): void {
+  if (!storage) return
+
+  ipcMain.handle('time-machine:capture', (_, payload: TimeMachineCapturePayload) => {
+    try {
+      if (
+        !payload ||
+        typeof payload.connectionId !== 'string' ||
+        payload.connectionId.length === 0 ||
+        typeof payload.sql !== 'string' ||
+        payload.sql.length === 0 ||
+        !Array.isArray(payload.rows)
+      ) {
+        return { success: false, error: 'Invalid capture payload' }
+      }
+      const fingerprint = fingerprintQuery(payload.sql)
+      const meta = storage.insertRun(payload, fingerprint)
+      return { success: true, data: meta }
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : String(error)
+      return { success: false, error: errorMessage }
+    }
+  })
+
+  ipcMain.handle('time-machine:list-runs', (_, args: { connectionId: string; sql: string }) => {
+    try {
+      const fingerprint = fingerprintQuery(args.sql)
+      const runs = storage.listRuns(args.connectionId, fingerprint)
+      return { success: true, data: { fingerprint, runs } }
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : String(error)
+      return { success: false, error: errorMessage }
+    }
+  })
+
+  ipcMain.handle('time-machine:get-snapshot', (_, id: string) => {
+    try {
+      const snapshot = storage.getSnapshot(id)
+      return { success: true, data: snapshot }
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : String(error)
+      return { success: false, error: errorMessage }
+    }
+  })
+
+  ipcMain.handle('time-machine:delete-run', (_, id: string) => {
+    try {
+      storage.deleteRun(id)
+      return { success: true }
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : String(error)
+      return { success: false, error: errorMessage }
+    }
+  })
+
+  ipcMain.handle('time-machine:clear-query', (_, args: { connectionId: string; sql: string }) => {
+    try {
+      const fingerprint = fingerprintQuery(args.sql)
+      storage.clearQuery(args.connectionId, fingerprint)
+      return { success: true }
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : String(error)
+      return { success: false, error: errorMessage }
+    }
+  })
+
+  ipcMain.handle('time-machine:clear-all', (_, connectionId?: string) => {
+    try {
+      storage.clearAll(connectionId)
+      return { success: true }
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : String(error)
+      return { success: false, error: errorMessage }
+    }
+  })
+
+  ipcMain.handle('time-machine:stats', () => {
+    try {
+      const stats = storage.stats()
+      return { success: true, data: stats }
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : String(error)
+      return { success: false, error: errorMessage }
+    }
+  })
+}

--- a/apps/desktop/src/main/menu.ts
+++ b/apps/desktop/src/main/menu.ts
@@ -237,6 +237,16 @@ export function createMenu(): void {
               focusedWindow.webContents.send('menu:toggle-watch')
             }
           }
+        },
+        {
+          label: 'Toggle Time Machine',
+          accelerator: 'CmdOrCtrl+Shift+H',
+          click: (): void => {
+            const focusedWindow = BrowserWindow.getFocusedWindow()
+            if (focusedWindow) {
+              focusedWindow.webContents.send('menu:toggle-time-machine')
+            }
+          }
         }
       ]
     },

--- a/apps/desktop/src/main/time-machine-storage.ts
+++ b/apps/desktop/src/main/time-machine-storage.ts
@@ -1,6 +1,7 @@
 import { randomUUID, createHash } from 'crypto'
 import { join } from 'path'
-import Database from 'better-sqlite3'
+import { createRequire } from 'module'
+import type BetterSqlite3 from 'better-sqlite3'
 import {
   TM_MAX_SNAPSHOT_PAYLOAD_BYTES,
   TM_MAX_RUNS_PER_QUERY,
@@ -70,7 +71,7 @@ export interface TimeMachineStorageOptions {
 }
 
 export class TimeMachineStorage {
-  private db: Database.Database
+  private db: BetterSqlite3.Database
   private maxRunsPerQuery: number
   private globalBudgetBytes: number
   private maxPayloadBytes: number
@@ -81,6 +82,11 @@ export class TimeMachineStorage {
     this.maxPayloadBytes = options.maxPayloadBytes ?? TM_MAX_SNAPSHOT_PAYLOAD_BYTES
 
     const dbPath = join(userDataPath, 'time-machine.db')
+
+    // Load the native module lazily so a broken-arch better-sqlite3 binary does
+    // not crash the main process at import time. The constructor try/catch in
+    // index.ts can then degrade to null storage.
+    const Database = createRequire(import.meta.url)('better-sqlite3') as typeof BetterSqlite3
     this.db = new Database(dbPath)
     // auto_vacuum only takes effect when set before the first table is created,
     // which is why it precedes init(). incremental_vacuum then actually shrinks
@@ -141,7 +147,7 @@ export class TimeMachineStorage {
           id,
           payload.connectionId,
           fingerprint,
-          payload.sql,
+          fingerprint,
           payload.capturedAt,
           payload.durationMs,
           payload.rowCount,

--- a/apps/desktop/src/main/time-machine-storage.ts
+++ b/apps/desktop/src/main/time-machine-storage.ts
@@ -1,0 +1,309 @@
+import { randomUUID, createHash } from 'crypto'
+import { join } from 'path'
+import Database from 'better-sqlite3'
+import {
+  TM_MAX_SNAPSHOT_PAYLOAD_BYTES,
+  TM_MAX_RUNS_PER_QUERY,
+  TM_GLOBAL_BUDGET_BYTES
+} from '@shared/index'
+import type {
+  TimeMachineCapturePayload,
+  TimeMachineRunMeta,
+  TimeMachineSnapshot,
+  TimeMachineStats
+} from '@shared/index'
+import { createLogger } from './lib/logger'
+
+const log = createLogger('time-machine-storage')
+
+// Meta queries must never touch the rows column — payloads stay on disk until
+// a snapshot is explicitly requested.
+const META_COLUMNS = `id, connection_id, fingerprint, sql, captured_at, duration_ms,
+  row_count, stored_row_count, truncated, content_hash, key_strategy, key_columns,
+  payload_bytes, (rows IS NOT NULL) AS has_rows`
+
+interface RunMetaRow {
+  id: string
+  connection_id: string
+  fingerprint: string
+  sql: string
+  captured_at: number
+  duration_ms: number
+  row_count: number
+  stored_row_count: number
+  truncated: number
+  content_hash: string
+  key_strategy: 'primary_key' | 'row_position'
+  key_columns: string
+  payload_bytes: number
+  has_rows: number
+}
+
+interface SnapshotRow extends RunMetaRow {
+  columns: string
+  rows: string | null
+}
+
+function rowToRunMeta(row: RunMetaRow): TimeMachineRunMeta {
+  return {
+    id: row.id,
+    connectionId: row.connection_id,
+    fingerprint: row.fingerprint,
+    sql: row.sql,
+    capturedAt: row.captured_at,
+    durationMs: row.duration_ms,
+    rowCount: row.row_count,
+    storedRowCount: row.stored_row_count,
+    truncated: row.truncated === 1,
+    contentHash: row.content_hash,
+    keyStrategy: row.key_strategy,
+    keyColumns: JSON.parse(row.key_columns) as string[],
+    hasRows: row.has_rows === 1
+  }
+}
+
+// Cap overrides exist for tests only — production callers rely on the shared defaults.
+export interface TimeMachineStorageOptions {
+  maxRunsPerQuery?: number
+  globalBudgetBytes?: number
+  maxPayloadBytes?: number
+}
+
+export class TimeMachineStorage {
+  private db: Database.Database
+  private maxRunsPerQuery: number
+  private globalBudgetBytes: number
+  private maxPayloadBytes: number
+
+  constructor(userDataPath: string, options: TimeMachineStorageOptions = {}) {
+    this.maxRunsPerQuery = options.maxRunsPerQuery ?? TM_MAX_RUNS_PER_QUERY
+    this.globalBudgetBytes = options.globalBudgetBytes ?? TM_GLOBAL_BUDGET_BYTES
+    this.maxPayloadBytes = options.maxPayloadBytes ?? TM_MAX_SNAPSHOT_PAYLOAD_BYTES
+
+    const dbPath = join(userDataPath, 'time-machine.db')
+    this.db = new Database(dbPath)
+    // auto_vacuum only takes effect when set before the first table is created,
+    // which is why it precedes init(). incremental_vacuum then actually shrinks
+    // the file after evictions.
+    this.db.pragma('auto_vacuum = INCREMENTAL')
+    this.db.pragma('journal_mode = WAL')
+    this.db.pragma('foreign_keys = ON')
+    this.init()
+    log.info('TimeMachineStorage initialised', dbPath)
+  }
+
+  private init(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS runs (
+        id TEXT PRIMARY KEY,
+        connection_id TEXT NOT NULL,
+        fingerprint TEXT NOT NULL,
+        sql TEXT NOT NULL,
+        captured_at INTEGER NOT NULL,
+        duration_ms INTEGER NOT NULL,
+        row_count INTEGER NOT NULL,
+        stored_row_count INTEGER NOT NULL,
+        truncated INTEGER NOT NULL DEFAULT 0,
+        content_hash TEXT NOT NULL,
+        key_strategy TEXT NOT NULL,
+        key_columns TEXT NOT NULL,
+        columns TEXT NOT NULL,
+        rows TEXT,
+        payload_bytes INTEGER NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_runs_conn_fp_at
+        ON runs (connection_id, fingerprint, captured_at DESC);
+    `)
+  }
+
+  private vacuum(): void {
+    this.db.pragma('incremental_vacuum')
+  }
+
+  insertRun(payload: TimeMachineCapturePayload, fingerprint: string): TimeMachineRunMeta {
+    const id = randomUUID()
+    const rowsJson = JSON.stringify(payload.rows)
+    const payloadBytes = Buffer.byteLength(rowsJson)
+    const contentHash = createHash('sha256').update(rowsJson).digest('hex')
+    const overCap = payloadBytes > this.maxPayloadBytes
+
+    const insertInTransaction = this.db.transaction((): boolean => {
+      this.db
+        .prepare(
+          `INSERT INTO runs (
+            id, connection_id, fingerprint, sql, captured_at, duration_ms,
+            row_count, stored_row_count, truncated, content_hash, key_strategy,
+            key_columns, columns, rows, payload_bytes
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        )
+        .run(
+          id,
+          payload.connectionId,
+          fingerprint,
+          payload.sql,
+          payload.capturedAt,
+          payload.durationMs,
+          payload.rowCount,
+          overCap ? 0 : payload.rows.length,
+          payload.truncated ? 1 : 0,
+          contentHash,
+          payload.keyStrategy,
+          JSON.stringify(payload.keyColumns),
+          JSON.stringify(payload.columns),
+          overCap ? null : rowsJson,
+          // Metadata-only runs store nothing — counting their would-be size
+          // against the global budget would evict real snapshots for phantom
+          // bytes and inflate the Settings usage figure.
+          overCap ? 0 : payloadBytes
+        )
+
+      // The just-inserted run is exempt from its own cap pass; otherwise a
+      // backwards clock step (its captured_at older than the kept timeline)
+      // would delete it and the post-transaction meta read would explode.
+      const perQueryEvicted = this.db
+        .prepare(
+          `DELETE FROM runs
+           WHERE connection_id = ? AND fingerprint = ? AND id != ?
+             AND id NOT IN (
+               SELECT id FROM runs
+               WHERE connection_id = ? AND fingerprint = ? AND id != ?
+               ORDER BY captured_at DESC, rowid DESC
+               LIMIT ?
+             )`
+        )
+        .run(
+          payload.connectionId,
+          fingerprint,
+          id,
+          payload.connectionId,
+          fingerprint,
+          id,
+          this.maxRunsPerQuery - 1
+        ).changes
+
+      let budgetEvicted = 0
+      let totalBytes = (
+        this.db.prepare('SELECT COALESCE(SUM(payload_bytes), 0) AS total FROM runs').get() as {
+          total: number
+        }
+      ).total
+
+      if (totalBytes > this.globalBudgetBytes) {
+        // Oldest-first eviction, never touching the run just inserted — if it
+        // alone exceeds the budget it was already stored metadata-only or is
+        // the sole survivor.
+        const candidates = this.db
+          .prepare(
+            'SELECT id, payload_bytes FROM runs WHERE id != ? ORDER BY captured_at ASC, rowid ASC'
+          )
+          .all(id) as { id: string; payload_bytes: number }[]
+        const deleteRun = this.db.prepare('DELETE FROM runs WHERE id = ?')
+        for (const candidate of candidates) {
+          if (totalBytes <= this.globalBudgetBytes) break
+          deleteRun.run(candidate.id)
+          totalBytes -= candidate.payload_bytes
+          budgetEvicted++
+        }
+      }
+
+      return perQueryEvicted > 0 || budgetEvicted > 0
+    })
+
+    const evicted = insertInTransaction()
+    if (evicted) this.vacuum()
+
+    const row = this.db
+      .prepare(`SELECT ${META_COLUMNS} FROM runs WHERE id = ?`)
+      .get(id) as RunMetaRow
+    return rowToRunMeta(row)
+  }
+
+  listRuns(connectionId: string, fingerprint: string): TimeMachineRunMeta[] {
+    const rows = this.db
+      .prepare(
+        `SELECT ${META_COLUMNS} FROM runs
+         WHERE connection_id = ? AND fingerprint = ?
+         ORDER BY captured_at DESC, rowid DESC`
+      )
+      .all(connectionId, fingerprint) as RunMetaRow[]
+    return rows.map(rowToRunMeta)
+  }
+
+  getSnapshot(id: string): TimeMachineSnapshot {
+    const row = this.db
+      .prepare(
+        `SELECT id, connection_id, fingerprint, sql, captured_at, duration_ms,
+           row_count, stored_row_count, truncated, content_hash, key_strategy,
+           key_columns, payload_bytes, columns, rows, (rows IS NOT NULL) AS has_rows
+         FROM runs WHERE id = ?`
+      )
+      .get(id) as SnapshotRow | undefined
+
+    if (!row) throw new Error(`Snapshot not found: ${id}`)
+    if (row.rows === null) throw new Error('Snapshot payload was not stored (over size cap)')
+
+    return {
+      ...rowToRunMeta(row),
+      columns: JSON.parse(row.columns) as { name: string; dataType: string }[],
+      rows: JSON.parse(row.rows) as unknown[][]
+    }
+  }
+
+  deleteRun(id: string): void {
+    this.db.prepare('DELETE FROM runs WHERE id = ?').run(id)
+    this.vacuum()
+  }
+
+  clearQuery(connectionId: string, fingerprint: string): void {
+    this.db
+      .prepare('DELETE FROM runs WHERE connection_id = ? AND fingerprint = ?')
+      .run(connectionId, fingerprint)
+    this.vacuum()
+  }
+
+  clearAll(connectionId?: string): void {
+    if (connectionId) {
+      this.db.prepare('DELETE FROM runs WHERE connection_id = ?').run(connectionId)
+    } else {
+      this.db.prepare('DELETE FROM runs').run()
+    }
+    this.vacuum()
+  }
+
+  stats(): TimeMachineStats {
+    const row = this.db
+      .prepare(
+        `SELECT
+           (SELECT COUNT(*) FROM runs) AS run_count,
+           (SELECT COUNT(*) FROM (SELECT DISTINCT connection_id, fingerprint FROM runs))
+             AS query_count,
+           (SELECT COALESCE(SUM(payload_bytes), 0) FROM runs) AS total_bytes,
+           (SELECT MIN(captured_at) FROM runs) AS oldest_captured_at`
+      )
+      .get() as {
+      run_count: number
+      query_count: number
+      total_bytes: number
+      oldest_captured_at: number | null
+    }
+
+    return {
+      runCount: row.run_count,
+      queryCount: row.query_count,
+      totalBytes: row.total_bytes,
+      oldestCapturedAt: row.oldest_captured_at
+    }
+  }
+
+  close(): void {
+    // Truncate the WAL so deleted snapshot content doesn't linger in the
+    // sidecar file after quit.
+    try {
+      this.db.pragma('wal_checkpoint(TRUNCATE)')
+    } catch {
+      // Checkpoint is best-effort; close regardless.
+    }
+    this.db.close()
+  }
+}

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -71,7 +71,12 @@ import type {
   SkipStepResponse,
   ContinueStepResponse,
   RetryStepResponse,
-  StopStepResponse
+  StopStepResponse,
+  TimeMachineCapturePayload,
+  TimeMachineRunMeta,
+  TimeMachineSnapshot,
+  TimeMachineListResult,
+  TimeMachineStats
 } from '@shared/index'
 
 // AI Types
@@ -294,6 +299,7 @@ interface DataPeekApi {
     onFormatSql: (callback: () => void) => () => void
     onClearResults: (callback: () => void) => () => void
     onToggleWatch: (callback: () => void) => () => void
+    onToggleTimeMachine: (callback: () => void) => () => void
     onToggleSidebar: (callback: () => void) => () => void
     onOpenSettings: (callback: () => void) => () => void
     onSaveChanges: (callback: () => void) => () => void
@@ -503,6 +509,15 @@ interface DataPeekApi {
     updateCell: (cellId: string, updates: UpdateCellInput) => Promise<IpcResponse<NotebookCell>>
     deleteCell: (cellId: string) => Promise<IpcResponse<void>>
     reorderCells: (notebookId: string, cellIds: string[]) => Promise<IpcResponse<void>>
+  }
+  timeMachine: {
+    capture: (payload: TimeMachineCapturePayload) => Promise<IpcResponse<TimeMachineRunMeta>>
+    listRuns: (connectionId: string, sql: string) => Promise<IpcResponse<TimeMachineListResult>>
+    getSnapshot: (id: string) => Promise<IpcResponse<TimeMachineSnapshot>>
+    deleteRun: (id: string) => Promise<IpcResponse<void>>
+    clearQuery: (connectionId: string, sql: string) => Promise<IpcResponse<void>>
+    clearAll: (connectionId?: string) => Promise<IpcResponse<void>>
+    stats: () => Promise<IpcResponse<TimeMachineStats>>
   }
   step: {
     start: (

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -80,7 +80,12 @@ import type {
   SkipStepResponse,
   ContinueStepResponse,
   RetryStepResponse,
-  StopStepResponse
+  StopStepResponse,
+  TimeMachineCapturePayload,
+  TimeMachineRunMeta,
+  TimeMachineSnapshot,
+  TimeMachineListResult,
+  TimeMachineStats
 } from '@shared/index'
 
 // Re-export AI types for renderer consumers
@@ -264,6 +269,11 @@ const api = {
       ipcRenderer.on('menu:toggle-watch', handler)
       return () => ipcRenderer.removeListener('menu:toggle-watch', handler)
     },
+    onToggleTimeMachine: (callback: () => void): (() => void) => {
+      const handler = (): void => callback()
+      ipcRenderer.on('menu:toggle-time-machine', handler)
+      return () => ipcRenderer.removeListener('menu:toggle-time-machine', handler)
+    },
     onToggleSidebar: (callback: () => void): (() => void) => {
       const handler = (): void => callback()
       ipcRenderer.on('menu:toggle-sidebar', handler)
@@ -362,6 +372,22 @@ const api = {
       ipcRenderer.invoke('notebooks:delete-cell', cellId),
     reorderCells: (notebookId: string, cellIds: string[]): Promise<IpcResponse<void>> =>
       ipcRenderer.invoke('notebooks:reorder-cells', { notebookId, cellIds })
+  },
+  // Time Machine result snapshots
+  timeMachine: {
+    capture: (payload: TimeMachineCapturePayload): Promise<IpcResponse<TimeMachineRunMeta>> =>
+      ipcRenderer.invoke('time-machine:capture', payload),
+    listRuns: (connectionId: string, sql: string): Promise<IpcResponse<TimeMachineListResult>> =>
+      ipcRenderer.invoke('time-machine:list-runs', { connectionId, sql }),
+    getSnapshot: (id: string): Promise<IpcResponse<TimeMachineSnapshot>> =>
+      ipcRenderer.invoke('time-machine:get-snapshot', id),
+    deleteRun: (id: string): Promise<IpcResponse<void>> =>
+      ipcRenderer.invoke('time-machine:delete-run', id),
+    clearQuery: (connectionId: string, sql: string): Promise<IpcResponse<void>> =>
+      ipcRenderer.invoke('time-machine:clear-query', { connectionId, sql }),
+    clearAll: (connectionId?: string): Promise<IpcResponse<void>> =>
+      ipcRenderer.invoke('time-machine:clear-all', connectionId),
+    stats: (): Promise<IpcResponse<TimeMachineStats>> => ipcRenderer.invoke('time-machine:stats')
   },
   step: {
     start: (

--- a/apps/desktop/src/renderer/src/components/command-palette.tsx
+++ b/apps/desktop/src/renderer/src/components/command-palette.tsx
@@ -17,12 +17,14 @@ import {
   ChevronLeft,
   Pin,
   PinOff,
-  Pencil
+  Pencil,
+  History
 } from 'lucide-react'
 
 import { useTheme } from '@/components/theme-provider'
 import { DatabaseIcon } from '@/components/database-icons'
-import { useConnectionStore, useTabStore } from '@/stores'
+import { useConnectionStore, useTabStore, useSettingsStore } from '@/stores'
+import { useTimeMachineStore } from '@/stores/time-machine-store'
 import { useSavedQueryStore } from '@/stores/saved-queries-store'
 import { useAIStore } from '@/stores/ai-store'
 import {
@@ -365,6 +367,30 @@ export function CommandPalette({
                   <Bookmark className="text-amber-400" />
                   <span>Saved Queries</span>
                   <ChevronRight className="ml-auto size-4 text-muted-foreground" />
+                </CommandItem>
+                <CommandItem
+                  value="query-time-machine"
+                  keywords={['history', 'snapshot', 'timeline', 'diff', 'runs', 'past']}
+                  onSelect={() => {
+                    const { activeTabId, getTab } = useTabStore.getState()
+                    const activeTab = activeTabId ? getTab(activeTabId) : null
+                    if (
+                      activeTab?.type === 'query' &&
+                      useSettingsStore.getState().timeMachineEnabled
+                    ) {
+                      const tm = useTimeMachineStore.getState()
+                      if (tm.getState(activeTab.id)?.open) tm.closeStrip(activeTab.id)
+                      else tm.openStrip(activeTab.id)
+                    }
+                    onClose()
+                  }}
+                >
+                  <History className="text-amber-400" />
+                  <span>Toggle Time Machine</span>
+                  <CommandShortcut>
+                    {keys.mod}
+                    {keys.shift}H
+                  </CommandShortcut>
                 </CommandItem>
               </CommandGroup>
 

--- a/apps/desktop/src/renderer/src/components/data-table.tsx
+++ b/apps/desktop/src/renderer/src/components/data-table.tsx
@@ -48,6 +48,8 @@ import { useMaskingStore } from '@/stores/masking-store'
 import { CellGridInspector, CellGridOverlays, useCellGrid } from '@/components/cell-grid'
 import { WatchDecorationOverlay } from '@/components/cell-grid/watch-decoration-overlay'
 import { useWatchStore } from '@/stores/watch-store'
+import type { WatchDiff } from '@/lib/watch-types'
+import { cellKey, deriveRowKey, type KeyingPlan } from '@/lib/watch-row-keying'
 
 const VIRTUALIZATION_THRESHOLD = 50
 const ROW_HEIGHT = 37
@@ -84,6 +86,12 @@ interface DataTableProps<TData> {
   onForeignKeyOpenTab?: (foreignKey: ForeignKeyInfo, value: unknown) => void
   /** Called when user requests column statistics for a column */
   onColumnStatsClick?: (column: DataTableColumn) => void
+  /**
+   * Pinned cell-diff decorations (Time Machine compare view). Unlike the watch
+   * overlay these never fade, and small (non-virtualized) results get inline
+   * cell tints since the geometry overlay only exists above the threshold.
+   */
+  diffOverlay?: WatchDiff | null
 }
 
 const CellValue = React.memo(function CellValue({
@@ -229,7 +237,8 @@ export function DataTable<TData extends Record<string, unknown>>({
   onApplyToQuery,
   onForeignKeyClick,
   onForeignKeyOpenTab,
-  onColumnStatsClick
+  onColumnStatsClick,
+  diffOverlay
 }: DataTableProps<TData>) {
   const { defaultPageSize } = useSettingsStore()
   const toggleColumnMask = useMaskingStore((s) => s.toggleColumnMask)
@@ -567,6 +576,10 @@ export function DataTable<TData extends Record<string, unknown>>({
     enabled: shouldVirtualize
   })
 
+  const diffPlan: KeyingPlan | null = diffOverlay
+    ? { strategy: diffOverlay.keyingStrategy, keyColumns: diffOverlay.keyColumns }
+    : null
+
   return (
     <div className="flex flex-col h-full min-h-0">
       <SmartFilterBar
@@ -670,21 +683,48 @@ export function DataTable<TData extends Record<string, unknown>>({
                     </td>
                   </tr>
                 ) : (
-                  rows.map((row) => (
-                    <RowContextMenu
-                      key={row.id}
-                      row={row.original as Record<string, unknown>}
-                      columns={columnDefs.map((c) => ({ name: c.name, dataType: c.dataType }))}
-                    >
-                      <TableRow className="hover:bg-accent/30 border-border/30 transition-colors">
-                        {row.getVisibleCells().map((cell) => (
-                          <TableCell key={cell.id} className="py-2 text-sm whitespace-nowrap">
-                            {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                          </TableCell>
-                        ))}
-                      </TableRow>
-                    </RowContextMenu>
-                  ))
+                  rows.map((row) => {
+                    const rowKey = diffPlan
+                      ? deriveRowKey(row.original as Record<string, unknown>, diffPlan, row.index)
+                      : null
+                    const isAddedRow = !!(rowKey && diffOverlay?.addedRowKeys.has(rowKey))
+                    return (
+                      <RowContextMenu
+                        key={row.id}
+                        row={row.original as Record<string, unknown>}
+                        columns={columnDefs.map((c) => ({ name: c.name, dataType: c.dataType }))}
+                      >
+                        <TableRow
+                          className="hover:bg-accent/30 border-border/30 transition-colors"
+                          style={
+                            isAddedRow ? { backgroundColor: 'var(--cell-diff-added)' } : undefined
+                          }
+                        >
+                          {row.getVisibleCells().map((cell, cellIndex) => {
+                            const isChangedCell =
+                              !isAddedRow &&
+                              rowKey !== null &&
+                              diffOverlay?.cells.get(
+                                cellKey(rowKey, columnDefs[cellIndex]?.name ?? '')
+                              )?.kind === 'changed'
+                            return (
+                              <TableCell
+                                key={cell.id}
+                                className="py-2 text-sm whitespace-nowrap"
+                                style={
+                                  isChangedCell
+                                    ? { backgroundColor: 'var(--cell-diff-fill)' }
+                                    : undefined
+                                }
+                              >
+                                {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                              </TableCell>
+                            )
+                          })}
+                        </TableRow>
+                      </RowContextMenu>
+                    )
+                  })
                 )
               ) : (
                 <TableRow>
@@ -704,6 +744,16 @@ export function DataTable<TData extends Record<string, unknown>>({
             virtualizer={virtualizer}
             enabled={shouldVirtualize && columnWidths.length > 0}
           />
+          {diffOverlay && shouldVirtualize && columnWidths.length > 0 && (
+            <WatchDecorationOverlay
+              diff={diffOverlay}
+              rows={rows}
+              columnNames={columnDefs.map((c) => c.name)}
+              geometry={cellGrid.geometry}
+              virtualizer={virtualizer}
+              fadeMs={Number.MAX_SAFE_INTEGER}
+            />
+          )}
         </div>
       </div>
 

--- a/apps/desktop/src/renderer/src/components/query-editor/editor-toolbar.tsx
+++ b/apps/desktop/src/renderer/src/components/query-editor/editor-toolbar.tsx
@@ -47,6 +47,8 @@ interface EditorToolbarProps {
   setShareDialogOpen: (v: boolean) => void
   /** Slot for the Watch button — rendered between Benchmark and Format. */
   watchSlot?: ReactNode
+  /** Slot for the Time Machine button — rendered next to the Watch button. */
+  timeMachineSlot?: ReactNode
   /** Slot for the cross-tab inlined-refs pill — rendered next to the Watch button. */
   refsSlot?: ReactNode
 }
@@ -72,6 +74,7 @@ export function EditorToolbar({
   setSaveDialogOpen,
   setShareDialogOpen,
   watchSlot,
+  timeMachineSlot,
   refsSlot
 }: EditorToolbarProps) {
   const executable = isExecutableTab(tab) ? tab : null
@@ -174,6 +177,7 @@ export function EditorToolbar({
           disabled={isExecuting || !hasQuery}
         />
         {watchSlot}
+        {timeMachineSlot}
         {refsSlot}
         {!isEditorCollapsed && (
           <>

--- a/apps/desktop/src/renderer/src/components/query-editor/query-results.tsx
+++ b/apps/desktop/src/renderer/src/components/query-editor/query-results.tsx
@@ -28,8 +28,12 @@ import { TelemetryPanel } from '@/components/telemetry-panel'
 import { PerfIndicatorPanel } from '@/components/perf-indicator-panel'
 import { MaskingToolbar } from '@/components/masking-toolbar'
 import { ExportMenuItems } from '@/components/export-menu-items'
+import { TimeMachineStrip } from '@/components/time-machine/time-machine-strip'
+import { TimeMachineView } from '@/components/time-machine/time-machine-view'
+import { useTimeMachineStore } from '@/stores/time-machine-store'
 
 import { isExecutableTab, type Tab } from '@/stores/tab-store'
+import { useSettingsStore } from '@/stores/settings-store'
 import type { TelemetryViewMode } from '@/stores/telemetry-store'
 import type { ConnectionWithStatus } from '@/stores/connection-store'
 import type { DataTableColumn as EditableColumn } from '@/components/editable-data-table'
@@ -160,6 +164,13 @@ export function QueryResults({
   const pageSize = executable?.pageSize ?? 50
   const tableName = tab.type === 'table-preview' ? tab.tableName : undefined
   const hasResults = !!tabResult || !!tabMultiResult
+  const timeMachineEnabled = useSettingsStore((s) => s.timeMachineEnabled)
+  // Boolean selector so the whole results pane doesn't re-render on every
+  // Time Machine loading flip — only the view transition matters here.
+  const timeMachineViewing = useTimeMachineStore((s) => {
+    const st = s.states[tabId]
+    return !!st?.snapshot && st.selectedRunId !== null
+  })
 
   const runExport = (format: ExportFormat, destination: ExportDestination) => {
     const data = getCurrentExportData()
@@ -218,311 +229,326 @@ export function QueryResults({
           </div>
           <span className="text-[10px] text-muted-foreground/50">Results collapsed</span>
         </div>
-      ) : tabError ? (
-        <div className="flex-1 flex items-center justify-center p-4">
-          <div className="max-w-md text-center space-y-2">
-            <AlertCircle className="size-8 text-red-400 mx-auto" />
-            <h3 className="font-medium text-red-400">Query Error</h3>
-            <p className="text-sm text-muted-foreground">{tabError}</p>
-          </div>
-        </div>
-      ) : hasResults ? (
+      ) : (
         <>
-          {hasMultipleResults && (
-            <div className="flex items-center gap-1 border-b border-border/40 bg-muted/10 px-3 py-1.5 shrink-0 overflow-x-auto">
-              {statementResults.map((stmt, idx) => {
-                const isActive = idx === activeResultIndex
-                const label = stmt.isDataReturning
-                  ? `Result ${idx + 1} (${stmt.rowCount} rows)`
-                  : `Statement ${idx + 1} (${stmt.rowCount} affected)`
-
-                return (
-                  <button
-                    key={stmt.statementIndex}
-                    onClick={() => setActiveResultIndex(tabId, idx)}
-                    className={`flex items-center gap-1.5 px-2.5 py-1 text-xs rounded-md transition-colors whitespace-nowrap ${
-                      isActive
-                        ? 'bg-primary text-primary-foreground'
-                        : 'hover:bg-muted text-muted-foreground hover:text-foreground'
-                    }`}
-                    title={stmt.statement.slice(0, 100)}
-                  >
-                    <span
-                      className={`size-1.5 rounded-full ${
-                        stmt.isDataReturning ? 'bg-green-500' : 'bg-blue-500'
-                      } ${isActive ? 'opacity-80' : ''}`}
-                    />
-                    {label}
-                    <span className={`text-[10px] ${isActive ? 'opacity-70' : 'opacity-50'}`}>
-                      {stmt.durationMs}ms
-                    </span>
-                  </button>
-                )
-              })}
-            </div>
+          {timeMachineEnabled && tab.type === 'query' && (
+            <TimeMachineStrip tabId={tabId} connectionId={tabConnection?.id} sql={tabQuery} />
           )}
+          {timeMachineEnabled && timeMachineViewing ? (
+            <div className="flex-1 overflow-hidden p-3">
+              <TimeMachineView tabId={tabId} pageSize={pageSize} />
+            </div>
+          ) : tabError ? (
+            <div className="flex-1 flex items-center justify-center p-4">
+              <div className="max-w-md text-center space-y-2">
+                <AlertCircle className="size-8 text-red-400 mx-auto" />
+                <h3 className="font-medium text-red-400">Query Error</h3>
+                <p className="text-sm text-muted-foreground">{tabError}</p>
+              </div>
+            </div>
+          ) : hasResults ? (
+            <>
+              {hasMultipleResults && (
+                <div className="flex items-center gap-1 border-b border-border/40 bg-muted/10 px-3 py-1.5 shrink-0 overflow-x-auto">
+                  {statementResults.map((stmt, idx) => {
+                    const isActive = idx === activeResultIndex
+                    const label = stmt.isDataReturning
+                      ? `Result ${idx + 1} (${stmt.rowCount} rows)`
+                      : `Statement ${idx + 1} (${stmt.rowCount} affected)`
 
-          <div className="flex-1 overflow-hidden p-3">
-            {(() => {
-              const editContext = getEditContext()
-              const isTablePreview = tab.type === 'table-preview'
-              if (editContext && (isTablePreview ? !hasMultipleResults : true)) {
-                return (
-                  <EditableDataTable
+                    return (
+                      <button
+                        key={stmt.statementIndex}
+                        onClick={() => setActiveResultIndex(tabId, idx)}
+                        className={`flex items-center gap-1.5 px-2.5 py-1 text-xs rounded-md transition-colors whitespace-nowrap ${
+                          isActive
+                            ? 'bg-primary text-primary-foreground'
+                            : 'hover:bg-muted text-muted-foreground hover:text-foreground'
+                        }`}
+                        title={stmt.statement.slice(0, 100)}
+                      >
+                        <span
+                          className={`size-1.5 rounded-full ${
+                            stmt.isDataReturning ? 'bg-green-500' : 'bg-blue-500'
+                          } ${isActive ? 'opacity-80' : ''}`}
+                        />
+                        {label}
+                        <span className={`text-[10px] ${isActive ? 'opacity-70' : 'opacity-50'}`}>
+                          {stmt.durationMs}ms
+                        </span>
+                      </button>
+                    )
+                  })}
+                </div>
+              )}
+
+              <div className="flex-1 overflow-hidden p-3">
+                {(() => {
+                  const editContext = getEditContext()
+                  const isTablePreview = tab.type === 'table-preview'
+                  if (editContext && (isTablePreview ? !hasMultipleResults : true)) {
+                    return (
+                      <EditableDataTable
+                        key={`result-${activeResultIndex}`}
+                        tabId={tabId}
+                        columns={getColumnsForEditing()}
+                        data={
+                          isTablePreview && tab.totalRowCount != null
+                            ? ((tabResult?.rows ?? []) as Record<string, unknown>[])
+                            : (paginatedRows as Record<string, unknown>[])
+                        }
+                        pageSize={pageSize}
+                        canEdit={true}
+                        editContext={editContext}
+                        connection={tabConnection}
+                        onFiltersChange={setTableFilters}
+                        onSortingChange={setTableSorting}
+                        onApplyToQuery={hasActiveFiltersOrSorting ? handleApplyToQuery : undefined}
+                        onForeignKeyClick={handleFKClick}
+                        onForeignKeyOpenTab={handleFKOpenTab}
+                        onColumnStatsClick={tabConnection ? handleColumnStatsClick : undefined}
+                        onChangesCommitted={handleRunQuery}
+                        serverCurrentPage={isTablePreview ? tab.currentPage : undefined}
+                        serverTotalRowCount={isTablePreview ? tab.totalRowCount : undefined}
+                        onServerPaginationChange={
+                          isTablePreview ? handleTablePreviewPaginationChange : undefined
+                        }
+                      />
+                    )
+                  }
+                  return null
+                })() || (
+                  <DataTable
                     key={`result-${activeResultIndex}`}
                     tabId={tabId}
-                    columns={getColumnsForEditing()}
-                    data={
-                      isTablePreview && tab.totalRowCount != null
-                        ? ((tabResult?.rows ?? []) as Record<string, unknown>[])
-                        : (paginatedRows as Record<string, unknown>[])
+                    columns={
+                      hasMultipleResults
+                        ? getActiveResultColumns().map((col) => ({
+                            name: col.name,
+                            dataType: col.dataType
+                          }))
+                        : getColumnsWithFKInfo()
                     }
+                    data={getAllRows()}
                     pageSize={pageSize}
-                    canEdit={true}
-                    editContext={editContext}
-                    connection={tabConnection}
                     onFiltersChange={setTableFilters}
                     onSortingChange={setTableSorting}
                     onApplyToQuery={hasActiveFiltersOrSorting ? handleApplyToQuery : undefined}
                     onForeignKeyClick={handleFKClick}
                     onForeignKeyOpenTab={handleFKOpenTab}
                     onColumnStatsClick={tabConnection ? handleColumnStatsClick : undefined}
-                    onChangesCommitted={handleRunQuery}
-                    serverCurrentPage={isTablePreview ? tab.currentPage : undefined}
-                    serverTotalRowCount={isTablePreview ? tab.totalRowCount : undefined}
-                    onServerPaginationChange={
-                      isTablePreview ? handleTablePreviewPaginationChange : undefined
-                    }
                   />
-                )
-              }
-              return null
-            })() || (
-              <DataTable
-                key={`result-${activeResultIndex}`}
-                tabId={tabId}
-                columns={
-                  hasMultipleResults
-                    ? getActiveResultColumns().map((col) => ({
-                        name: col.name,
-                        dataType: col.dataType
-                      }))
-                    : getColumnsWithFKInfo()
-                }
-                data={getAllRows()}
-                pageSize={pageSize}
-                onFiltersChange={setTableFilters}
-                onSortingChange={setTableSorting}
-                onApplyToQuery={hasActiveFiltersOrSorting ? handleApplyToQuery : undefined}
-                onForeignKeyClick={handleFKClick}
-                onForeignKeyOpenTab={handleFKOpenTab}
-                onColumnStatsClick={tabConnection ? handleColumnStatsClick : undefined}
-              />
-            )}
-          </div>
-
-          <div className="flex items-center justify-between border-t border-border/40 bg-muted/20 px-3 py-1.5 shrink-0">
-            <div className="flex items-center gap-2">
-              <Button
-                variant="ghost"
-                size="sm"
-                className="h-7 w-7 p-0"
-                onClick={() => setIsResultsCollapsed(true)}
-                title="Collapse results panel"
-              >
-                <PanelBottomClose className="size-3.5" />
-              </Button>
-              <div className="flex items-center gap-4 text-xs text-muted-foreground">
-                {hasMultipleResults ? (
-                  <>
-                    <span className="flex items-center gap-1.5">
-                      <span className="size-1.5 rounded-full bg-green-500" />
-                      {activeStatementResult?.rowCount ?? 0}{' '}
-                      {activeStatementResult?.isDataReturning ? 'rows' : 'affected'}
-                    </span>
-                    <span className="text-muted-foreground/60">
-                      {statementResults.length} statements
-                    </span>
-                    <span>{tabMultiResult?.totalDurationMs}ms total</span>
-                  </>
-                ) : (
-                  <>
-                    <span className="flex items-center gap-1.5">
-                      <span className="size-1.5 rounded-full bg-green-500" />
-                      {tabResult?.rowCount ?? 0} rows returned
-                    </span>
-                    <span>{tabResult?.durationMs}ms</span>
-                  </>
                 )}
               </div>
-            </div>
-            <div className="flex items-center gap-2">
-              {(telemetry || benchmark) && (
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        variant={showTelemetryPanel ? 'secondary' : 'ghost'}
-                        size="sm"
-                        className="gap-1.5 h-7"
-                        onClick={() => setShowTelemetryPanel(!showTelemetryPanel)}
-                      >
-                        <Timer className="size-3.5" />
-                        Telemetry
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent side="top">
-                      <p className="text-xs">
-                        {showTelemetryPanel ? 'Hide' : 'Show'} query performance breakdown
-                      </p>
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
-              )}
-              {tabResult && (!tabConnection?.dbType || tabConnection.dbType === 'postgresql') && (
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        variant={showPerfPanel ? 'secondary' : 'ghost'}
-                        size="sm"
-                        className="gap-1.5 h-7"
-                        onClick={
-                          perfAnalysis
-                            ? () => setShowPerfPanel(!showPerfPanel)
-                            : handleAnalyzePerformance
-                        }
-                        disabled={isPerfAnalyzing}
-                      >
-                        {isPerfAnalyzing ? (
-                          <Loader2 className="size-3.5 animate-spin" />
-                        ) : (
-                          <ActivitySquare className="size-3.5" />
-                        )}
-                        {perfAnalysis &&
-                          perfAnalysis.issueCount.critical + perfAnalysis.issueCount.warning >
-                            0 && (
-                            <Badge
-                              variant="secondary"
-                              className={`h-4 px-1.5 text-[10px] ${
-                                perfAnalysis.issueCount.critical > 0
-                                  ? 'bg-red-500/20 text-red-500'
-                                  : 'bg-yellow-500/20 text-yellow-500'
-                              }`}
-                            >
-                              {perfAnalysis.issueCount.critical + perfAnalysis.issueCount.warning}
-                            </Badge>
-                          )}
-                        Analyze
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent side="top">
-                      <p className="text-xs">
-                        {perfAnalysis
-                          ? showPerfPanel
-                            ? 'Hide performance analysis'
-                            : 'Show performance analysis'
-                          : 'Analyze query for performance issues'}
-                      </p>
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
-              )}
-              <MaskingToolbar tabId={tabId} />
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="gap-1.5 h-7"
-                      onClick={() => setShareResultsOpen(true)}
-                    >
-                      <Share2 className="size-3.5" />
-                      Share
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent side="top">
-                    <p className="text-xs">Share results as an image</p>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button variant="outline" size="sm" className="gap-1.5 h-7">
-                    <Download className="size-3.5" />
-                    Export
+
+              <div className="flex items-center justify-between border-t border-border/40 bg-muted/20 px-3 py-1.5 shrink-0">
+                <div className="flex items-center gap-2">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 w-7 p-0"
+                    onClick={() => setIsResultsCollapsed(true)}
+                    title="Collapse results panel"
+                  >
+                    <PanelBottomClose className="size-3.5" />
                   </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" className="w-36">
-                  <ExportMenuItems onSelect={runExport} />
-                </DropdownMenuContent>
-              </DropdownMenu>
+                  <div className="flex items-center gap-4 text-xs text-muted-foreground">
+                    {hasMultipleResults ? (
+                      <>
+                        <span className="flex items-center gap-1.5">
+                          <span className="size-1.5 rounded-full bg-green-500" />
+                          {activeStatementResult?.rowCount ?? 0}{' '}
+                          {activeStatementResult?.isDataReturning ? 'rows' : 'affected'}
+                        </span>
+                        <span className="text-muted-foreground/60">
+                          {statementResults.length} statements
+                        </span>
+                        <span>{tabMultiResult?.totalDurationMs}ms total</span>
+                      </>
+                    ) : (
+                      <>
+                        <span className="flex items-center gap-1.5">
+                          <span className="size-1.5 rounded-full bg-green-500" />
+                          {tabResult?.rowCount ?? 0} rows returned
+                        </span>
+                        <span>{tabResult?.durationMs}ms</span>
+                      </>
+                    )}
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  {(telemetry || benchmark) && (
+                    <TooltipProvider>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            variant={showTelemetryPanel ? 'secondary' : 'ghost'}
+                            size="sm"
+                            className="gap-1.5 h-7"
+                            onClick={() => setShowTelemetryPanel(!showTelemetryPanel)}
+                          >
+                            <Timer className="size-3.5" />
+                            Telemetry
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent side="top">
+                          <p className="text-xs">
+                            {showTelemetryPanel ? 'Hide' : 'Show'} query performance breakdown
+                          </p>
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                  )}
+                  {tabResult &&
+                    (!tabConnection?.dbType || tabConnection.dbType === 'postgresql') && (
+                      <TooltipProvider>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              variant={showPerfPanel ? 'secondary' : 'ghost'}
+                              size="sm"
+                              className="gap-1.5 h-7"
+                              onClick={
+                                perfAnalysis
+                                  ? () => setShowPerfPanel(!showPerfPanel)
+                                  : handleAnalyzePerformance
+                              }
+                              disabled={isPerfAnalyzing}
+                            >
+                              {isPerfAnalyzing ? (
+                                <Loader2 className="size-3.5 animate-spin" />
+                              ) : (
+                                <ActivitySquare className="size-3.5" />
+                              )}
+                              {perfAnalysis &&
+                                perfAnalysis.issueCount.critical + perfAnalysis.issueCount.warning >
+                                  0 && (
+                                  <Badge
+                                    variant="secondary"
+                                    className={`h-4 px-1.5 text-[10px] ${
+                                      perfAnalysis.issueCount.critical > 0
+                                        ? 'bg-red-500/20 text-red-500'
+                                        : 'bg-yellow-500/20 text-yellow-500'
+                                    }`}
+                                  >
+                                    {perfAnalysis.issueCount.critical +
+                                      perfAnalysis.issueCount.warning}
+                                  </Badge>
+                                )}
+                              Analyze
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent side="top">
+                            <p className="text-xs">
+                              {perfAnalysis
+                                ? showPerfPanel
+                                  ? 'Hide performance analysis'
+                                  : 'Show performance analysis'
+                                : 'Analyze query for performance issues'}
+                            </p>
+                          </TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                    )}
+                  <MaskingToolbar tabId={tabId} />
+                  <TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="gap-1.5 h-7"
+                          onClick={() => setShareResultsOpen(true)}
+                        >
+                          <Share2 className="size-3.5" />
+                          Share
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent side="top">
+                        <p className="text-xs">Share results as an image</p>
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button variant="outline" size="sm" className="gap-1.5 h-7">
+                        <Download className="size-3.5" />
+                        Export
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end" className="w-36">
+                      <ExportMenuItems onSelect={runExport} />
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
+              </div>
+
+              {showTelemetryPanel && (telemetry || benchmark) && (
+                <TelemetryPanel
+                  telemetry={telemetry}
+                  benchmark={benchmark}
+                  showConnectionOverhead={showConnectionOverhead}
+                  onToggleConnectionOverhead={setShowConnectionOverhead}
+                  selectedPercentile={selectedPercentile}
+                  onSelectPercentile={setSelectedPercentile}
+                  viewMode={viewMode}
+                  onViewModeChange={setViewMode}
+                  onClose={() => setShowTelemetryPanel(false)}
+                />
+              )}
+
+              {showPerfPanel && perfAnalysis && (
+                <PerfIndicatorPanel
+                  analysis={perfAnalysis}
+                  onClose={() => setShowPerfPanel(false)}
+                  onReanalyze={handleAnalyzePerformance}
+                  isAnalyzing={isPerfAnalyzing}
+                  showCritical={showCritical}
+                  showWarning={showWarning}
+                  showInfo={showInfo}
+                  onToggleSeverity={toggleSeverityFilter}
+                />
+              )}
+            </>
+          ) : (
+            <div className="flex-1 flex items-center justify-center">
+              <div className="text-center space-y-3 max-w-sm">
+                <div className="size-10 rounded-full bg-muted/50 flex items-center justify-center mx-auto">
+                  <Play className="size-5 text-muted-foreground" />
+                </div>
+                <div className="space-y-1">
+                  <p className="text-sm text-muted-foreground">
+                    {tabQuery.trim() ? 'Ready to execute' : 'Write a query to get started'}
+                  </p>
+                  <p className="text-xs text-muted-foreground/60">
+                    {tabQuery.trim()
+                      ? `Press ${keys.mod}+Enter to run your query`
+                      : 'Browse the schema explorer to view tables, or type a SQL query above'}
+                  </p>
+                </div>
+                <div className="flex items-center justify-center gap-4 pt-1">
+                  <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground/50">
+                    <kbd className="rounded bg-muted/80 px-1.5 py-0.5 font-mono">
+                      {keys.mod}Enter
+                    </kbd>
+                    <span>Run</span>
+                  </div>
+                  <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground/50">
+                    <kbd className="rounded bg-muted/80 px-1.5 py-0.5 font-mono">
+                      {keys.mod}
+                      {keys.shift}F
+                    </kbd>
+                    <span>Format</span>
+                  </div>
+                  <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground/50">
+                    <kbd className="rounded bg-muted/80 px-1.5 py-0.5 font-mono">{keys.mod}K</kbd>
+                    <span>Search</span>
+                  </div>
+                </div>
+              </div>
             </div>
-          </div>
-
-          {showTelemetryPanel && (telemetry || benchmark) && (
-            <TelemetryPanel
-              telemetry={telemetry}
-              benchmark={benchmark}
-              showConnectionOverhead={showConnectionOverhead}
-              onToggleConnectionOverhead={setShowConnectionOverhead}
-              selectedPercentile={selectedPercentile}
-              onSelectPercentile={setSelectedPercentile}
-              viewMode={viewMode}
-              onViewModeChange={setViewMode}
-              onClose={() => setShowTelemetryPanel(false)}
-            />
-          )}
-
-          {showPerfPanel && perfAnalysis && (
-            <PerfIndicatorPanel
-              analysis={perfAnalysis}
-              onClose={() => setShowPerfPanel(false)}
-              onReanalyze={handleAnalyzePerformance}
-              isAnalyzing={isPerfAnalyzing}
-              showCritical={showCritical}
-              showWarning={showWarning}
-              showInfo={showInfo}
-              onToggleSeverity={toggleSeverityFilter}
-            />
           )}
         </>
-      ) : (
-        <div className="flex-1 flex items-center justify-center">
-          <div className="text-center space-y-3 max-w-sm">
-            <div className="size-10 rounded-full bg-muted/50 flex items-center justify-center mx-auto">
-              <Play className="size-5 text-muted-foreground" />
-            </div>
-            <div className="space-y-1">
-              <p className="text-sm text-muted-foreground">
-                {tabQuery.trim() ? 'Ready to execute' : 'Write a query to get started'}
-              </p>
-              <p className="text-xs text-muted-foreground/60">
-                {tabQuery.trim()
-                  ? `Press ${keys.mod}+Enter to run your query`
-                  : 'Browse the schema explorer to view tables, or type a SQL query above'}
-              </p>
-            </div>
-            <div className="flex items-center justify-center gap-4 pt-1">
-              <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground/50">
-                <kbd className="rounded bg-muted/80 px-1.5 py-0.5 font-mono">{keys.mod}Enter</kbd>
-                <span>Run</span>
-              </div>
-              <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground/50">
-                <kbd className="rounded bg-muted/80 px-1.5 py-0.5 font-mono">
-                  {keys.mod}
-                  {keys.shift}F
-                </kbd>
-                <span>Format</span>
-              </div>
-              <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground/50">
-                <kbd className="rounded bg-muted/80 px-1.5 py-0.5 font-mono">{keys.mod}K</kbd>
-                <span>Search</span>
-              </div>
-            </div>
-          </div>
-        </div>
       )}
     </div>
   )

--- a/apps/desktop/src/renderer/src/components/settings-modal.tsx
+++ b/apps/desktop/src/renderer/src/components/settings-modal.tsx
@@ -1,11 +1,30 @@
+import { useEffect, useState } from 'react'
 import { Settings } from 'lucide-react'
-import { Button, Switch, Label, Input, Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@data-peek/ui'
+import {
+  Button,
+  Switch,
+  Label,
+  Input,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle
+} from '@data-peek/ui'
+import type { TimeMachineStats } from '@data-peek/shared'
 
 import { useSettingsStore } from '@/stores/settings-store'
 
 interface SettingsModalProps {
   open: boolean
   onOpenChange: (open: boolean) => void
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`
 }
 
 export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
@@ -16,14 +35,51 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
     hideQuickQueryPanel,
     queryTimeoutMs,
     pokemonBuddyEnabled,
+    timeMachineEnabled,
     setHideQueryEditorByDefault,
     setExpandJsonByDefault,
     setJsonExpandDepth,
     setHideQuickQueryPanel,
     setQueryTimeoutMs,
     setPokemonBuddyEnabled,
+    setTimeMachineEnabled,
     resetSettings
   } = useSettingsStore()
+
+  const [tmStats, setTmStats] = useState<TimeMachineStats | null>(null)
+  const [tmWipeArmed, setTmWipeArmed] = useState(false)
+
+  useEffect(() => {
+    if (!open) {
+      setTmWipeArmed(false)
+      return
+    }
+    let cancelled = false
+    window.api.timeMachine
+      .stats()
+      .then((response) => {
+        if (!cancelled && response.success && response.data) setTmStats(response.data)
+      })
+      .catch(() => {})
+    return () => {
+      cancelled = true
+    }
+  }, [open])
+
+  const handleWipeTimeMachine = async () => {
+    if (!tmWipeArmed) {
+      setTmWipeArmed(true)
+      return
+    }
+    setTmWipeArmed(false)
+    try {
+      await window.api.timeMachine.clearAll()
+      const response = await window.api.timeMachine.stats()
+      if (response.success && response.data) setTmStats(response.data)
+    } catch {
+      // Storage unavailable — nothing to wipe.
+    }
+  }
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -164,6 +220,43 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
                   }}
                 />
               </div>
+            </div>
+          </div>
+
+          {/* Time Machine Section */}
+          <div className="space-y-4">
+            <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">
+              Time Machine
+            </h3>
+            <div className="flex items-center justify-between">
+              <div className="space-y-0.5">
+                <Label htmlFor="time-machine">Snapshot query results</Label>
+                <p className="text-xs text-muted-foreground">
+                  Keep a local history of SELECT results to scrub and diff. Masked columns are
+                  stored redacted.
+                </p>
+              </div>
+              <Switch
+                id="time-machine"
+                checked={timeMachineEnabled}
+                onCheckedChange={setTimeMachineEnabled}
+              />
+            </div>
+            <div className="flex items-center justify-between">
+              <p className="text-xs text-muted-foreground">
+                {tmStats
+                  ? `${tmStats.runCount} runs across ${tmStats.queryCount} queries · ${formatBytes(tmStats.totalBytes)} on disk`
+                  : 'No snapshot storage in use'}
+              </p>
+              <Button
+                variant={tmWipeArmed ? 'destructive' : 'outline'}
+                size="sm"
+                className="h-7 text-xs"
+                disabled={!tmStats || tmStats.runCount === 0}
+                onClick={handleWipeTimeMachine}
+              >
+                {tmWipeArmed ? 'Click again to confirm' : 'Delete all snapshots'}
+              </Button>
             </div>
           </div>
         </div>

--- a/apps/desktop/src/renderer/src/components/tab-query-editor.tsx
+++ b/apps/desktop/src/renderer/src/components/tab-query-editor.tsx
@@ -16,7 +16,7 @@ import {
 import { isExecutableTab, type Tab, type MultiQueryResult } from '@/stores/tab-store'
 import type { StatementResult } from '@data-peek/shared'
 import { type DataTableFilter, type DataTableSort } from '@/components/data-table'
-import { analyzeEditableSelect, sqlMatchesStoredTable } from '@/lib/editable-select'
+import { sqlMatchesStoredTable } from '@/lib/editable-select'
 import {
   resolveForRun,
   crossTabErrorMessage,
@@ -69,6 +69,10 @@ import type { WatchRunner } from '@/lib/watch-scheduler'
 import { watchScheduler } from '@/lib/watch-scheduler'
 import { useWatchStore } from '@/stores/watch-store'
 import { gateForWatch } from '@/lib/watch-sql-gate'
+import { TimeMachineButton } from '@/components/time-machine/time-machine-button'
+import { captureRun } from '@/lib/time-machine-capture'
+import { resolveSelectKeyColumns } from '@/lib/result-key-columns'
+import { useTimeMachineStore } from '@/stores/time-machine-store'
 import { useStepStore } from '@/stores/step-store'
 import { DDL_KEYWORD_REGEX } from '@shared/index'
 import type { editor as monacoEditor } from 'monaco-editor'
@@ -322,6 +326,10 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
       const executionId = crypto.randomUUID()
       updateTabExecuting(tabId, true, executionId)
 
+      // Running a query always returns the panel to the live result — leaving
+      // a Time Machine snapshot on screen would silently hide the fresh rows.
+      useTimeMachineStore.getState().backToLive(tabId)
+
       // Drop any state writes from this execution if the tab has moved on (cancelled,
       // re-run, or closed-and-reopened in the same session). Without this, a slow
       // response from execution A can clobber the result of execution B that started
@@ -427,6 +435,28 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
               rowCount: totalRows,
               status: 'success',
               connectionId: tabConnection.id
+            })
+
+            captureRun(tabId, {
+              enabled: useSettingsStore.getState().timeMachineEnabled,
+              tabType: currentTab.type,
+              connectionId: tabConnection.id,
+              sql: originalQuery,
+              statements: multiResult.statements,
+              explicitKeyColumns: resolveSelectKeyColumns(
+                originalQuery,
+                tabConnection.dbType,
+                useConnectionStore.getState().schemas
+              ),
+              maskedColumns: useMaskingStore
+                .getState()
+                .getEffectiveMaskedColumns(
+                  tabId,
+                  multiResult.statements
+                    .find((s) => s.isDataReturning)
+                    ?.fields.map((f) => f.name) ?? []
+                ),
+              capturedAt: Date.now()
             })
           } else {
             // Legacy single result (fallback)
@@ -1175,25 +1205,11 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
           return pks && pks.length > 0 ? pks : undefined
         }
 
-        // Query tabs: parse the SQL — if it's a single-table SELECT, look up
-        // that table's PK in the schema cache. Falls through to the heuristic
-        // in pickKeyingPlan when parsing or lookup fails.
+        // Query tabs: single-table SELECTs resolve their PK from the schema
+        // cache (shared with Time Machine capture so both key rows the same
+        // way); pickKeyingPlan's heuristic covers everything else.
         if (live.type === 'query' && tabConnection) {
-          const info = analyzeEditableSelect(live.query, tabConnection.dbType)
-          if (!info || info.hasFilters) return undefined
-          const candidates = allSchemas.filter(
-            (s) => !info.schema || s.name.toLowerCase() === info.schema.toLowerCase()
-          )
-          for (const schema of candidates) {
-            const tableInfo = schema.tables.find(
-              (t) => t.name.toLowerCase() === info.table.toLowerCase()
-            )
-            if (tableInfo) {
-              const pks = tableInfo.columns.filter((c) => c.isPrimaryKey).map((c) => c.name)
-              if (pks.length > 0) return pks
-              break
-            }
-          }
+          return resolveSelectKeyColumns(live.query, tabConnection.dbType, allSchemas)
         }
         return undefined
       }
@@ -1226,6 +1242,25 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
   }, [tabId, tabConnection, watchRunner])
 
   useEffect(() => window.api.menu.onToggleWatch(handleToggleWatch), [handleToggleWatch])
+
+  // ⌘⇧H — same menu-accelerator wiring as Watch Mode (menu wins over
+  // renderer keybindings on Electron).
+  const handleToggleTimeMachine = useCallback(() => {
+    const t = useTabStore.getState().getTab(tabId)
+    if (!t || t.type !== 'query') return
+    if (!useSettingsStore.getState().timeMachineEnabled) return
+    const tm = useTimeMachineStore.getState()
+    if (tm.getState(tabId)?.open) {
+      tm.closeStrip(tabId)
+    } else {
+      tm.openStrip(tabId)
+    }
+  }, [tabId])
+
+  useEffect(
+    () => window.api.menu.onToggleTimeMachine(handleToggleTimeMachine),
+    [handleToggleTimeMachine]
+  )
 
   if (!tab || tab.type === 'notebook') {
     return null
@@ -1391,6 +1426,11 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
               runner={watchRunner}
               disabled={!tabConnection}
             />
+          }
+          timeMachineSlot={
+            tab.type === 'query' ? (
+              <TimeMachineButton tabId={tabId} disabled={!tabConnection} />
+            ) : undefined
           }
           refsSlot={
             refsSummary ? (

--- a/apps/desktop/src/renderer/src/components/time-machine/time-machine-button.tsx
+++ b/apps/desktop/src/renderer/src/components/time-machine/time-machine-button.tsx
@@ -1,0 +1,59 @@
+import { History } from 'lucide-react'
+import {
+  Badge,
+  Button,
+  keys,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger
+} from '@data-peek/ui'
+import { useTimeMachineStore } from '@/stores/time-machine-store'
+import { useSettingsStore } from '@/stores/settings-store'
+
+interface TimeMachineButtonProps {
+  tabId: string
+  disabled?: boolean
+}
+
+export function TimeMachineButton({ tabId, disabled }: TimeMachineButtonProps) {
+  const state = useTimeMachineStore((s) => s.states[tabId])
+  const enabled = useSettingsStore((s) => s.timeMachineEnabled)
+  const openStrip = useTimeMachineStore((s) => s.openStrip)
+  const closeStrip = useTimeMachineStore((s) => s.closeStrip)
+
+  if (!enabled) return null
+
+  const isOpen = !!state?.open
+  const runCount = state?.runs.length ?? 0
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant={isOpen ? 'secondary' : 'ghost'}
+            size="sm"
+            className="gap-1.5 h-7"
+            disabled={disabled}
+            onClick={() => (isOpen ? closeStrip(tabId) : openStrip(tabId))}
+          >
+            <History className="size-3.5" />
+            Time Machine
+            {isOpen && runCount > 0 && (
+              <Badge variant="secondary" className="h-4 px-1.5 text-[10px] tabular-nums">
+                {runCount}
+              </Badge>
+            )}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">
+          <p className="text-xs">
+            {isOpen ? 'Hide' : 'Show'} run history timeline ({keys.mod}
+            {keys.shift}H)
+          </p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}

--- a/apps/desktop/src/renderer/src/components/time-machine/time-machine-strip.tsx
+++ b/apps/desktop/src/renderer/src/components/time-machine/time-machine-strip.tsx
@@ -1,0 +1,186 @@
+import { useEffect, useMemo, useRef } from 'react'
+import { History, Loader2, X } from 'lucide-react'
+import { cn, Button, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@data-peek/ui'
+import type { TimeMachineRunMeta } from '@data-peek/shared'
+import { useTimeMachineStore } from '@/stores/time-machine-store'
+import { ensureTimeMachineTabListener } from '@/lib/time-machine-capture'
+import { WatchSparkline } from '@/components/watch-sparkline'
+import type { WatchMetricPoint } from '@/lib/watch-types'
+
+const LOAD_DEBOUNCE_MS = 400
+
+interface TimeMachineStripProps {
+  tabId: string
+  connectionId: string | undefined
+  sql: string
+}
+
+function formatRunTime(capturedAt: number, now: number): string {
+  const date = new Date(capturedAt)
+  const sameDay = new Date(now).toDateString() === date.toDateString()
+  const time = date.toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false
+  })
+  if (sameDay) return time
+  return `${date.toLocaleDateString([], { month: 'short', day: 'numeric' })} ${time}`
+}
+
+/**
+ * Timeline of persisted runs for the tab's current query. Chips read oldest →
+ * newest left-to-right, with Live pinned at the right edge. Click a chip to
+ * view that run; alt-click (or click while viewing another run) to diff.
+ */
+export function TimeMachineStrip({ tabId, connectionId, sql }: TimeMachineStripProps) {
+  const state = useTimeMachineStore((s) => s.states[tabId])
+  const railRef = useRef<HTMLDivElement | null>(null)
+
+  const open = !!state?.open
+  const trimmedSql = sql.trim()
+
+  useEffect(() => {
+    if (!open || !connectionId || !trimmedSql) return
+    // Tab-close cleanup must be armed even if this tab never captures a run.
+    ensureTimeMachineTabListener()
+    const timer = setTimeout(() => {
+      void useTimeMachineStore.getState().loadRuns(tabId, connectionId, trimmedSql)
+    }, LOAD_DEBOUNCE_MS)
+    return () => clearTimeout(timer)
+  }, [open, tabId, connectionId, trimmedSql])
+
+  // Keep the rail scrolled to the newest run when the timeline grows.
+  const runCount = state?.runs.length ?? 0
+  useEffect(() => {
+    const rail = railRef.current
+    if (rail) rail.scrollLeft = rail.scrollWidth
+  }, [runCount])
+
+  const chronological = useMemo(() => (state ? [...state.runs].reverse() : []), [state?.runs])
+
+  const sparklinePoints = useMemo<WatchMetricPoint[]>(
+    () =>
+      chronological.map((run, index) => ({
+        tick: index,
+        capturedAt: run.capturedAt,
+        rowCount: run.rowCount,
+        durationMs: run.durationMs,
+        errored: false
+      })),
+    [chronological]
+  )
+
+  if (!state || !open) return null
+
+  const now = Date.now()
+  const viewingLive = state.selectedRunId === null
+
+  const handleChipClick = (run: TimeMachineRunMeta, event: React.MouseEvent) => {
+    const store = useTimeMachineStore.getState()
+    if (!run.hasRows) return
+    if ((event.altKey || event.shiftKey) && state.selectedRunId && run.id !== state.selectedRunId) {
+      void store.selectCompare(tabId, run.id)
+      return
+    }
+    if (run.id === state.selectedRunId && state.compareRunId === null) {
+      void store.selectRun(tabId, null)
+      return
+    }
+    void store.selectRun(tabId, run.id)
+  }
+
+  return (
+    <div className="flex items-center gap-2 border-b border-border/40 bg-muted/10 px-3 py-1.5 shrink-0">
+      <div className="flex items-center gap-1.5 text-xs text-muted-foreground shrink-0">
+        <History className="size-3.5" />
+        <span className="font-medium">Time Machine</span>
+        {state.isLoading && <Loader2 className="size-3 animate-spin" />}
+      </div>
+
+      {chronological.length > 1 && (
+        <div className="w-28 shrink-0 hidden md:block">
+          <WatchSparkline points={sparklinePoints} />
+        </div>
+      )}
+
+      {state.error ? (
+        <span className="text-xs text-red-400 truncate">{state.error}</span>
+      ) : chronological.length === 0 ? (
+        <span className="text-xs text-muted-foreground/60">
+          No runs captured yet — successful SELECTs are snapshotted automatically
+        </span>
+      ) : (
+        <div ref={railRef} className="flex items-center gap-1 overflow-x-auto min-w-0 flex-1">
+          {chronological.map((run, index) => {
+            const isSelected = run.id === state.selectedRunId
+            const isCompare = run.id === state.compareRunId
+            const previous = index > 0 ? chronological[index - 1] : null
+            const unchanged = previous !== null && previous.contentHash === run.contentHash
+            return (
+              <TooltipProvider key={run.id}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      onClick={(e) => handleChipClick(run, e)}
+                      disabled={!run.hasRows}
+                      className={cn(
+                        'flex items-center gap-1.5 rounded-md px-2 py-1 text-xs whitespace-nowrap transition-colors font-mono tabular-nums',
+                        isSelected
+                          ? 'bg-primary text-primary-foreground'
+                          : isCompare
+                            ? 'bg-primary/20 text-foreground ring-1 ring-primary/50'
+                            : 'text-muted-foreground hover:bg-muted hover:text-foreground',
+                        unchanged && !isSelected && !isCompare && 'opacity-50',
+                        !run.hasRows && 'opacity-40 cursor-not-allowed'
+                      )}
+                    >
+                      {formatRunTime(run.capturedAt, now)}
+                      <span className={isSelected ? 'opacity-80' : 'opacity-60'}>
+                        {run.rowCount}
+                        {run.truncated && '†'}
+                      </span>
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">
+                    <p className="text-xs">
+                      {run.rowCount} rows · {run.durationMs}ms
+                      {run.truncated && ' · stored first rows only'}
+                      {!run.hasRows && ' · too large to store — metadata only'}
+                      {unchanged && ' · no change vs previous run'}
+                    </p>
+                    <p className="text-[10px] text-muted-foreground">
+                      Click to view · ⌥-click to compare with the selected run
+                    </p>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            )
+          })}
+          <button
+            onClick={() => void useTimeMachineStore.getState().selectRun(tabId, null)}
+            className={cn(
+              'flex items-center gap-1.5 rounded-md px-2 py-1 text-xs whitespace-nowrap transition-colors sticky right-0',
+              viewingLive
+                ? 'bg-primary text-primary-foreground'
+                : 'bg-background text-muted-foreground hover:bg-muted hover:text-foreground ring-1 ring-border'
+            )}
+          >
+            <span className="size-1.5 rounded-full bg-green-500" />
+            Live
+          </button>
+        </div>
+      )}
+
+      <Button
+        variant="ghost"
+        size="sm"
+        className="h-6 w-6 p-0 shrink-0 ml-auto"
+        onClick={() => useTimeMachineStore.getState().closeStrip(tabId)}
+        title="Close Time Machine"
+      >
+        <X className="size-3.5" />
+      </Button>
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/src/components/time-machine/time-machine-view.tsx
+++ b/apps/desktop/src/renderer/src/components/time-machine/time-machine-view.tsx
@@ -1,0 +1,136 @@
+import { useMemo } from 'react'
+import { ArrowLeft, GitCompareArrows, Trash2 } from 'lucide-react'
+import { Badge, Button } from '@data-peek/ui'
+import { DataTable } from '@/components/data-table'
+import { useTimeMachineStore } from '@/stores/time-machine-store'
+import { recordsFromColumnar } from '@/lib/time-machine-payload'
+
+interface TimeMachineViewProps {
+  tabId: string
+  pageSize: number
+}
+
+function formatFullTime(capturedAt: number): string {
+  const date = new Date(capturedAt)
+  return `${date.toLocaleDateString([], { month: 'short', day: 'numeric' })} ${date.toLocaleTimeString(
+    [],
+    { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false }
+  )}`
+}
+
+/**
+ * Read-only view of a past run, replacing the live grid while active. In
+ * compare mode the newer run's rows render with pinned diff decorations
+ * against the older run.
+ */
+export function TimeMachineView({ tabId, pageSize }: TimeMachineViewProps) {
+  const state = useTimeMachineStore((s) => s.states[tabId])
+
+  const snapshot = state?.snapshot ?? null
+  const rows = useMemo(
+    () => (snapshot ? recordsFromColumnar(snapshot.columns, snapshot.rows) : []),
+    [snapshot]
+  )
+
+  if (!state || !snapshot) return null
+
+  const compareRun = state.compareRunId
+    ? (state.runs.find((r) => r.id === state.compareRunId) ?? null)
+    : null
+  const diff = state.diff
+
+  const changedCells = diff
+    ? [...diff.cells.values()].filter((c) => c.kind === 'changed').length
+    : 0
+
+  return (
+    <div className="flex flex-col h-full min-h-0">
+      <div className="flex items-center gap-2 rounded-md border border-primary/30 bg-primary/5 px-3 py-1.5 mb-2 shrink-0 text-xs">
+        {compareRun && diff ? (
+          <>
+            <GitCompareArrows className="size-3.5 text-primary shrink-0" />
+            <span className="font-medium">
+              {formatFullTime(compareRun.capturedAt)} → {formatFullTime(snapshot.capturedAt)}
+            </span>
+            <span className="flex items-center gap-1.5 text-muted-foreground tabular-nums">
+              <Badge
+                variant="secondary"
+                className="h-4 px-1.5 text-[10px] bg-green-500/15 text-green-500"
+              >
+                +{diff.addedRowKeys.size} added
+              </Badge>
+              <Badge
+                variant="secondary"
+                className="h-4 px-1.5 text-[10px] bg-red-500/15 text-red-400"
+              >
+                −{diff.removedRowKeys.size} removed
+              </Badge>
+              <Badge
+                variant="secondary"
+                className="h-4 px-1.5 text-[10px] bg-amber-500/15 text-amber-500"
+              >
+                {changedCells} cells changed
+              </Badge>
+            </span>
+            <span className="text-muted-foreground/60">
+              keyed by{' '}
+              {diff.keyingStrategy === 'primary_key' ? diff.keyColumns.join(', ') : 'position'}
+            </span>
+            {diff.removedRowKeys.size > 0 && (
+              <span className="text-muted-foreground/60">· removed rows not shown</span>
+            )}
+          </>
+        ) : (
+          <>
+            <span className="relative flex size-2 shrink-0">
+              <span className="absolute inline-flex h-full w-full rounded-full bg-primary/60 animate-ping" />
+              <span className="relative inline-flex size-2 rounded-full bg-primary" />
+            </span>
+            <span className="font-medium">
+              Viewing run from {formatFullTime(snapshot.capturedAt)}
+            </span>
+            <span className="text-muted-foreground tabular-nums">
+              {snapshot.rowCount} rows · {snapshot.durationMs}ms · read-only
+            </span>
+            {snapshot.truncated && (
+              <span className="text-amber-500">
+                first {snapshot.storedRowCount} of {snapshot.rowCount} rows stored
+              </span>
+            )}
+          </>
+        )}
+        <div className="flex items-center gap-1 ml-auto shrink-0">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 gap-1 px-2 text-xs text-muted-foreground hover:text-red-400"
+            onClick={() => void useTimeMachineStore.getState().deleteRun(tabId, snapshot.id)}
+            title="Delete this run from history"
+          >
+            <Trash2 className="size-3" />
+          </Button>
+          <Button
+            variant="secondary"
+            size="sm"
+            className="h-6 gap-1 px-2 text-xs"
+            onClick={() => void useTimeMachineStore.getState().selectRun(tabId, null)}
+          >
+            <ArrowLeft className="size-3" />
+            Back to live
+          </Button>
+        </div>
+      </div>
+
+      <div className="flex-1 min-h-0">
+        <DataTable
+          key={`tm-${snapshot.id}-${state.compareRunId ?? 'solo'}`}
+          tabId={tabId}
+          columns={snapshot.columns.map((c) => ({ name: c.name, dataType: c.dataType }))}
+          data={rows}
+          pageSize={pageSize}
+          diffOverlay={diff}
+        />
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/src/lib/__tests__/time-machine-capture.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/time-machine-capture.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest'
+import type { StatementResult } from '@data-peek/shared'
+import { TM_MAX_SNAPSHOT_ROWS } from '@data-peek/shared'
+import { buildCapturePayload, type BuildCaptureInput } from '../time-machine-capture'
+
+function makeStatement(overrides: Partial<StatementResult> = {}): StatementResult {
+  return {
+    statement: 'SELECT * FROM users',
+    statementIndex: 0,
+    rows: [
+      { id: 1, name: 'alpha' },
+      { id: 2, name: 'beta' }
+    ],
+    fields: [
+      { name: 'id', dataType: 'int4' },
+      { name: 'name', dataType: 'text' }
+    ],
+    rowCount: 2,
+    durationMs: 18,
+    isDataReturning: true,
+    ...overrides
+  }
+}
+
+function makeInput(overrides: Partial<BuildCaptureInput> = {}): BuildCaptureInput {
+  return {
+    enabled: true,
+    tabType: 'query',
+    connectionId: 'conn-1',
+    sql: 'SELECT * FROM users',
+    statements: [makeStatement()],
+    explicitKeyColumns: undefined,
+    maskedColumns: new Set<string>(),
+    capturedAt: 1750000000000,
+    ...overrides
+  }
+}
+
+describe('buildCapturePayload gating', () => {
+  it('captures an eligible single-statement SELECT', () => {
+    const payload = buildCapturePayload(makeInput())
+    expect(payload).not.toBeNull()
+    expect(payload!.connectionId).toBe('conn-1')
+    expect(payload!.sql).toBe('SELECT * FROM users')
+    expect(payload!.rowCount).toBe(2)
+    expect(payload!.truncated).toBe(false)
+    expect(payload!.rows).toEqual([
+      [1, 'alpha'],
+      [2, 'beta']
+    ])
+  })
+
+  it('returns null when the feature is disabled', () => {
+    expect(buildCapturePayload(makeInput({ enabled: false }))).toBeNull()
+  })
+
+  it('returns null for non-query tabs (table previews page-flip too much)', () => {
+    expect(buildCapturePayload(makeInput({ tabType: 'table-preview' }))).toBeNull()
+  })
+
+  it('returns null for destructive SQL', () => {
+    expect(
+      buildCapturePayload(makeInput({ sql: "UPDATE users SET name = 'x' WHERE id = 1" }))
+    ).toBeNull()
+    expect(buildCapturePayload(makeInput({ sql: 'DROP TABLE users' }))).toBeNull()
+  })
+
+  it('returns null for multi-statement SQL', () => {
+    expect(buildCapturePayload(makeInput({ sql: 'SELECT 1; SELECT 2' }))).toBeNull()
+  })
+
+  it('returns null when no statement returned data', () => {
+    expect(
+      buildCapturePayload(makeInput({ statements: [makeStatement({ isDataReturning: false })] }))
+    ).toBeNull()
+  })
+
+  it('returns null when several statements returned data', () => {
+    expect(
+      buildCapturePayload(
+        makeInput({
+          statements: [makeStatement(), makeStatement({ statementIndex: 1 })]
+        })
+      )
+    ).toBeNull()
+  })
+
+  it('captures WITH ... SELECT CTEs', () => {
+    const payload = buildCapturePayload(
+      makeInput({ sql: 'WITH recent AS (SELECT * FROM users) SELECT * FROM recent' })
+    )
+    expect(payload).not.toBeNull()
+  })
+
+  it('captures empty result sets — an empty table is meaningful history', () => {
+    const payload = buildCapturePayload(
+      makeInput({ statements: [makeStatement({ rows: [], rowCount: 0 })] })
+    )
+    expect(payload).not.toBeNull()
+    expect(payload!.rowCount).toBe(0)
+    expect(payload!.rows).toEqual([])
+  })
+})
+
+describe('buildCapturePayload row cap', () => {
+  it('caps stored rows at TM_MAX_SNAPSHOT_ROWS and flags truncation', () => {
+    const rows = Array.from({ length: TM_MAX_SNAPSHOT_ROWS + 5 }, (_, i) => ({
+      id: i,
+      name: `row-${i}`
+    }))
+    const payload = buildCapturePayload(
+      makeInput({ statements: [makeStatement({ rows, rowCount: rows.length })] })
+    )
+    expect(payload).not.toBeNull()
+    expect(payload!.rows.length).toBe(TM_MAX_SNAPSHOT_ROWS)
+    expect(payload!.rowCount).toBe(TM_MAX_SNAPSHOT_ROWS + 5)
+    expect(payload!.truncated).toBe(true)
+  })
+})
+
+describe('buildCapturePayload keying plan', () => {
+  it('uses explicit key columns when all are present in the projection', () => {
+    const payload = buildCapturePayload(makeInput({ explicitKeyColumns: ['id'] }))
+    expect(payload!.keyStrategy).toBe('primary_key')
+    expect(payload!.keyColumns).toEqual(['id'])
+  })
+
+  it('falls back to the id heuristic without explicit keys', () => {
+    const payload = buildCapturePayload(makeInput())
+    expect(payload!.keyStrategy).toBe('primary_key')
+    expect(payload!.keyColumns).toEqual(['id'])
+  })
+
+  it('falls back to row_position when nothing key-like exists', () => {
+    const payload = buildCapturePayload(
+      makeInput({
+        statements: [
+          makeStatement({
+            rows: [{ total: 5 }],
+            fields: [{ name: 'total', dataType: 'int8' }],
+            rowCount: 1
+          })
+        ]
+      })
+    )
+    expect(payload!.keyStrategy).toBe('row_position')
+    expect(payload!.keyColumns).toEqual([])
+  })
+})
+
+describe('buildCapturePayload masking', () => {
+  it('redacts masked columns before the payload leaves the renderer', () => {
+    const payload = buildCapturePayload(
+      makeInput({
+        maskedColumns: new Set(['name']),
+        statements: [makeStatement()]
+      })
+    )
+    expect(payload!.rows).toEqual([
+      [1, '[MASKED]'],
+      [2, '[MASKED]']
+    ])
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/__tests__/time-machine-payload.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/time-machine-payload.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest'
+import { normalizeValue, toColumnarRows, recordsFromColumnar } from '../time-machine-payload'
+
+describe('normalizeValue', () => {
+  it('passes primitives through untouched', () => {
+    expect(normalizeValue('hello')).toBe('hello')
+    expect(normalizeValue(42)).toBe(42)
+    expect(normalizeValue(4.5)).toBe(4.5)
+    expect(normalizeValue(true)).toBe(true)
+    expect(normalizeValue(false)).toBe(false)
+  })
+
+  it('maps null and undefined to null', () => {
+    expect(normalizeValue(null)).toBeNull()
+    expect(normalizeValue(undefined)).toBeNull()
+  })
+
+  it('serializes Dates to ISO strings', () => {
+    const d = new Date('2026-07-02T10:30:00.000Z')
+    expect(normalizeValue(d)).toBe('2026-07-02T10:30:00.000Z')
+  })
+
+  it('maps invalid Dates to null', () => {
+    expect(normalizeValue(new Date('not a date'))).toBeNull()
+  })
+
+  it('serializes bigints to strings', () => {
+    expect(normalizeValue(BigInt('9007199254740993'))).toBe('9007199254740993')
+  })
+
+  it('keeps non-finite numbers distinguishable from SQL NULL', () => {
+    expect(normalizeValue(NaN)).toBe('NaN')
+    expect(normalizeValue(Infinity)).toBe('Infinity')
+    expect(normalizeValue(-Infinity)).toBe('-Infinity')
+  })
+
+  it('renders small binary values as full hex', () => {
+    const bytes = new Uint8Array([0xde, 0xad, 0xbe, 0xef])
+    expect(normalizeValue(bytes)).toBe('\\xdeadbeef')
+  })
+
+  it('caps large binary values with a byte-count suffix', () => {
+    const bytes = new Uint8Array(300).fill(0xab)
+    const result = normalizeValue(bytes) as string
+    expect(result.startsWith('\\x')).toBe(true)
+    expect(result).toContain('(300 bytes)')
+    // 2 hex chars per byte, 256-byte preview
+    expect(result.slice(2, 2 + 512)).toBe('ab'.repeat(256))
+  })
+
+  it('leaves parsed JSON objects and arrays alone', () => {
+    const obj = { a: 1, nested: { b: [1, 2] } }
+    expect(normalizeValue(obj)).toBe(obj)
+  })
+
+  it('is idempotent — normalizing a normalized value is a no-op', () => {
+    const once = normalizeValue(new Date('2026-01-01T00:00:00Z'))
+    expect(normalizeValue(once)).toBe(once)
+  })
+})
+
+describe('toColumnarRows', () => {
+  const rows = [
+    { id: 1, email: 'a@b.test', created_at: new Date('2026-06-01T00:00:00Z') },
+    { id: 2, email: 'c@d.test', created_at: null }
+  ]
+  const columns = ['id', 'email', 'created_at']
+
+  it('produces columnar arrays in column order', () => {
+    const out = toColumnarRows(rows, columns, new Set())
+    expect(out).toEqual([
+      [1, 'a@b.test', '2026-06-01T00:00:00.000Z'],
+      [2, 'c@d.test', null]
+    ])
+  })
+
+  it('redacts masked columns with the export placeholder', () => {
+    const out = toColumnarRows(rows, columns, new Set(['email']))
+    expect(out[0][1]).toBe('[MASKED]')
+    expect(out[1][1]).toBe('[MASKED]')
+    expect(out[0][0]).toBe(1)
+  })
+
+  it('fills missing keys with null', () => {
+    const out = toColumnarRows([{ id: 1 }], columns, new Set())
+    expect(out).toEqual([[1, null, null]])
+  })
+})
+
+describe('recordsFromColumnar', () => {
+  it('round-trips with toColumnarRows', () => {
+    const rows = [
+      { id: 1, name: 'alpha' },
+      { id: 2, name: 'beta' }
+    ]
+    const columns = [
+      { name: 'id', dataType: 'int4' },
+      { name: 'name', dataType: 'text' }
+    ]
+    const columnar = toColumnarRows(rows, ['id', 'name'], new Set())
+    expect(recordsFromColumnar(columns, columnar)).toEqual(rows)
+  })
+
+  it('handles empty row sets', () => {
+    expect(recordsFromColumnar([{ name: 'id', dataType: 'int4' }], [])).toEqual([])
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/export.ts
+++ b/apps/desktop/src/renderer/src/lib/export.ts
@@ -137,6 +137,8 @@ export function serializeExport(
   }
 }
 
+export const MASKED_PLACEHOLDER = '[MASKED]'
+
 export function maskExportData(data: ExportData, maskedColumns: Set<string>): ExportData {
   if (maskedColumns.size === 0) return data
 
@@ -145,7 +147,7 @@ export function maskExportData(data: ExportData, maskedColumns: Set<string>): Ex
     rows: data.rows.map((row) => {
       const newRow = { ...row }
       for (const column of maskedColumns) {
-        newRow[column] = '[MASKED]'
+        newRow[column] = MASKED_PLACEHOLDER
       }
       return newRow
     })

--- a/apps/desktop/src/renderer/src/lib/result-key-columns.ts
+++ b/apps/desktop/src/renderer/src/lib/result-key-columns.ts
@@ -1,0 +1,31 @@
+/**
+ * Resolve explicit primary-key columns for a single-table SELECT from the
+ * schema cache. Shared by Watch Mode diffing and Time Machine capture so both
+ * derive identical row keys for the same query. Returns undefined when the SQL
+ * doesn't resolve to one unambiguous table — pickKeyingPlan's heuristic takes
+ * over from there.
+ */
+
+import type { DatabaseType, SchemaInfo } from '@data-peek/shared'
+import { analyzeEditableSelect } from './editable-select'
+
+export function resolveSelectKeyColumns(
+  sql: string,
+  dbType: DatabaseType,
+  schemas: ReadonlyArray<SchemaInfo>
+): string[] | undefined {
+  const info = analyzeEditableSelect(sql, dbType)
+  if (!info || info.hasFilters) return undefined
+  const candidates = schemas.filter(
+    (s) => !info.schema || s.name.toLowerCase() === info.schema.toLowerCase()
+  )
+  for (const schema of candidates) {
+    const tableInfo = schema.tables.find((t) => t.name.toLowerCase() === info.table.toLowerCase())
+    if (tableInfo) {
+      const pks = tableInfo.columns.filter((c) => c.isPrimaryKey).map((c) => c.name)
+      if (pks.length > 0) return pks
+      break
+    }
+  }
+  return undefined
+}

--- a/apps/desktop/src/renderer/src/lib/time-machine-capture.ts
+++ b/apps/desktop/src/renderer/src/lib/time-machine-capture.ts
@@ -1,0 +1,109 @@
+/**
+ * Time Machine capture — decides whether a completed run is snapshot-worthy
+ * and ships it to the main process.
+ *
+ * Capture hooks into the manual-run success path only. Watch ticks, notebook
+ * cells, AI runs and table-preview page flips all reach the database through
+ * other code paths, so they are excluded by construction, not by filtering.
+ */
+
+import type { StatementResult, TimeMachineCapturePayload } from '@data-peek/shared'
+import { TM_MAX_SNAPSHOT_ROWS } from '@data-peek/shared'
+import { gateForWatch } from './watch-sql-gate'
+import { pickKeyingPlan } from './watch-row-keying'
+import { toColumnarRows } from './time-machine-payload'
+import { useTimeMachineStore } from '@/stores/time-machine-store'
+import { useTabStore } from '@/stores/tab-store'
+
+export interface BuildCaptureInput {
+  enabled: boolean
+  tabType: string
+  connectionId: string
+  /** The user's typed SQL — fingerprinted main-side, shown in the timeline. */
+  sql: string
+  statements: ReadonlyArray<StatementResult>
+  /** Explicit PK columns from the schema cache, when resolvable. */
+  explicitKeyColumns: ReadonlyArray<string> | undefined
+  maskedColumns: ReadonlySet<string>
+  capturedAt: number
+}
+
+/**
+ * Returns null when the run isn't eligible: feature off, not a query tab,
+ * not a single-statement pure SELECT, or no data-returning result.
+ */
+export function buildCapturePayload(input: BuildCaptureInput): TimeMachineCapturePayload | null {
+  if (!input.enabled) return null
+  if (input.tabType !== 'query') return null
+  if (!gateForWatch(input.sql).ok) return null
+
+  const dataStatements = input.statements.filter((s) => s.isDataReturning)
+  if (dataStatements.length !== 1) return null
+  const statement = dataStatements[0]
+
+  const fieldNames = statement.fields.map((f) => f.name)
+  const plan = pickKeyingPlan({
+    explicitKeyColumns: input.explicitKeyColumns,
+    fieldNames
+  })
+
+  const totalRows = statement.rows.length
+  const cappedRows =
+    totalRows > TM_MAX_SNAPSHOT_ROWS
+      ? statement.rows.slice(0, TM_MAX_SNAPSHOT_ROWS)
+      : statement.rows
+
+  return {
+    connectionId: input.connectionId,
+    sql: input.sql,
+    capturedAt: input.capturedAt,
+    durationMs: statement.durationMs,
+    rowCount: statement.rowCount || totalRows,
+    truncated: cappedRows.length < totalRows,
+    keyStrategy: plan.strategy,
+    keyColumns: [...plan.keyColumns],
+    columns: statement.fields.map((f) => ({ name: f.name, dataType: f.dataType })),
+    rows: toColumnarRows(
+      cappedRows as ReadonlyArray<Record<string, unknown>>,
+      fieldNames,
+      input.maskedColumns
+    )
+  }
+}
+
+/**
+ * Fire-and-forget: never blocks or fails the run that produced the result.
+ * On success the tab's open timeline (if any) is updated in place.
+ */
+export function captureRun(tabId: string, input: BuildCaptureInput): void {
+  const payload = buildCapturePayload(input)
+  if (!payload) return
+  ensureTimeMachineTabListener()
+  window.api.timeMachine
+    .capture(payload)
+    .then((response) => {
+      if (response.success && response.data) {
+        useTimeMachineStore.getState().applyCapture(tabId, response.data)
+      }
+    })
+    .catch((err) => console.error('Time Machine capture failed', err))
+}
+
+let tabListenerSetup = false
+
+/**
+ * Tab-store close cleanup, same pattern as the watch scheduler: tab-store
+ * never notifies satellites, so we diff live tab ids ourselves.
+ */
+export function ensureTimeMachineTabListener(): void {
+  if (tabListenerSetup) return
+  tabListenerSetup = true
+  useTabStore.subscribe((state, prev) => {
+    if (state.tabs === prev.tabs) return
+    const live = new Set(state.tabs.map((t) => t.id))
+    const tm = useTimeMachineStore.getState()
+    for (const tabId of Object.keys(tm.states)) {
+      if (!live.has(tabId)) tm.stop(tabId)
+    }
+  })
+}

--- a/apps/desktop/src/renderer/src/lib/time-machine-payload.ts
+++ b/apps/desktop/src/renderer/src/lib/time-machine-payload.ts
@@ -1,0 +1,65 @@
+/**
+ * Time Machine payload helpers — pure functions, no store imports.
+ *
+ * Snapshot values are normalized ONCE here, before they cross IPC. pg hands the
+ * renderer live Date objects (timestamptz) and Uint8Arrays (bytea); persisting
+ * those through JSON would make a rehydrated snapshot disagree with a fresh one
+ * on every timestamp cell. Normalizing at capture means both sides of any
+ * snapshot-vs-snapshot diff went through the same serialization.
+ */
+
+import { MASKED_PLACEHOLDER } from './export'
+
+const BINARY_PREVIEW_BYTES = 256
+
+export function normalizeValue(value: unknown): unknown {
+  if (value === null || value === undefined) return null
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value.toISOString()
+  }
+  if (typeof value === 'bigint') return value.toString()
+  // JSON.stringify would silently turn these into null, conflating them with
+  // SQL NULL in the stored snapshot and the content hash.
+  if (typeof value === 'number' && !Number.isFinite(value)) return String(value)
+  if (value instanceof Uint8Array) {
+    let hex = ''
+    const previewLength = Math.min(value.length, BINARY_PREVIEW_BYTES)
+    for (let i = 0; i < previewLength; i++) {
+      hex += value[i].toString(16).padStart(2, '0')
+    }
+    const suffix = value.length > BINARY_PREVIEW_BYTES ? `… (${value.length} bytes)` : ''
+    return `\\x${hex}${suffix}`
+  }
+  return value
+}
+
+/**
+ * Convert result rows to the columnar payload shape (column names stored once,
+ * values as arrays), redacting masked columns so sensitive values never reach
+ * disk. Mirrors the '[MASKED]' substitution used by exports.
+ */
+export function toColumnarRows(
+  rows: ReadonlyArray<Record<string, unknown>>,
+  columnNames: ReadonlyArray<string>,
+  maskedColumns: ReadonlySet<string>
+): unknown[][] {
+  return rows.map((row) =>
+    columnNames.map((name) =>
+      maskedColumns.has(name) ? MASKED_PLACEHOLDER : normalizeValue(row[name])
+    )
+  )
+}
+
+/** Inverse of toColumnarRows — rebuild Record rows for the grid and the differ. */
+export function recordsFromColumnar(
+  columns: ReadonlyArray<{ name: string; dataType: string }>,
+  rows: ReadonlyArray<ReadonlyArray<unknown>>
+): Record<string, unknown>[] {
+  return rows.map((values) => {
+    const record: Record<string, unknown> = {}
+    for (let i = 0; i < columns.length; i++) {
+      record[columns[i].name] = values[i]
+    }
+    return record
+  })
+}

--- a/apps/desktop/src/renderer/src/router.tsx
+++ b/apps/desktop/src/renderer/src/router.tsx
@@ -18,7 +18,22 @@ import { SavedQueriesDialog } from '@/components/saved-queries-dialog'
 import { DatabaseIcon } from '@/components/database-icons'
 import { AppSidebar } from '@/components/app-sidebar'
 import { NavActions } from '@/components/nav-actions'
-import { Separator, SidebarInset, SidebarProvider, SidebarTrigger, useSidebar, Switch, Label, Input, cn, keys, Button, Tooltip, TooltipContent, TooltipTrigger } from '@data-peek/ui'
+import {
+  Separator,
+  SidebarInset,
+  SidebarProvider,
+  SidebarTrigger,
+  useSidebar,
+  Switch,
+  Label,
+  Input,
+  cn,
+  keys,
+  Button,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from '@data-peek/ui'
 import { TabContainer } from '@/components/tab-container'
 import { DashboardView } from '@/components/dashboard'
 import { ConnectionPicker } from '@/components/connection-picker'
@@ -569,6 +584,11 @@ function SettingsPage() {
               <div className="space-y-1">
                 <ShortcutRow keys={[keys.mod, 'Enter']} description="Execute/run current query" />
                 <ShortcutRow keys={[keys.mod, keys.shift, 'F']} description="Format SQL query" />
+                <ShortcutRow keys={[keys.mod, keys.shift, 'W']} description="Toggle Watch Mode" />
+                <ShortcutRow
+                  keys={[keys.mod, keys.shift, 'H']}
+                  description="Toggle Time Machine run history"
+                />
               </div>
             </div>
 

--- a/apps/desktop/src/renderer/src/stores/__tests__/time-machine-store.test.ts
+++ b/apps/desktop/src/renderer/src/stores/__tests__/time-machine-store.test.ts
@@ -1,0 +1,346 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { TimeMachineRunMeta, TimeMachineSnapshot } from '@data-peek/shared'
+import { useTimeMachineStore } from '../time-machine-store'
+
+const listRunsMock = vi.fn()
+const getSnapshotMock = vi.fn()
+const deleteRunMock = vi.fn().mockResolvedValue({ success: true })
+
+vi.stubGlobal('window', {
+  api: {
+    timeMachine: {
+      listRuns: listRunsMock,
+      getSnapshot: getSnapshotMock,
+      deleteRun: deleteRunMock
+    }
+  }
+})
+
+const TAB = 'tab-1'
+
+function makeMeta(overrides: Partial<TimeMachineRunMeta> = {}): TimeMachineRunMeta {
+  return {
+    id: 'run-1',
+    connectionId: 'conn-1',
+    fingerprint: 'select * from users',
+    sql: 'SELECT * FROM users',
+    capturedAt: 1750000000000,
+    durationMs: 12,
+    rowCount: 2,
+    storedRowCount: 2,
+    truncated: false,
+    contentHash: 'hash-1',
+    keyStrategy: 'primary_key',
+    keyColumns: ['id'],
+    hasRows: true,
+    ...overrides
+  }
+}
+
+function makeSnapshot(overrides: Partial<TimeMachineSnapshot> = {}): TimeMachineSnapshot {
+  return {
+    ...makeMeta(),
+    columns: [
+      { name: 'id', dataType: 'int4' },
+      { name: 'status', dataType: 'text' }
+    ],
+    rows: [
+      [1, 'active'],
+      [2, 'pending']
+    ],
+    ...overrides
+  }
+}
+
+beforeEach(() => {
+  useTimeMachineStore.setState({ states: {} })
+  listRunsMock.mockReset()
+  getSnapshotMock.mockReset()
+  deleteRunMock.mockClear()
+})
+
+describe('strip lifecycle', () => {
+  it('openStrip creates fresh state, closeStrip resets selection back to live', () => {
+    const store = useTimeMachineStore.getState()
+    store.openStrip(TAB)
+    expect(store.getState(TAB)?.open).toBe(true)
+
+    useTimeMachineStore.setState((s) => ({
+      states: {
+        ...s.states,
+        [TAB]: { ...s.states[TAB], selectedRunId: 'run-1', snapshot: makeSnapshot() }
+      }
+    }))
+    useTimeMachineStore.getState().closeStrip(TAB)
+    const st = useTimeMachineStore.getState().getState(TAB)
+    expect(st?.open).toBe(false)
+    expect(st?.selectedRunId).toBeNull()
+    expect(st?.snapshot).toBeNull()
+  })
+
+  it('stop removes all state for the tab', () => {
+    useTimeMachineStore.getState().openStrip(TAB)
+    useTimeMachineStore.getState().stop(TAB)
+    expect(useTimeMachineStore.getState().getState(TAB)).toBeNull()
+  })
+})
+
+describe('loadRuns', () => {
+  it('populates fingerprint and runs on success', async () => {
+    const runs = [makeMeta(), makeMeta({ id: 'run-2', capturedAt: 1749990000000 })]
+    listRunsMock.mockResolvedValue({
+      success: true,
+      data: { fingerprint: 'fp-1', runs }
+    })
+    useTimeMachineStore.getState().openStrip(TAB)
+    await useTimeMachineStore.getState().loadRuns(TAB, 'conn-1', 'SELECT * FROM users')
+    const st = useTimeMachineStore.getState().getState(TAB)
+    expect(st?.fingerprint).toBe('fp-1')
+    expect(st?.runs).toHaveLength(2)
+    expect(st?.isLoading).toBe(false)
+  })
+
+  it('surfaces the error without wiping runs already shown', async () => {
+    listRunsMock.mockResolvedValue({ success: false, error: 'storage unavailable' })
+    useTimeMachineStore.getState().openStrip(TAB)
+    await useTimeMachineStore.getState().loadRuns(TAB, 'conn-1', 'SELECT 1')
+    const st = useTimeMachineStore.getState().getState(TAB)
+    expect(st?.error).toBe('storage unavailable')
+    expect(st?.isLoading).toBe(false)
+  })
+
+  it('drops the selection when the selected run vanished from the new list', async () => {
+    useTimeMachineStore.getState().openStrip(TAB)
+    useTimeMachineStore.setState((s) => ({
+      states: {
+        ...s.states,
+        [TAB]: {
+          ...s.states[TAB],
+          selectedRunId: 'gone',
+          snapshot: makeSnapshot({ id: 'gone' })
+        }
+      }
+    }))
+    listRunsMock.mockResolvedValue({
+      success: true,
+      data: { fingerprint: 'fp-1', runs: [makeMeta()] }
+    })
+    await useTimeMachineStore.getState().loadRuns(TAB, 'conn-1', 'SELECT 1')
+    const st = useTimeMachineStore.getState().getState(TAB)
+    expect(st?.selectedRunId).toBeNull()
+    expect(st?.snapshot).toBeNull()
+  })
+
+  it('ignores a stale response that resolves after a newer request', async () => {
+    useTimeMachineStore.getState().openStrip(TAB)
+    let resolveFirst: (v: unknown) => void = () => {}
+    listRunsMock
+      .mockImplementationOnce(() => new Promise((resolve) => (resolveFirst = resolve)))
+      .mockResolvedValueOnce({
+        success: true,
+        data: { fingerprint: 'fp-new', runs: [makeMeta({ id: 'new-run' })] }
+      })
+    const first = useTimeMachineStore.getState().loadRuns(TAB, 'conn-1', 'SELECT 1')
+    const second = useTimeMachineStore.getState().loadRuns(TAB, 'conn-1', 'SELECT 2')
+    await second
+    resolveFirst({
+      success: true,
+      data: { fingerprint: 'fp-stale', runs: [] }
+    })
+    await first
+    const st = useTimeMachineStore.getState().getState(TAB)
+    expect(st?.fingerprint).toBe('fp-new')
+    expect(st?.runs[0]?.id).toBe('new-run')
+  })
+})
+
+describe('selectRun', () => {
+  it('loads the snapshot and enters view mode', async () => {
+    useTimeMachineStore.getState().openStrip(TAB)
+    useTimeMachineStore.setState((s) => ({
+      states: { ...s.states, [TAB]: { ...s.states[TAB], runs: [makeMeta()] } }
+    }))
+    getSnapshotMock.mockResolvedValue({ success: true, data: makeSnapshot() })
+    await useTimeMachineStore.getState().selectRun(TAB, 'run-1')
+    const st = useTimeMachineStore.getState().getState(TAB)
+    expect(st?.selectedRunId).toBe('run-1')
+    expect(st?.snapshot?.rows).toHaveLength(2)
+    expect(st?.diff).toBeNull()
+  })
+
+  it('refuses to view metadata-only runs', async () => {
+    useTimeMachineStore.getState().openStrip(TAB)
+    useTimeMachineStore.setState((s) => ({
+      states: {
+        ...s.states,
+        [TAB]: { ...s.states[TAB], runs: [makeMeta({ hasRows: false })] }
+      }
+    }))
+    await useTimeMachineStore.getState().selectRun(TAB, 'run-1')
+    expect(getSnapshotMock).not.toHaveBeenCalled()
+    expect(useTimeMachineStore.getState().getState(TAB)?.selectedRunId).toBeNull()
+  })
+
+  it('selectRun(null) returns to live', async () => {
+    useTimeMachineStore.getState().openStrip(TAB)
+    useTimeMachineStore.setState((s) => ({
+      states: {
+        ...s.states,
+        [TAB]: {
+          ...s.states[TAB],
+          runs: [makeMeta()],
+          selectedRunId: 'run-1',
+          snapshot: makeSnapshot()
+        }
+      }
+    }))
+    await useTimeMachineStore.getState().selectRun(TAB, null)
+    const st = useTimeMachineStore.getState().getState(TAB)
+    expect(st?.selectedRunId).toBeNull()
+    expect(st?.snapshot).toBeNull()
+  })
+})
+
+describe('selectCompare', () => {
+  function seedTwoRuns(): { older: TimeMachineRunMeta; newer: TimeMachineRunMeta } {
+    const older = makeMeta({ id: 'older', capturedAt: 1749990000000, contentHash: 'h-a' })
+    const newer = makeMeta({ id: 'newer', capturedAt: 1750000000000, contentHash: 'h-b' })
+    useTimeMachineStore.getState().openStrip(TAB)
+    useTimeMachineStore.setState((s) => ({
+      states: {
+        ...s.states,
+        [TAB]: { ...s.states[TAB], runs: [newer, older], selectedRunId: newer.id }
+      }
+    }))
+    return { older, newer }
+  }
+
+  it('computes a PK-keyed diff between two runs', async () => {
+    const { older, newer } = seedTwoRuns()
+    getSnapshotMock.mockImplementation((id: string) =>
+      Promise.resolve({
+        success: true,
+        data:
+          id === older.id
+            ? makeSnapshot({
+                id: older.id,
+                rows: [
+                  [1, 'active'],
+                  [2, 'pending']
+                ]
+              })
+            : makeSnapshot({
+                id: newer.id,
+                rows: [
+                  [1, 'active'],
+                  [2, 'shipped'],
+                  [3, 'new']
+                ]
+              })
+      })
+    )
+    await useTimeMachineStore.getState().selectCompare(TAB, older.id)
+    const st = useTimeMachineStore.getState().getState(TAB)
+    expect(st?.selectedRunId).toBe(newer.id)
+    expect(st?.compareRunId).toBe(older.id)
+    expect(st?.snapshot?.id).toBe(newer.id)
+    expect(st?.diff).not.toBeNull()
+    expect(st?.diff?.addedRowKeys.size).toBe(1)
+    expect(st?.diff?.removedRowKeys.size).toBe(0)
+    const changed = [...st!.diff!.cells.values()].filter((c) => c.kind === 'changed')
+    expect(changed).toHaveLength(1)
+    expect(changed[0].previousValue).toBe('pending')
+  })
+
+  it('orients the diff older → newer regardless of click order', async () => {
+    const older = makeMeta({ id: 'older', capturedAt: 1749990000000 })
+    const newer = makeMeta({ id: 'newer', capturedAt: 1750000000000 })
+    useTimeMachineStore.getState().openStrip(TAB)
+    useTimeMachineStore.setState((s) => ({
+      states: {
+        ...s.states,
+        [TAB]: { ...s.states[TAB], runs: [newer, older], selectedRunId: older.id }
+      }
+    }))
+    getSnapshotMock.mockImplementation((id: string) =>
+      Promise.resolve({ success: true, data: makeSnapshot({ id }) })
+    )
+    await useTimeMachineStore.getState().selectCompare(TAB, newer.id)
+    const st = useTimeMachineStore.getState().getState(TAB)
+    expect(st?.selectedRunId).toBe('newer')
+    expect(st?.compareRunId).toBe('older')
+  })
+
+  it('falls back to position keying when the runs disagree on key columns', async () => {
+    const older = makeMeta({ id: 'older', capturedAt: 1, keyColumns: ['uuid'] })
+    const newer = makeMeta({ id: 'newer', capturedAt: 2, keyColumns: ['id'] })
+    useTimeMachineStore.getState().openStrip(TAB)
+    useTimeMachineStore.setState((s) => ({
+      states: {
+        ...s.states,
+        [TAB]: { ...s.states[TAB], runs: [newer, older], selectedRunId: newer.id }
+      }
+    }))
+    getSnapshotMock.mockImplementation((id: string) =>
+      Promise.resolve({ success: true, data: makeSnapshot({ id }) })
+    )
+    await useTimeMachineStore.getState().selectCompare(TAB, older.id)
+    expect(useTimeMachineStore.getState().getState(TAB)?.diff?.keyingStrategy).toBe('row_position')
+  })
+})
+
+describe('applyCapture', () => {
+  it('prepends when the fingerprint matches the loaded timeline', () => {
+    useTimeMachineStore.getState().openStrip(TAB)
+    useTimeMachineStore.setState((s) => ({
+      states: {
+        ...s.states,
+        [TAB]: { ...s.states[TAB], fingerprint: 'fp-1', runs: [makeMeta({ id: 'old' })] }
+      }
+    }))
+    useTimeMachineStore.getState().applyCapture(TAB, makeMeta({ id: 'fresh', fingerprint: 'fp-1' }))
+    const st = useTimeMachineStore.getState().getState(TAB)
+    expect(st?.runs.map((r) => r.id)).toEqual(['fresh', 'old'])
+  })
+
+  it('reloads the timeline when the fingerprint changed', () => {
+    listRunsMock.mockResolvedValue({
+      success: true,
+      data: { fingerprint: 'fp-2', runs: [makeMeta({ id: 'other' })] }
+    })
+    useTimeMachineStore.getState().openStrip(TAB)
+    useTimeMachineStore.setState((s) => ({
+      states: { ...s.states, [TAB]: { ...s.states[TAB], fingerprint: 'fp-1' } }
+    }))
+    useTimeMachineStore.getState().applyCapture(TAB, makeMeta({ id: 'fresh', fingerprint: 'fp-2' }))
+    expect(listRunsMock).toHaveBeenCalledWith('conn-1', 'SELECT * FROM users')
+  })
+
+  it('is a no-op for tabs with no open strip state', () => {
+    useTimeMachineStore.getState().applyCapture(TAB, makeMeta())
+    expect(useTimeMachineStore.getState().getState(TAB)).toBeNull()
+  })
+})
+
+describe('deleteRun', () => {
+  it('removes the run optimistically and resets the view when it was on screen', async () => {
+    useTimeMachineStore.getState().openStrip(TAB)
+    useTimeMachineStore.setState((s) => ({
+      states: {
+        ...s.states,
+        [TAB]: {
+          ...s.states[TAB],
+          runs: [makeMeta({ id: 'a' }), makeMeta({ id: 'b' })],
+          selectedRunId: 'a',
+          snapshot: makeSnapshot({ id: 'a' })
+        }
+      }
+    }))
+    await useTimeMachineStore.getState().deleteRun(TAB, 'a')
+    const st = useTimeMachineStore.getState().getState(TAB)
+    expect(st?.runs.map((r) => r.id)).toEqual(['b'])
+    expect(st?.selectedRunId).toBeNull()
+    expect(st?.snapshot).toBeNull()
+    expect(deleteRunMock).toHaveBeenCalledWith('a')
+  })
+})

--- a/apps/desktop/src/renderer/src/stores/settings-store.ts
+++ b/apps/desktop/src/renderer/src/stores/settings-store.ts
@@ -21,6 +21,9 @@ export interface AppSettings {
   // Fun features
   /** Show Pokemon buddy and fun analytics widgets */
   pokemonBuddyEnabled: boolean
+  // Time Machine
+  /** Snapshot successful SELECT results locally for the run-history timeline */
+  timeMachineEnabled: boolean
 }
 
 interface SettingsState extends AppSettings {
@@ -31,6 +34,7 @@ interface SettingsState extends AppSettings {
   setQueryTimeoutMs: (value: number) => void
   setDefaultPageSize: (size: PageSizeOption) => void
   setPokemonBuddyEnabled: (value: boolean) => void
+  setTimeMachineEnabled: (value: boolean) => void
   resetSettings: () => void
   setHideQuickQueryPanel: (value: boolean) => void
 }
@@ -42,7 +46,8 @@ const defaultSettings: AppSettings = {
   hideQuickQueryPanel: true,
   queryTimeoutMs: 0, // 0 = no timeout
   defaultPageSize: 100,
-  pokemonBuddyEnabled: false
+  pokemonBuddyEnabled: false,
+  timeMachineEnabled: true
 }
 
 export const useSettingsStore = create<SettingsState>()(
@@ -55,6 +60,7 @@ export const useSettingsStore = create<SettingsState>()(
       setQueryTimeoutMs: (value) => set({ queryTimeoutMs: value }),
       setDefaultPageSize: (size) => set({ defaultPageSize: size }),
       setPokemonBuddyEnabled: (value) => set({ pokemonBuddyEnabled: value }),
+      setTimeMachineEnabled: (value) => set({ timeMachineEnabled: value }),
       setHideQuickQueryPanel: (value) => set({ hideQuickQueryPanel: value }),
       resetSettings: () => set(defaultSettings)
     }),

--- a/apps/desktop/src/renderer/src/stores/time-machine-store.ts
+++ b/apps/desktop/src/renderer/src/stores/time-machine-store.ts
@@ -1,0 +1,432 @@
+/**
+ * Time Machine store.
+ *
+ * Per-tab state for browsing persisted result history. Payloads live in the
+ * main process (better-sqlite3); this store caches run metadata for the tab's
+ * current query fingerprint plus at most two loaded snapshots (the one being
+ * viewed and, in diff mode, the older side's rows are folded into the diff).
+ *
+ * Diffs are always computed between two persisted snapshots — never against
+ * the live result — so both sides share the capture-time value normalization
+ * and timestamp cells don't spuriously light up.
+ */
+
+import { create } from 'zustand'
+import type { TimeMachineRunMeta, TimeMachineSnapshot } from '@data-peek/shared'
+import { TM_MAX_RUNS_PER_QUERY } from '@data-peek/shared'
+import type { WatchDiff } from '@/lib/watch-types'
+import type { KeyingPlan } from '@/lib/watch-row-keying'
+import { computeDiff } from '@/lib/watch-diff'
+import { recordsFromColumnar } from '@/lib/time-machine-payload'
+
+export interface TabTimeMachineState {
+  open: boolean
+  fingerprint: string | null
+  runs: TimeMachineRunMeta[]
+  /** Run being viewed; in diff mode this is the newer side. null = live result. */
+  selectedRunId: string | null
+  /** Older side of a diff; non-null implies diff mode. */
+  compareRunId: string | null
+  snapshot: TimeMachineSnapshot | null
+  diff: WatchDiff | null
+  isLoading: boolean
+  error: string | null
+}
+
+interface TimeMachineStore {
+  states: Record<string, TabTimeMachineState>
+
+  openStrip: (tabId: string) => void
+  closeStrip: (tabId: string) => void
+  /** Fetch run metadata for the tab's current SQL. Safe to call repeatedly. */
+  loadRuns: (tabId: string, connectionId: string, sql: string) => Promise<void>
+  /** View a single past run read-only. null returns to the live result. */
+  selectRun: (tabId: string, runId: string | null) => Promise<void>
+  /** Diff the given run against the currently selected one (order-insensitive). */
+  selectCompare: (tabId: string, runId: string) => Promise<void>
+  backToLive: (tabId: string) => void
+  /** Prepend a freshly captured run (called by the capture path). */
+  applyCapture: (tabId: string, meta: TimeMachineRunMeta) => void
+  deleteRun: (tabId: string, runId: string) => Promise<void>
+  /** Drop all state for a tab (tab closed). */
+  stop: (tabId: string) => void
+
+  getState: (tabId: string) => TabTimeMachineState | null
+}
+
+function makeInitialState(): TabTimeMachineState {
+  return {
+    open: true,
+    fingerprint: null,
+    runs: [],
+    selectedRunId: null,
+    compareRunId: null,
+    snapshot: null,
+    diff: null,
+    isLoading: false,
+    error: null
+  }
+}
+
+// Monotonic token per tab so a slow listRuns/getSnapshot response can't
+// clobber state written by a newer request (same idea as the executionId
+// guard on query runs).
+const loadSeq = new Map<string, number>()
+
+function nextSeq(tabId: string): number {
+  const next = (loadSeq.get(tabId) ?? 0) + 1
+  loadSeq.set(tabId, next)
+  return next
+}
+
+function isCurrentSeq(tabId: string, seq: number): boolean {
+  return loadSeq.get(tabId) === seq
+}
+
+/**
+ * Both runs must agree on an explicit key plan for a PK-keyed diff; otherwise
+ * fall back to position keying (the differ requires one plan for both sides).
+ */
+function sharedKeyingPlan(newer: TimeMachineRunMeta, older: TimeMachineRunMeta): KeyingPlan {
+  const samePlan =
+    newer.keyStrategy === older.keyStrategy &&
+    newer.keyColumns.length === older.keyColumns.length &&
+    newer.keyColumns.every((c, i) => c === older.keyColumns[i])
+  if (samePlan && newer.keyStrategy === 'primary_key') {
+    return { strategy: 'primary_key', keyColumns: newer.keyColumns }
+  }
+  return { strategy: 'row_position', keyColumns: [] }
+}
+
+async function fetchSnapshot(id: string): Promise<TimeMachineSnapshot> {
+  const response = await window.api.timeMachine.getSnapshot(id)
+  if (!response.success || !response.data) {
+    throw new Error(response.error ?? 'Failed to load snapshot')
+  }
+  return response.data
+}
+
+export const useTimeMachineStore = create<TimeMachineStore>((set, get) => ({
+  states: {},
+
+  openStrip: (tabId) => {
+    set((s) => {
+      const cur = s.states[tabId]
+      if (cur?.open) return s
+      return {
+        states: {
+          ...s.states,
+          [tabId]: cur ? { ...cur, open: true } : makeInitialState()
+        }
+      }
+    })
+  },
+
+  closeStrip: (tabId) => {
+    set((s) => {
+      const cur = s.states[tabId]
+      if (!cur || !cur.open) return s
+      // Closing the strip always returns to the live result — leaving the grid
+      // silently pinned to the past with no visible strip would be a trap.
+      return {
+        states: {
+          ...s.states,
+          [tabId]: {
+            ...cur,
+            open: false,
+            selectedRunId: null,
+            compareRunId: null,
+            snapshot: null,
+            diff: null,
+            error: null
+          }
+        }
+      }
+    })
+  },
+
+  loadRuns: async (tabId, connectionId, sql) => {
+    const seq = nextSeq(tabId)
+    set((s) => {
+      const cur = s.states[tabId]
+      if (!cur) return s
+      return { states: { ...s.states, [tabId]: { ...cur, isLoading: true, error: null } } }
+    })
+    try {
+      const response = await window.api.timeMachine.listRuns(connectionId, sql)
+      if (!isCurrentSeq(tabId, seq)) return
+      set((s) => {
+        const cur = s.states[tabId]
+        if (!cur) return s
+        if (!response.success || !response.data) {
+          return {
+            states: {
+              ...s.states,
+              [tabId]: {
+                ...cur,
+                isLoading: false,
+                error: response.error ?? 'Failed to load run history'
+              }
+            }
+          }
+        }
+        const { fingerprint, runs } = response.data
+        const selectionSurvives =
+          cur.selectedRunId !== null && runs.some((r) => r.id === cur.selectedRunId)
+        return {
+          states: {
+            ...s.states,
+            [tabId]: {
+              ...cur,
+              isLoading: false,
+              fingerprint,
+              runs,
+              selectedRunId: selectionSurvives ? cur.selectedRunId : null,
+              compareRunId: selectionSurvives ? cur.compareRunId : null,
+              snapshot: selectionSurvives ? cur.snapshot : null,
+              diff: selectionSurvives ? cur.diff : null
+            }
+          }
+        }
+      })
+    } catch (err) {
+      if (!isCurrentSeq(tabId, seq)) return
+      set((s) => {
+        const cur = s.states[tabId]
+        if (!cur) return s
+        return {
+          states: {
+            ...s.states,
+            [tabId]: {
+              ...cur,
+              isLoading: false,
+              error: err instanceof Error ? err.message : String(err)
+            }
+          }
+        }
+      })
+    }
+  },
+
+  selectRun: async (tabId, runId) => {
+    if (runId === null) {
+      get().backToLive(tabId)
+      return
+    }
+    const cur = get().states[tabId]
+    if (!cur) return
+    const run = cur.runs.find((r) => r.id === runId)
+    if (!run || !run.hasRows) return
+    const seq = nextSeq(tabId)
+    set((s) => {
+      const st = s.states[tabId]
+      if (!st) return s
+      return {
+        states: {
+          ...s.states,
+          [tabId]: { ...st, isLoading: true, error: null }
+        }
+      }
+    })
+    try {
+      const snapshot = await fetchSnapshot(runId)
+      if (!isCurrentSeq(tabId, seq)) return
+      set((s) => {
+        const st = s.states[tabId]
+        if (!st) return s
+        return {
+          states: {
+            ...s.states,
+            [tabId]: {
+              ...st,
+              isLoading: false,
+              selectedRunId: runId,
+              compareRunId: null,
+              snapshot,
+              diff: null
+            }
+          }
+        }
+      })
+    } catch (err) {
+      if (!isCurrentSeq(tabId, seq)) return
+      set((s) => {
+        const st = s.states[tabId]
+        if (!st) return s
+        return {
+          states: {
+            ...s.states,
+            [tabId]: {
+              ...st,
+              isLoading: false,
+              error: err instanceof Error ? err.message : String(err)
+            }
+          }
+        }
+      })
+    }
+  },
+
+  selectCompare: async (tabId, runId) => {
+    const cur = get().states[tabId]
+    if (!cur || cur.selectedRunId === null || runId === cur.selectedRunId) return
+    const a = cur.runs.find((r) => r.id === cur.selectedRunId)
+    const b = cur.runs.find((r) => r.id === runId)
+    if (!a || !b || !a.hasRows || !b.hasRows) return
+    const [older, newer] = a.capturedAt <= b.capturedAt ? [a, b] : [b, a]
+    const seq = nextSeq(tabId)
+    set((s) => {
+      const st = s.states[tabId]
+      if (!st) return s
+      return { states: { ...s.states, [tabId]: { ...st, isLoading: true, error: null } } }
+    })
+    try {
+      const [olderSnap, newerSnap] = await Promise.all([
+        fetchSnapshot(older.id),
+        fetchSnapshot(newer.id)
+      ])
+      if (!isCurrentSeq(tabId, seq)) return
+      const plan = sharedKeyingPlan(newer, older)
+      const diff = computeDiff({
+        previous: {
+          rows: recordsFromColumnar(olderSnap.columns, olderSnap.rows),
+          keyingPlan: plan
+        },
+        next: {
+          rows: recordsFromColumnar(newerSnap.columns, newerSnap.rows),
+          keyingPlan: plan,
+          fieldNames: newerSnap.columns.map((c) => c.name)
+        },
+        now: Date.now(),
+        carryFromPrevious: null,
+        // Diff highlights are pinned, not fading — this keeps the overlay's
+        // opacity math at ~1 without a dedicated no-fade mode.
+        fadeMs: Number.MAX_SAFE_INTEGER
+      })
+      set((s) => {
+        const st = s.states[tabId]
+        if (!st) return s
+        return {
+          states: {
+            ...s.states,
+            [tabId]: {
+              ...st,
+              isLoading: false,
+              selectedRunId: newer.id,
+              compareRunId: older.id,
+              snapshot: newerSnap,
+              diff
+            }
+          }
+        }
+      })
+    } catch (err) {
+      if (!isCurrentSeq(tabId, seq)) return
+      set((s) => {
+        const st = s.states[tabId]
+        if (!st) return s
+        return {
+          states: {
+            ...s.states,
+            [tabId]: {
+              ...st,
+              isLoading: false,
+              error: err instanceof Error ? err.message : String(err)
+            }
+          }
+        }
+      })
+    }
+  },
+
+  backToLive: (tabId) => {
+    nextSeq(tabId)
+    set((s) => {
+      const cur = s.states[tabId]
+      if (!cur) return s
+      if (cur.selectedRunId === null && !cur.isLoading && cur.error === null) return s
+      return {
+        states: {
+          ...s.states,
+          [tabId]: {
+            ...cur,
+            selectedRunId: null,
+            compareRunId: null,
+            snapshot: null,
+            diff: null,
+            isLoading: false,
+            error: null
+          }
+        }
+      }
+    })
+  },
+
+  applyCapture: (tabId, meta) => {
+    const cur = get().states[tabId]
+    if (!cur) return
+    if (cur.fingerprint === meta.fingerprint) {
+      set((s) => {
+        const st = s.states[tabId]
+        if (!st) return s
+        return {
+          states: {
+            ...s.states,
+            [tabId]: {
+              ...st,
+              runs: [meta, ...st.runs].slice(0, TM_MAX_RUNS_PER_QUERY)
+            }
+          }
+        }
+      })
+      return
+    }
+    // Different fingerprint — the SQL changed since the strip loaded. Reload
+    // the full timeline for the new query rather than showing a lone run.
+    void get().loadRuns(tabId, meta.connectionId, meta.sql)
+  },
+
+  deleteRun: async (tabId, runId) => {
+    const cur = get().states[tabId]
+    if (!cur) return
+    const wasViewing = cur.selectedRunId === runId || cur.compareRunId === runId
+    set((s) => {
+      const st = s.states[tabId]
+      if (!st) return s
+      const runs = st.runs.filter((r) => r.id !== runId)
+      if (runs.length === st.runs.length) return s
+      return {
+        states: {
+          ...s.states,
+          [tabId]: wasViewing
+            ? {
+                ...st,
+                runs,
+                selectedRunId: null,
+                compareRunId: null,
+                snapshot: null,
+                diff: null
+              }
+            : { ...st, runs }
+        }
+      }
+    })
+    try {
+      await window.api.timeMachine.deleteRun(runId)
+    } catch (err) {
+      console.error('Failed to delete Time Machine run', err)
+    }
+  },
+
+  stop: (tabId) => {
+    loadSeq.delete(tabId)
+    set((s) => {
+      if (!(tabId in s.states)) return s
+      const next = { ...s.states }
+      delete next[tabId]
+      return { states: next }
+    })
+  },
+
+  getState: (tabId) => get().states[tabId] ?? null
+}))

--- a/docs/PLAN-time-machine.md
+++ b/docs/PLAN-time-machine.md
@@ -1,0 +1,310 @@
+# Time Machine — Implementation Plan
+
+## Overview
+
+Time Machine gives every query a memory. Each successful SELECT run in a query tab is
+snapshotted to local disk. A timeline strip above the results grid lets you scrub back through
+past runs, view any old result read-only, diff any two runs at cell level, and inspect a single
+row's values across time.
+
+The pitch: you run the same query all day — checking a migration, watching a job table,
+verifying a fix. Today each run overwrites the last and the previous state is gone. Time Machine
+answers "what did this look like an hour ago?", "what changed since I last ran this?", and "when
+did this row's status flip?" without you having to set anything up. Watch Mode shows you *live*
+change; Time Machine shows you *history*.
+
+No SQL client has this. DataGrip and DBeaver keep query text history; nobody keeps *result*
+history. It composes with everything already shipped: the Watch Mode differ and row keying do
+the diffing, the sparkline renders the row-count trend, and the notebook's better-sqlite3
+storage pattern holds the payloads.
+
+## Scope
+
+In scope:
+
+- Auto-capture on every successful manual run in a query tab, when the query is a
+  single-statement pure SELECT (same gate as Watch Mode)
+- Timeline strip above the grid: one chip per past run (relative time, row count, duration),
+  row-count sparkline, oldest → newest, "Live" pinned at the right
+- View any past run read-only in the existing grid, with a clear "viewing the past" banner
+- Diff any two runs: cell-level highlights via the Watch decoration overlay + summary counts
+- Row history: pick a row, see its values across the last runs (PK-keyed)
+- Retention: per-query run cap, per-snapshot row/byte caps, global disk budget, oldest-first
+  eviction, incremental vacuum
+- Privacy: masked columns are redacted *before* rows leave the renderer; global enable toggle +
+  storage usage + "Delete all snapshots" in Settings
+- `⌘⇧H` toggle (menu accelerator), command palette entry
+
+Out of scope (MVP cuts):
+
+- Capturing watch ticks, notebook cells, AI-assistant runs, table-preview tabs (page flips share
+  a fingerprint and would churn the timeline), or main-process scheduler/dashboard runs
+- Diffing a snapshot against the *live* unsaved result (value normalization differs; the latest
+  run is itself a snapshot, so "diff vs previous" already covers the real use)
+- Rendering removed rows inline in the diff grid (counted in the summary, same trade Watch made)
+- Cross-connection timelines (two saved connections to the same physical DB keep separate
+  timelines — keyed by connection id)
+- Compression, payload dedup between identical runs, export of snapshots
+
+## Design decisions (and why)
+
+1. **Capture in the renderer, at `executeSql`'s success path** (`tab-query-editor.tsx`), not in
+   the main-process `db:query` handlers. The handler funnel also carries watch ticks (up to
+   4/sec), notebook cells, AI runs, editable-grid refreshes and COUNT queries — all noise. The
+   renderer hook fires only for user-initiated runs, already sits behind the stale-execution
+   guard, and has three things main never has: the user's typed SQL (pre cross-tab expansion),
+   the masking state, and the schema-derived PK keying plan.
+2. **Fingerprint is the full normalized-SQL string, not the 32-bit hash.** `hashFingerprint` is
+   a Java-style 31-bit hash — collisions would silently merge two queries' histories. The main
+   process computes `fingerprintQuery(sql)` (already normalizes literals, so `WHERE id = 1` and
+   `WHERE id = 2` share a timeline — desired) and keys runs by
+   `(connection_id, fingerprint TEXT)`. The renderer treats the fingerprint as opaque; it always
+   sends raw SQL and lets main normalize, so `query-fingerprint.ts` stays in main.
+3. **Values are normalized once, at capture.** pg returns `Date` for timestamptz, `Buffer` for
+   bytea, strings for numerics. JSON round-tripping would make a rehydrated snapshot disagree
+   with a live one on every timestamp cell. Rule: snapshots are only ever diffed against other
+   snapshots, and `normalizeValue` maps Date → ISO string, bigint → string, undefined → null,
+   Uint8Array → `\x…` hex preview capped at 256 bytes. Deterministic on both sides of any diff.
+4. **Columnar payload** (`unknown[][]` + column names once), the `PinnedResult` precedent —
+   30–50% smaller than repeating keys per row.
+5. **Redact before IPC.** Masking is renderer state and display-only; disk is neither. At
+   capture, `getEffectiveMaskedColumns(tabId, columnNames)` is evaluated and masked columns are
+   stored as the literal `'[MASKED]'` (the export precedent). Masked-in-both cells therefore
+   diff as unchanged.
+6. **Enabled by default, with the redaction above + a visible off switch.** Query history
+   already persists SQL text (with inline literals) by default; snapshots add result data, which
+   is why masked columns never reach disk and Settings shows usage + a wipe button. Flagged in
+   the handoff for review.
+7. **Storage is a new `time-machine.db`** (better-sqlite3, WAL, `auto_vacuum = INCREMENTAL`
+   set at creation), not notebooks.db — independent lifecycle, wipeable without touching
+   notebooks. Construction failure degrades to null and the handler group is skipped
+   (issue #174 pattern).
+
+## Data model
+
+SQLite, `userData/time-machine.db`:
+
+```sql
+CREATE TABLE IF NOT EXISTS runs (
+  id TEXT PRIMARY KEY,
+  connection_id TEXT NOT NULL,
+  fingerprint TEXT NOT NULL,
+  sql TEXT NOT NULL,               -- user's typed SQL as of this run
+  captured_at INTEGER NOT NULL,    -- epoch ms
+  duration_ms INTEGER NOT NULL,
+  row_count INTEGER NOT NULL,      -- true row count of the run
+  stored_row_count INTEGER NOT NULL,
+  truncated INTEGER NOT NULL DEFAULT 0,
+  content_hash TEXT NOT NULL,      -- hash of payload; equal hash = "no change" chip
+  key_strategy TEXT NOT NULL,      -- 'primary_key' | 'row_position'
+  key_columns TEXT NOT NULL,       -- JSON string[]
+  columns TEXT NOT NULL,           -- JSON {name,dataType}[]
+  rows TEXT,                       -- JSON unknown[][] (columnar); NULL if over byte cap
+  payload_bytes INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_runs_conn_fp_at
+  ON runs (connection_id, fingerprint, captured_at DESC);
+```
+
+Caps (constants in `packages/shared`):
+
+| Constant | Value | Enforced |
+|---|---|---|
+| `TM_MAX_SNAPSHOT_ROWS` | 2000 | renderer, at capture (`truncated` flag set) |
+| `TM_MAX_SNAPSHOT_PAYLOAD_BYTES` | 6 MB | main, on insert — over cap stores metadata only (`rows = NULL`) |
+| `TM_MAX_RUNS_PER_QUERY` | 50 | main, on insert — oldest rows for that (conn, fp) deleted |
+| `TM_GLOBAL_BUDGET_BYTES` | 512 MB | main, on insert — oldest rows globally deleted until under |
+
+`PRAGMA incremental_vacuum` runs after any eviction/clear so the file actually shrinks.
+
+## Shared types (`packages/shared/src/index.ts`)
+
+```typescript
+export interface TimeMachineRunMeta {
+  id: string
+  connectionId: string
+  fingerprint: string
+  sql: string
+  capturedAt: number
+  durationMs: number
+  rowCount: number
+  storedRowCount: number
+  truncated: boolean
+  contentHash: string
+  keyStrategy: 'primary_key' | 'row_position'
+  keyColumns: string[]
+  hasRows: boolean
+}
+
+export interface TimeMachineSnapshot extends TimeMachineRunMeta {
+  columns: { name: string; dataType: string }[]
+  rows: unknown[][]
+}
+
+export interface TimeMachineCapturePayload {
+  connectionId: string
+  sql: string
+  capturedAt: number
+  durationMs: number
+  rowCount: number
+  truncated: boolean
+  keyStrategy: 'primary_key' | 'row_position'
+  keyColumns: string[]
+  columns: { name: string; dataType: string }[]
+  rows: unknown[][]           // normalized + redacted, capped at TM_MAX_SNAPSHOT_ROWS
+}
+
+export interface TimeMachineStats {
+  runCount: number
+  queryCount: number          // distinct (connection, fingerprint) pairs
+  totalBytes: number
+  oldestCapturedAt: number | null
+}
+```
+
+## IPC contract
+
+Channels `time-machine:*`, namespace `window.api.timeMachine`:
+
+| Method | Channel | Notes |
+|---|---|---|
+| `capture(payload)` | `time-machine:capture` | main fingerprints `payload.sql`, hashes content, inserts, enforces caps; returns `TimeMachineRunMeta` |
+| `listRuns(connectionId, sql)` | `time-machine:list-runs` | main fingerprints `sql`; returns `{ fingerprint, runs: TimeMachineRunMeta[] }` newest-first, no payloads |
+| `getSnapshot(id)` | `time-machine:get-snapshot` | full payload; error if `rows` is NULL (metadata-only run) |
+| `deleteRun(id)` | `time-machine:delete-run` | |
+| `clearQuery(connectionId, sql)` | `time-machine:clear-query` | wipe one timeline |
+| `clearAll(connectionId?)` | `time-machine:clear-all` | all, or one connection |
+| `stats()` | `time-machine:stats` | for Settings |
+
+All return `IpcResponse<T>`; handlers follow the inline try/catch envelope style. Handler group
+registered as `registerTimeMachineHandlers(storage: TimeMachineStorage | null)` — skipped with a
+log.warn when storage failed to construct.
+
+## Phases
+
+### Phase 1 — shared types + constants
+`packages/shared/src/index.ts`: types above + the four `TM_*` constants.
+
+### Phase 2 — main: `TimeMachineStorage`
+`apps/desktop/src/main/time-machine-storage.ts`, modeled line-for-line on `NotebookStorage`:
+constructor takes `userDataPath`, opens `time-machine.db`, sets WAL + `auto_vacuum`, idempotent
+DDL in `init()`. Methods: `insertRun(payload, fingerprint)` (single transaction: insert +
+per-query cap + global budget eviction + vacuum), `listRuns`, `getSnapshot`, `deleteRun`,
+`clearQuery`, `clearAll`, `stats`, `close`. Content hash: sha256 of the serialized payload
+(node:crypto). Tests against a temp dir cover caps, eviction order, metadata-only storage,
+and the vacuum call.
+
+### Phase 3 — main: handlers + wiring
+`apps/desktop/src/main/ipc/time-machine-handlers.ts` + wiring in `ipc/index.ts`
+(`registerAllHandlers` gains a `timeMachineStorage: TimeMachineStorage | null` param) and
+`main/index.ts` (try/catch construction next to NotebookStorage). Fingerprinting via existing
+`main/lib/query-fingerprint.ts` `fingerprintQuery` (not the weak hash).
+
+### Phase 4 — preload
+`preload/index.ts` `timeMachine` block + hand-maintained `preload/index.d.ts` in lockstep, plus
+`menu.onToggleTimeMachine`.
+
+### Phase 5 — renderer lib: capture
+`apps/desktop/src/renderer/src/lib/time-machine-capture.ts`:
+
+- `normalizeValue(v): unknown` — the canonical serialization (decision 3)
+- `toColumnarRows(rows, columnNames, maskedColumns): unknown[][]` — normalize + redact + columnar
+- `recordsFromColumnar(columns, rows): Record<string, unknown>[]` — inverse, for the grid/differ
+- `buildCapturePayload({...}): TimeMachineCapturePayload | null` — returns null unless: setting
+  enabled, tab is a query tab, `gateForWatch(sql).ok`, exactly one data-returning statement.
+  Row cap applied here.
+- `captureRun(...)` — fire-and-forget `window.api.timeMachine.capture`, then
+  `useTimeMachineStore.getState().applyCapture(tabId, meta)`
+- `ensureTimeMachineTabListener()` — the watch-scheduler tab-close cleanup pattern, verbatim
+
+Hook: in `tab-query-editor.tsx` `executeSql`, inside the existing `isStillCurrent()` success
+block, after `addToHistory`. Key columns reuse the existing watch key-column derivation.
+
+### Phase 6 — renderer store
+`apps/desktop/src/renderer/src/stores/time-machine-store.ts`, watch-store shape
+(`states: Record<tabId, TabTimeMachineState>`, plain zustand, identity-preserving no-ops):
+
+```typescript
+interface TabTimeMachineState {
+  open: boolean
+  fingerprint: string | null
+  runs: TimeMachineRunMeta[]        // newest-first
+  selectedRunId: string | null      // null = live
+  compareRunId: string | null      // non-null => diff mode (older side)
+  snapshot: TimeMachineSnapshot | null
+  diff: WatchDiff | null
+  isLoading: boolean
+  error: string | null
+}
+```
+
+Actions: `toggleStrip`, `loadRuns` (calls `listRuns` with the tab's current SQL), `selectRun`
+(fetch snapshot → view mode), `selectCompare` (fetch both → `computeDiff` with a shared keying
+plan: the newer run's plan if both runs' `keyColumns` match, else `row_position`; `fadeMs:
+Number.MAX_SAFE_INTEGER`, `carryFromPrevious: null`), `backToLive`, `applyCapture` (prepend when
+fingerprint matches), `deleteRun`, `stop(tabId)`.
+
+### Phase 7 — UI
+- `components/time-machine/time-machine-button.tsx` — toolbar button (History icon, run-count
+  badge), wired via a new `timeMachineSlot` on `EditorToolbar` next to `watchSlot`
+- `components/time-machine/time-machine-strip.tsx` — mounts in `query-results.tsx` between the
+  multi-statement strip and the grid. `WatchSparkline` (metas → `WatchMetricPoint`) + chip rail,
+  oldest → newest, auto-scrolled right, "Live" chip pinned. Click = view; ⌥-click or a per-chip
+  "compare" affordance = diff vs selected. Dimmed chips for `contentHash === previous` (no
+  change); dot marker for truncated/metadata-only runs.
+- Snapshot view: in `query-results.tsx`, when a snapshot is selected render a banner (run time,
+  row count, truncation notice, "Back to live") + read-only `DataTable` fed
+  `recordsFromColumnar(...)` — bypasses the editable branch entirely.
+- Diff view: newer run's rows in read-only `DataTable` + `WatchDecorationOverlay` with the
+  computed diff; summary line "+A added · −R removed · C cells changed" in the banner.
+- Row history: `components/time-machine/row-history-dialog.tsx` — walks the last ≤10 runs with
+  payloads, `deriveRowKey` per run, renders column → value-per-run table (changed values
+  accented). Entry points: `RowContextMenu` (non-virtualized) and a History action on the cell
+  inspector (both grids, optional prop).
+
+### Phase 8 — shortcut, palette, settings, docs
+- `menu.ts`: `CmdOrCtrl+Shift+H` "Toggle Time Machine" in the Query menu →
+  `menu:toggle-time-machine`; subscription in `tab-query-editor.tsx` (watch pattern)
+- Palette `CommandItem` (keywords: history, snapshot, timeline, diff)
+- Settings: `timeMachineEnabled` in `AppSettings` (default true) + Time Machine section in
+  `settings-modal.tsx` (toggle, storage usage via `stats()`, "Delete all snapshots")
+- Four shortcut display surfaces: menu label, `docs/keyboard-shortcuts.md`, Settings
+  ShortcutRow list, palette hint
+- `README.md` feature bullet, `notes/time-machine.mdx` blog draft (`published: false`),
+  roadmap touch
+
+## Testing
+
+Vitest, following existing suite layout:
+
+- `main/__tests__/time-machine-storage.test.ts` — insert/list/get, per-query cap, global budget
+  eviction order, metadata-only over-byte-cap runs, clearQuery/clearAll/stats, temp-dir DB
+- `main/__tests__/time-machine-handlers.test.ts` — envelope contract, null-storage degrade
+- `renderer/src/lib/__tests__/time-machine-capture.test.ts` — gating matrix (setting off,
+  multi-statement, non-SELECT, table-preview), normalization (Date/bigint/Uint8Array/undefined),
+  redaction, columnar round-trip, row cap
+- `renderer/src/stores/__tests__/time-machine-store.test.ts` — lifecycle, view/compare
+  transitions, keying-plan agreement fallback, applyCapture fingerprint mismatch, tab-close stop
+- Integration-ish: two persisted payloads → `recordsFromColumnar` → `computeDiff` produces
+  expected added/removed/changed sets (Date-normalization regression case included)
+
+Existing 619 tests must stay green; `pnpm typecheck` (node + web) and electron-vite build clean.
+
+## Risks / edge cases handled
+
+- **SQL edited between runs** → new fingerprint → `listRuns` returns the new (possibly empty)
+  timeline; strip re-syncs on every load. Old timeline still on disk under the old fingerprint.
+- **Connection switched on the tab** → runs keyed by connection id; strip reloads.
+- **Stale execution** → capture sits inside the existing `isStillCurrent()` guard.
+- **Duplicate row keys / all-null keys** → `deriveRowKey` fallback behavior inherited from
+  Watch; keying strategy shown in the diff banner ("diffs by position") when not PK-keyed.
+- **Metadata-only runs** (over byte cap) → chip renders with a marker; view/diff disabled with
+  a tooltip.
+- **better-sqlite3 load failure** → storage null, handlers skipped, button hidden (probe via
+  `stats()` failure), app unaffected.
+- **Multi-window** → handlers are window-agnostic; timelines keyed by (connection, fingerprint)
+  are naturally shared; per-window strips just read the same store.
+
+## Estimated size
+
+~2,300 LoC including tests. Comparable to the Watch Mode MVP night.

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -1,0 +1,286 @@
+# Keyboard Shortcuts
+
+data-peek is designed for keyboard-first workflows. This guide covers all available shortcuts to help you work faster without reaching for your mouse.
+
+> **Note:** On macOS, use `Cmd` (⌘). On Windows/Linux, use `Ctrl`.
+
+---
+
+## Quick Reference
+
+### Most Used Shortcuts
+
+| Shortcut | Action |
+|----------|--------|
+| `Cmd/Ctrl + Enter` | Execute current query |
+| `↑` `↓` `←` `→` | Move between result cells |
+| `Enter` | Open the focused cell's inspector |
+| `Cmd/Ctrl + C` | Copy the focused cell |
+| `Cmd/Ctrl + S` | Save pending changes (in edit mode) |
+| `Cmd/Ctrl + K` | Open command palette |
+| `Cmd/Ctrl + T` | New query tab |
+| `Cmd/Ctrl + W` | Close current tab |
+| `Escape` | Close inspector / Exit edit mode / Cancel |
+
+---
+
+## Tab Management
+
+Navigate and manage query tabs without using the mouse.
+
+| Shortcut | Action |
+|----------|--------|
+| `Cmd/Ctrl + T` | Create new query tab |
+| `Cmd/Ctrl + W` | Close current tab |
+| `Cmd/Ctrl + 1-9` | Switch to tab 1-9 |
+| `Cmd/Ctrl + Alt + →` | Switch to next tab |
+| `Cmd/Ctrl + Alt + ←` | Switch to previous tab |
+
+---
+
+## Connection Management
+
+Quickly switch between database connections.
+
+| Shortcut | Action |
+|----------|--------|
+| `Cmd/Ctrl + P` | Open connection picker |
+| `Cmd/Ctrl + Shift + 1-9` | Switch to connection 1-9 |
+
+**Tip:** Connections are numbered in the order they appear in your sidebar.
+
+---
+
+## Query Editor
+
+Execute, format, and manage your SQL queries.
+
+| Shortcut | Action |
+|----------|--------|
+| `Cmd/Ctrl + Enter` | Execute current query |
+| `Shift + Alt + F` | Format SQL query |
+| `Cmd/Ctrl + K` | Clear query results |
+| `Cmd/Ctrl + Shift + W` | Toggle Watch Mode |
+| `Cmd/Ctrl + Shift + H` | Toggle Time Machine run history |
+
+### Monaco Editor Shortcuts
+
+The query editor uses Monaco (the VS Code editor), so standard editor shortcuts work:
+
+| Shortcut | Action |
+|----------|--------|
+| `Cmd/Ctrl + Z` | Undo |
+| `Cmd/Ctrl + Shift + Z` | Redo |
+| `Cmd/Ctrl + C` | Copy |
+| `Cmd/Ctrl + V` | Paste |
+| `Cmd/Ctrl + A` | Select all |
+| `Cmd/Ctrl + F` | Find in editor |
+| `Cmd/Ctrl + D` | Select next occurrence |
+| `Alt + Up/Down` | Move line up/down |
+| `Cmd/Ctrl + /` | Toggle line comment |
+
+---
+
+## Result Grid
+
+Navigate query results entirely from the keyboard. The grid activates when virtualization kicks in (result row count > 50); smaller results use native browser focus.
+
+### Cell Navigation
+
+| Shortcut | Action |
+|----------|--------|
+| `↑` `↓` `←` `→` | Move focus between cells |
+| `Home` | First cell in the current row |
+| `End` | Last cell in the current row |
+| `Cmd/Ctrl + Home` | First cell of the result |
+| `Cmd/Ctrl + End` | Last cell of the result |
+| `PageUp` / `PageDown` | Jump 20 rows |
+| `Click` | Focus the clicked cell |
+
+### Cell Inspector
+
+Press `Enter` on a focused cell to open the inspector. It shows the full untruncated value, column type, char/byte counts, and a follow-foreign-key action when available.
+
+| Shortcut | Action |
+|----------|--------|
+| `Enter` | Open the inspector for the focused cell |
+| `↑` `↓` `←` `→` | Scrub between cells while the inspector is open |
+| `Cmd/Ctrl + C` | Copy the focused cell's value |
+| `Escape` | Close the inspector and return focus to the grid |
+
+---
+
+## Data Editing
+
+Edit table data efficiently with keyboard shortcuts.
+
+| Shortcut | Action | When Available |
+|----------|--------|----------------|
+| `Cmd/Ctrl + S` | Save all pending changes | Edit mode with unsaved changes |
+| `Cmd/Ctrl + Shift + Z` | Discard all changes | Edit mode with unsaved changes |
+| `Cmd/Ctrl + Shift + I` | Add new row (with form) | Viewing an editable table |
+| `Escape` | Exit edit mode | Edit mode (not editing a cell) |
+
+### Cell Editing
+
+| Shortcut | Action |
+|----------|--------|
+| `Click` | Start editing a cell (enters edit mode) |
+| `Enter` | Save cell and move to next row |
+| `Tab` | Save cell and move to next column |
+| `Escape` | Cancel cell edit |
+
+### Foreign Key Navigation
+
+| Shortcut | Action |
+|----------|--------|
+| `Click` on FK value | Open related record in side panel |
+| `Cmd/Ctrl + Click` on FK value | Open related record in new tab |
+
+---
+
+## Sidebar & Navigation
+
+| Shortcut | Action |
+|----------|--------|
+| `Cmd/Ctrl + B` | Toggle sidebar visibility |
+| `Cmd/Ctrl + K` | Open command palette |
+
+---
+
+## AI Assistant
+
+| Shortcut | Action |
+|----------|--------|
+| `Cmd/Ctrl + I` | Toggle AI assistant panel |
+
+---
+
+## View Menu
+
+| Shortcut | Action |
+|----------|--------|
+| `Cmd/Ctrl + Shift + S` | Open saved queries |
+
+---
+
+## Command Palette
+
+The command palette (`Cmd/Ctrl + K`) provides quick access to all commands:
+
+| Action | How to Access |
+|--------|---------------|
+| Execute query | Type "execute" or "run" |
+| Format SQL | Type "format" |
+| Switch connection | Type connection name |
+| Change theme | Type "theme" |
+| Open settings | Type "settings" |
+
+**Navigation:**
+- `↑` / `↓` - Navigate commands
+- `Enter` - Execute selected command
+- `Escape` - Close palette
+- `Backspace` - Go back (when search is empty)
+
+---
+
+## Dashboard Mode
+
+When viewing a dashboard, single-key shortcuts work (without modifiers):
+
+| Key | Action |
+|-----|--------|
+| `R` | Refresh all widgets |
+| `E` | Toggle edit mode |
+| `N` or `A` | Add new widget |
+| `Escape` | Exit edit mode |
+
+---
+
+## Settings
+
+To view all keyboard shortcuts within the app:
+
+1. Open **Settings** (`Cmd/Ctrl + ,` or via menu)
+2. Scroll to **Keyboard Shortcuts** section
+
+---
+
+## Tips for Mouseless Workflow
+
+### 1. Use the Command Palette
+
+`Cmd/Ctrl + K` is your best friend. It provides fuzzy search access to:
+- All commands
+- Connections
+- Saved queries
+- Theme switching
+- Settings
+
+### 2. Tab Navigation Pattern
+
+A typical workflow:
+1. `Cmd/Ctrl + T` - New tab
+2. Type your query
+3. `Cmd/Ctrl + Enter` - Execute
+4. Review results
+5. `Cmd/Ctrl + W` - Close tab when done
+
+### 3. Data Editing Pattern
+
+1. Click a table in the sidebar
+2. Click any cell to enter edit mode
+3. Make your changes (arrow keys, Tab, Enter)
+4. `Cmd/Ctrl + S` - Save all changes
+5. `Escape` - Exit edit mode
+
+### 4. Connection Switching
+
+For projects with multiple databases:
+- Use `Cmd/Ctrl + Shift + 1-9` for quick switching
+- Or `Cmd/Ctrl + P` to search connections by name
+
+---
+
+## Platform-Specific Notes
+
+### macOS
+
+- Uses `Cmd` (⌘) as the primary modifier
+- `Ctrl` key is reserved for system shortcuts
+- `Option` (⌥) used for alternate actions
+
+### Windows / Linux
+
+- Uses `Ctrl` as the primary modifier
+- `Alt` used for alternate actions
+- Window management shortcuts may conflict with system shortcuts
+
+---
+
+## Customizing Shortcuts
+
+Currently, keyboard shortcuts are not customizable. This feature is planned for a future release.
+
+If you have specific shortcut requests, please [open an issue](https://github.com/Rohithgilla12/data-peek/issues).
+
+---
+
+## Troubleshooting
+
+### Shortcuts Not Working?
+
+1. **Check focus** - Make sure data-peek is the active window
+2. **Check context** - Some shortcuts only work in specific contexts (e.g., edit mode)
+3. **Check for conflicts** - Other apps or system shortcuts may intercept keys
+4. **Check the menu bar** - The menu shows available shortcuts and their current state
+
+### Monaco Editor Shortcuts Conflicting?
+
+The SQL editor (Monaco) has its own shortcuts that take priority when the editor is focused. If you need to trigger an app shortcut while editing:
+1. Click outside the editor first
+2. Or use the menu bar
+
+---
+
+*Last updated: January 2026*

--- a/notes/time-machine.mdx
+++ b/notes/time-machine.mdx
@@ -1,0 +1,79 @@
+---
+title: "Time Machine — every query gets a memory"
+description: "data-peek now snapshots every successful SELECT locally. Scrub back through past runs on a timeline, view any old result read-only, and diff any two runs at cell level. Cmd+Shift+H. Masked columns stay redacted on disk, storage is capped, and one click wipes it all."
+date: "2026-07-02"
+author: "Rohith Gilla"
+tags: ["release-notes", "feature", "history", "diff", "postgres", "mysql"]
+published: false
+---
+
+You run the same query all day. Checking a migration, watching a job
+table, verifying a fix — the SQL barely changes, the *data* does. And
+every SQL client on earth treats each run as a fresh start: the moment
+results land, the previous state is gone. "Wait, what did this look
+like an hour ago?" has no answer. You either screenshotted it or you
+didn't.
+
+Time Machine is the answer. data-peek now snapshots the result of every
+successful `SELECT` you run in a query tab — automatically, locally, no
+setup. Press `⌘⇧H` and a timeline strip appears above the grid: one
+chip per run, oldest to newest, with a row-count sparkline. Click a
+chip and the grid shows *that* result, read-only, with a banner so you
+always know you're looking at the past. Click **Live** and you're back.
+
+## Diff any two runs
+
+Viewing history is half of it. Select a run, then ⌥-click another and
+data-peek diffs them cell by cell — the same differ that powers Watch
+Mode, so the semantics match: changed cells highlight amber with the
+old value a hover away, added rows band green, and the banner counts
+what moved: `+6 added · −2 removed · 14 cells changed`.
+
+Rows are keyed the way Watch Mode keys them: by the table's primary key
+when your query selects from one table, then a heuristic
+`id`/`uuid`/`*_id` column, then row position as a last resort. The
+banner tells you which strategy was used, because a position-keyed diff
+after an `ORDER BY` change is a different claim than a PK-keyed one.
+
+## Watch Mode shows you now. Time Machine shows you then.
+
+The two compose. Watch Mode is live — it polls and flashes as data
+moves, holding six snapshots in memory. Time Machine is durable — every
+manual run lands on disk and survives restarts. Run a query before
+kicking off a migration, run it after, diff the two. That's a
+before/after audit you previously needed a scratch file and discipline
+for.
+
+## The boring parts, done properly
+
+Persisting query results to disk is the kind of feature that goes wrong
+quietly, so the guardrails are the feature:
+
+- **Masked columns never reach disk.** If a column matches your
+  data-masking rules (email, password, token, ssn out of the box), the
+  snapshot stores `[MASKED]` — redaction happens before the rows leave
+  the renderer, not at display time.
+- **Storage is capped, not open-ended.** 2,000 rows per snapshot, 50
+  runs per query, 512 MB global budget with oldest-first eviction, and
+  the database vacuums itself after cleanup.
+- **Only deliberate runs are captured.** Single-statement pure SELECTs
+  from query tabs. Watch ticks, notebook cells, AI-assistant runs, and
+  table-preview page flips never pollute the timeline.
+- **One switch, one wipe.** Settings → Time Machine: turn capture off,
+  see exactly how much disk history is using, delete all of it with two
+  clicks.
+
+## Under the hood
+
+Snapshots live in a dedicated SQLite database in your app data
+directory, columnar-encoded to skip repeating column names per row.
+Runs are grouped by a normalized fingerprint of the SQL — literals are
+stripped, so `WHERE id = 1` and `WHERE id = 2` share a timeline, which
+is what you want when you're poking at different rows of the same
+question. Values are normalized once at capture (timestamps to ISO,
+binary to hex previews) so a diff between two snapshots never lies
+about a timestamp cell because of serialization drift.
+
+`⌘⇧H` to try it. It's been running on every query I've made this week,
+and the first time you catch a row changing between two runs you didn't
+plan to compare, it clicks.

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -2483,3 +2483,65 @@ export {
   STEP_SESSION_CLEANUP_INTERVAL_MS,
   DDL_KEYWORD_REGEX
 } from './step-types'
+
+/**
+ * Time Machine — persisted result-history for query tabs.
+ *
+ * Runs are keyed by (connectionId, fingerprint) where the fingerprint is the FULL
+ * normalized-SQL string produced main-side by fingerprintQuery — never the 32-bit
+ * hashFingerprint, whose collisions would silently merge two queries' histories.
+ * Timestamps are epoch ms so they survive JSON/IPC. Row payloads are columnar
+ * (unknown[][] with column metadata stored once), values pre-normalized at capture:
+ * Date → ISO string, bigint → string, undefined → null, binary → capped hex preview.
+ */
+export interface TimeMachineRunMeta {
+  id: string
+  connectionId: string
+  fingerprint: string
+  sql: string
+  capturedAt: number
+  durationMs: number
+  rowCount: number
+  storedRowCount: number
+  truncated: boolean
+  contentHash: string
+  keyStrategy: 'primary_key' | 'row_position'
+  keyColumns: string[]
+  /** False when the payload exceeded TM_MAX_SNAPSHOT_PAYLOAD_BYTES and only metadata was kept. */
+  hasRows: boolean
+}
+
+export interface TimeMachineSnapshot extends TimeMachineRunMeta {
+  columns: { name: string; dataType: string }[]
+  rows: unknown[][]
+}
+
+export interface TimeMachineCapturePayload {
+  connectionId: string
+  sql: string
+  capturedAt: number
+  durationMs: number
+  rowCount: number
+  truncated: boolean
+  keyStrategy: 'primary_key' | 'row_position'
+  keyColumns: string[]
+  columns: { name: string; dataType: string }[]
+  rows: unknown[][]
+}
+
+export interface TimeMachineListResult {
+  fingerprint: string
+  runs: TimeMachineRunMeta[]
+}
+
+export interface TimeMachineStats {
+  runCount: number
+  queryCount: number
+  totalBytes: number
+  oldestCapturedAt: number | null
+}
+
+export const TM_MAX_SNAPSHOT_ROWS = 2000
+export const TM_MAX_SNAPSHOT_PAYLOAD_BYTES = 6 * 1024 * 1024
+export const TM_MAX_RUNS_PER_QUERY = 50
+export const TM_GLOBAL_BUDGET_BYTES = 512 * 1024 * 1024


### PR DESCRIPTION
## What

**Time Machine** gives every query a memory. Each successful single-statement SELECT in a query tab is snapshotted to local disk. A timeline strip above the results grid (`⌘⇧H`) scrubs back through past runs, loads any old result read-only, and diffs any two runs at cell level.

Design doc: `docs/PLAN-time-machine.md`. Blog draft: `notes/time-machine.mdx` (`published: false`).

## How it works

- **Capture** hooks the manual-run success path in `tab-query-editor` — watch ticks, notebook cells, AI runs, and table-preview page flips are excluded by construction. Gate: single-statement pure SELECT (`gateForWatch`).
- **Values normalized once at capture** (Date→ISO, bigint→string, binary→hex preview, NaN/Infinity→strings) so persisted-vs-persisted diffs never lie about timestamp cells.
- **Privacy**: masked columns are stored as `[MASKED]` — redaction happens before rows cross IPC. Storage is capped (2000 rows/snapshot, 6 MB payload, 50 runs/query, 512 MB global, oldest-first eviction, incremental vacuum, WAL truncated on quit). Settings has a toggle + usage + wipe.
- **Storage**: new `time-machine.db` (better-sqlite3, NotebookStorage pattern, null-degrade on native-module failure). Runs keyed by `(connectionId, fingerprintQuery(sql))` — the full normalized string, not the weak 32-bit hash.
- **Diff** reuses `computeDiff`/`pickKeyingPlan`/`WatchDecorationOverlay`; `DataTable` gains a `diffOverlay` prop with inline cell tints for small non-virtualized results (a case Watch Mode doesn't cover).

## Testing

- 81 new tests (storage caps/eviction, handlers, capture gating matrix, normalization, store lifecycle/races, diff integration) — 968 pass total
- sqlite storage tests run under the Electron ABI: `ELECTRON_RUN_AS_NODE=1 electron node_modules/vitest/vitest.mjs run src/main/__tests__/time-machine-storage.test.ts` (auto-skip under plain node)
- `pnpm typecheck` (node+web) and `pnpm build` clean
- Multi-dimension adversarial review ran; confirmed findings fixed (phantom byte accounting in the global budget, clock-skew eviction of the just-inserted run, fresh results hidden behind a viewed snapshot, settings-toggle gating, WAL checkpoint on quit)

## Known limitations (deliberate MVP cuts)

- Masking is capture-time only; rules added later don't retro-redact (wipe + re-run)
- Selection runs capture under the selection's fingerprint; the strip lists by full editor text
- Per-row history dialog cut — the differ already stores `previousValue` per cell, natural follow-up
- Position-keyed diffs + client sorting can misplace highlights (same trade as Watch Mode)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Time Machine** experience for browsing successful query snapshots, viewing read-only past runs, and comparing runs with cell-level diffs.
  * Added a Time Machine toggle across the app (toolbar, command palette, menu, and keyboard shortcuts) plus per-tab UI controls.
  * Added Time Machine settings to enable/disable, show storage usage, and wipe saved snapshots; snapshot retention and storage caps protect privacy and disk space.
* **Bug Fixes**
  * Improved resilience when snapshot storage is unavailable so the app keeps functioning normally.
* **Documentation**
  * Updated README and added dedicated Time Machine release notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->