### PR TITLE
fix(time-machine): store the user's SQL, not the fingerprint, in the sql column

### DIFF
--- a/apps/desktop/src/main/__tests__/time-machine-storage.test.ts
+++ b/apps/desktop/src/main/__tests__/time-machine-storage.test.ts
@@ -85,7 +85,8 @@ describe.skipIf(!sqliteAvailable)('TimeMachineStorage', () => {
       expect(meta.id).toBeDefined()
       expect(meta.connectionId).toBe('conn-1')
       expect(meta.fingerprint).toBe('fp-1')
-      expect(meta.sql).toBe('fp-1')
+      // The user's typed SQL, not the fingerprint — the timeline displays this.
+      expect(meta.sql).toBe('SELECT * FROM users WHERE id = 1')
       expect(meta.capturedAt).toBe(1000)
       expect(meta.durationMs).toBe(12)
       expect(meta.rowCount).toBe(2)

--- a/apps/desktop/src/main/time-machine-storage.ts
+++ b/apps/desktop/src/main/time-machine-storage.ts
@@ -147,7 +147,7 @@ export class TimeMachineStorage {
           id,
           payload.connectionId,
           fingerprint,
-          fingerprint,
+          payload.sql,
           payload.capturedAt,
           payload.durationMs,
           payload.rowCount,


### PR DESCRIPTION
The INSERT passed fingerprint twice, so the timeline displayed normalized
SQL instead of the typed query. The test had baked in the same mistake —
it now asserts the round-trip. Caught pre-release; slipped CI because the
sqlite tests skip under plain node.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed saved run details so the stored SQL text now matches the original query entered by the user.
  * Corrected run history data to display the expected query content instead of an abbreviated identifier.
  * Updated coverage to confirm the saved run metadata preserves the full SQL statement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->