### PR TITLE
feat: manual transaction mode for PostgreSQL

### DIFF
--- a/apps/desktop/src/main/adapters/pg-pool-manager.ts
+++ b/apps/desktop/src/main/adapters/pg-pool-manager.ts
@@ -93,7 +93,7 @@ async function createPoolEntry(config: ConnectionConfig, key: string): Promise<P
   }
 }
 
-async function getOrCreatePool(config: ConnectionConfig): Promise<PoolEntry> {
+export async function getOrCreatePool(config: ConnectionConfig): Promise<PoolEntry> {
   if (shuttingDown) {
     throw new Error('Pool manager is shutting down')
   }

--- a/apps/desktop/src/main/adapters/postgres-adapter.ts
+++ b/apps/desktop/src/main/adapters/postgres-adapter.ts
@@ -39,7 +39,7 @@ import type {
 import { registerQuery, unregisterQuery } from '../query-tracker'
 import { splitStatements } from '../lib/sql-parser'
 import { telemetryCollector, TELEMETRY_PHASES } from '../telemetry-collector'
-import { withPgClient, withPgTransaction } from './pg-pool-manager'
+import { withPgClient, withPgTransaction, getOrCreatePool } from './pg-pool-manager'
 
 export { buildClientConfig } from './pg-client-config'
 
@@ -91,6 +91,7 @@ export function isDataReturningStatement(sql: string): boolean {
  */
 export class PostgresAdapter implements DatabaseAdapter {
   readonly dbType = 'postgresql' as const
+  private sessions = new Map<string, import('pg').PoolClient>()
 
   async connect(config: ConnectionConfig): Promise<void> {
     // Warm the pool AND verify the socket end-to-end. An empty callback would only
@@ -130,7 +131,7 @@ export class PostgresAdapter implements DatabaseAdapter {
       telemetryCollector.startPhase(executionId, TELEMETRY_PHASES.TCP_HANDSHAKE)
     }
 
-    return withPgClient(config, async (client) => {
+    const runWithClient = async (client: import('pg').PoolClient) => {
       if (collectTelemetry) {
         telemetryCollector.endPhase(executionId, TELEMETRY_PHASES.TCP_HANDSHAKE)
         telemetryCollector.startPhase(executionId, TELEMETRY_PHASES.DB_HANDSHAKE)
@@ -255,7 +256,14 @@ export class PostgresAdapter implements DatabaseAdapter {
           unregisterQuery(options.executionId)
         }
       }
-    })
+    }
+
+    if (options?.sessionId && this.sessions.has(options.sessionId)) {
+      const client = this.sessions.get(options.sessionId)!
+      return runWithClient(client)
+    } else {
+      return withPgClient(config, runWithClient)
+    }
   }
 
   async execute(
@@ -283,6 +291,69 @@ export class PostgresAdapter implements DatabaseAdapter {
       }
       return { rowsAffected, results }
     })
+  }
+
+  async beginTransaction(_config: ConnectionConfig, sessionId: string): Promise<void> {
+    if (this.sessions.has(sessionId)) {
+      throw new Error(`Session ${sessionId} already has an active transaction`)
+    }
+    const poolEntry = await getOrCreatePool(_config)
+    const client = await poolEntry.pool.connect()
+    try {
+      await client.query('BEGIN')
+      this.sessions.set(sessionId, client)
+    } catch (error) {
+      client.release(true)
+      throw error
+    }
+  }
+
+  async queryInTransaction(
+    _config: ConnectionConfig,
+    sessionId: string,
+    sql: string,
+    params?: unknown[]
+  ): Promise<AdapterQueryResult> {
+    const client = this.sessions.get(sessionId)
+    if (!client) {
+      throw new Error(`Session ${sessionId} does not have an active transaction`)
+    }
+    const res = await client.query(sql, params)
+    const fields: QueryField[] = res.fields.map((f) => ({
+      name: f.name,
+      dataType: resolvePostgresType(f.dataTypeID),
+      dataTypeID: f.dataTypeID
+    }))
+    return {
+      rows: res.rows,
+      fields,
+      rowCount: res.rowCount
+    }
+  }
+
+  async commitTransaction(_config: ConnectionConfig, sessionId: string): Promise<void> {
+    const client = this.sessions.get(sessionId)
+    if (!client) return
+    this.sessions.delete(sessionId)
+    try {
+      await client.query('COMMIT')
+    } finally {
+      client.release()
+    }
+  }
+
+  async rollbackTransaction(_config: ConnectionConfig, sessionId: string): Promise<void> {
+    const client = this.sessions.get(sessionId)
+    if (!client) return
+    this.sessions.delete(sessionId)
+    let poisoned = false
+    try {
+      await client.query('ROLLBACK')
+    } catch {
+      poisoned = true
+    } finally {
+      client.release(poisoned ? true : undefined)
+    }
   }
 
   async getSchemas(config: ConnectionConfig): Promise<SchemaInfo[]> {

--- a/apps/desktop/src/main/adapters/postgres-adapter.ts
+++ b/apps/desktop/src/main/adapters/postgres-adapter.ts
@@ -92,6 +92,7 @@ export function isDataReturningStatement(sql: string): boolean {
 export class PostgresAdapter implements DatabaseAdapter {
   readonly dbType = 'postgresql' as const
   private sessions = new Map<string, import('pg').PoolClient>()
+  private pendingSessions = new Set<string>()
 
   async connect(config: ConnectionConfig): Promise<void> {
     // Warm the pool AND verify the socket end-to-end. An empty callback would only
@@ -294,17 +295,24 @@ export class PostgresAdapter implements DatabaseAdapter {
   }
 
   async beginTransaction(_config: ConnectionConfig, sessionId: string): Promise<void> {
-    if (this.sessions.has(sessionId)) {
+    // Reserve the slot before any await so two concurrent begins for the same
+    // session can't both pass the guard and orphan a checked-out client.
+    if (this.sessions.has(sessionId) || this.pendingSessions.has(sessionId)) {
       throw new Error(`Session ${sessionId} already has an active transaction`)
     }
-    const poolEntry = await getOrCreatePool(_config)
-    const client = await poolEntry.pool.connect()
+    this.pendingSessions.add(sessionId)
     try {
-      await client.query('BEGIN')
-      this.sessions.set(sessionId, client)
-    } catch (error) {
-      client.release(true)
-      throw error
+      const poolEntry = await getOrCreatePool(_config)
+      const client = await poolEntry.pool.connect()
+      try {
+        await client.query('BEGIN')
+        this.sessions.set(sessionId, client)
+      } catch (error) {
+        client.release(true)
+        throw error
+      }
+    } finally {
+      this.pendingSessions.delete(sessionId)
     }
   }
 
@@ -337,9 +345,23 @@ export class PostgresAdapter implements DatabaseAdapter {
     this.sessions.delete(sessionId)
     try {
       await client.query('COMMIT')
-    } finally {
-      client.release()
+    } catch (error) {
+      // A failed COMMIT leaves the connection in an unknown state — discard it.
+      client.release(true)
+      throw error
     }
+    client.release()
+  }
+
+  /**
+   * Roll back every open session. Called on app quit so checked-out clients
+   * don't block pool.end() and open transactions don't linger server-side.
+   */
+  async rollbackAllTransactions(): Promise<void> {
+    const sessionIds = [...this.sessions.keys()]
+    await Promise.allSettled(
+      sessionIds.map((id) => this.rollbackTransaction(undefined as never, id))
+    )
   }
 
   async rollbackTransaction(_config: ConnectionConfig, sessionId: string): Promise<void> {

--- a/apps/desktop/src/main/db-adapter.ts
+++ b/apps/desktop/src/main/db-adapter.ts
@@ -47,6 +47,8 @@ export interface QueryOptions {
   collectTelemetry?: boolean
   /** Query timeout in milliseconds (0 = no timeout) */
   queryTimeoutMs?: number
+  /** Execute query in this specific stateful transaction session */
+  sessionId?: string
 }
 
 /**
@@ -89,6 +91,23 @@ export interface DatabaseAdapter {
     config: ConnectionConfig,
     statements: Array<{ sql: string; params: unknown[] }>
   ): Promise<{ rowsAffected: number; results: Array<{ rowCount: number | null }> }>
+
+  /** Begin a stateful transaction for a specific session */
+  beginTransaction?(config: ConnectionConfig, sessionId: string): Promise<void>
+
+  /** Execute a query within a stateful transaction */
+  queryInTransaction?(
+    config: ConnectionConfig,
+    sessionId: string,
+    sql: string,
+    params?: unknown[]
+  ): Promise<AdapterQueryResult>
+
+  /** Commit a stateful transaction */
+  commitTransaction?(config: ConnectionConfig, sessionId: string): Promise<void>
+
+  /** Rollback a stateful transaction */
+  rollbackTransaction?(config: ConnectionConfig, sessionId: string): Promise<void>
 
   /** Fetch database schemas, tables, and columns */
   getSchemas(config: ConnectionConfig): Promise<SchemaInfo[]>

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -27,6 +27,8 @@ import { initSchedulerService, stopAllSchedules } from './scheduler-service'
 import { initDashboardService } from './dashboard-service'
 import { cleanup as cleanupPgNotify } from './pg-notification-listener'
 import { closeAllPgPools } from './adapters/pg-pool-manager'
+import { PostgresAdapter } from './adapters/postgres-adapter'
+import { getAdapterByType } from './db-adapter'
 import { StepSessionRegistry } from './step-session'
 import { createLogger } from './lib/logger'
 
@@ -276,8 +278,20 @@ app.on('before-quit', (event) => {
   stopAllSchedules()
   cleanupPgNotify()
 
+  // Roll back any open manual transactions first — their checked-out clients
+  // would otherwise block pool.end() and leave transactions open server-side.
+  const drainPgSessions = async (): Promise<void> => {
+    const pg = getAdapterByType('postgresql')
+    if (pg instanceof PostgresAdapter) {
+      await pg.rollbackAllTransactions()
+    }
+  }
+
   Promise.race([
-    Promise.all([stepSessionRegistry.cleanupAll(), closeAllPgPools()]),
+    Promise.all([
+      stepSessionRegistry.cleanupAll(),
+      drainPgSessions().then(() => closeAllPgPools())
+    ]),
     new Promise((resolve) => setTimeout(resolve, 3000))
   ])
     .catch((err) => log.error('cleanupAll failed during quit:', err))

--- a/apps/desktop/src/main/ipc/query-handlers.ts
+++ b/apps/desktop/src/main/ipc/query-handlers.ts
@@ -50,23 +50,32 @@ export function registerQueryHandlers(): void {
         config,
         query,
         executionId,
-        queryTimeoutMs
-      }: { config: ConnectionConfig; query: string; executionId?: string; queryTimeoutMs?: number }
+        queryTimeoutMs,
+        sessionId
+      }: {
+        config: ConnectionConfig
+        query: string
+        executionId?: string
+        queryTimeoutMs?: number
+        sessionId?: string
+      }
     ) => {
       log.debug('Received query request', { ...config, password: '***' })
       log.debug('Query:', query)
       log.debug('Execution ID:', executionId)
       log.debug('Query timeout:', queryTimeoutMs)
+      log.debug('Session ID:', sessionId)
 
       try {
         const adapter = getAdapter(config)
         log.debug('Connecting...')
 
         // Use queryMultiple to support multiple statements
-        // Pass executionId for cancellation support and queryTimeoutMs for timeout
+        // Pass executionId for cancellation support, queryTimeoutMs for timeout, and sessionId for transactions
         const multiResult = await adapter.queryMultiple(config, query, {
           executionId,
-          queryTimeoutMs
+          queryTimeoutMs,
+          sessionId
         })
 
         log.debug('Query completed in', multiResult.totalDurationMs, 'ms')
@@ -260,6 +269,29 @@ export function registerQueryHandlers(): void {
       }
 
       try {
+        if (batch.sessionId && adapter.queryInTransaction) {
+          for (const op of validOperations) {
+            try {
+              const res = await adapter.queryInTransaction(
+                config,
+                batch.sessionId,
+                op.sql,
+                op.params
+              )
+              result.rowsAffected += res.rowCount ?? 0
+              result.executedSql.push(op.preview)
+            } catch (error) {
+              result.errors!.push({
+                operationId: op.opId,
+                message: error instanceof Error ? error.message : String(error)
+              })
+              break // Stop executing further ops in this transaction
+            }
+          }
+          result.success = result.errors!.length === 0
+          return { success: true, data: result }
+        }
+
         const statements = validOperations.map((op) => ({ sql: op.sql, params: op.params }))
         const txResult = await adapter.executeTransaction(config, statements)
 
@@ -336,8 +368,15 @@ export function registerQueryHandlers(): void {
         config,
         query,
         executionId,
-        queryTimeoutMs
-      }: { config: ConnectionConfig; query: string; executionId?: string; queryTimeoutMs?: number }
+        queryTimeoutMs,
+        sessionId
+      }: {
+        config: ConnectionConfig
+        query: string
+        executionId?: string
+        queryTimeoutMs?: number
+        sessionId?: string
+      }
     ) => {
       log.debug('Received query with telemetry request', { ...config, password: '***' })
       log.debug('Query:', query)
@@ -352,7 +391,8 @@ export function registerQueryHandlers(): void {
         const multiResult = await adapter.queryMultiple(config, query, {
           executionId,
           collectTelemetry: true,
-          queryTimeoutMs
+          queryTimeoutMs,
+          sessionId
         })
 
         log.debug('Query completed in', multiResult.totalDurationMs, 'ms')
@@ -498,6 +538,55 @@ export function registerQueryHandlers(): void {
         log.error('Performance analysis error:', error)
         const errorMessage = error instanceof Error ? error.message : String(error)
         return { success: false, error: errorMessage }
+      }
+    }
+  )
+
+  ipcMain.handle(
+    'db:begin-transaction',
+    async (_, { config, sessionId }: { config: ConnectionConfig; sessionId: string }) => {
+      try {
+        const adapter = getAdapter(config)
+        if (adapter.beginTransaction) {
+          await adapter.beginTransaction(config, sessionId)
+          return { success: true }
+        } else {
+          return { success: false, error: 'Transactions not supported for this database type.' }
+        }
+      } catch (error: unknown) {
+        return { success: false, error: error instanceof Error ? error.message : String(error) }
+      }
+    }
+  )
+
+  ipcMain.handle(
+    'db:commit-transaction',
+    async (_, { config, sessionId }: { config: ConnectionConfig; sessionId: string }) => {
+      try {
+        const adapter = getAdapter(config)
+        if (adapter.commitTransaction) {
+          await adapter.commitTransaction(config, sessionId)
+          return { success: true }
+        }
+        return { success: false, error: 'Transactions not supported.' }
+      } catch (error: unknown) {
+        return { success: false, error: error instanceof Error ? error.message : String(error) }
+      }
+    }
+  )
+
+  ipcMain.handle(
+    'db:rollback-transaction',
+    async (_, { config, sessionId }: { config: ConnectionConfig; sessionId: string }) => {
+      try {
+        const adapter = getAdapter(config)
+        if (adapter.rollbackTransaction) {
+          await adapter.rollbackTransaction(config, sessionId)
+          return { success: true }
+        }
+        return { success: false, error: 'Transactions not supported.' }
+      } catch (error: unknown) {
+        return { success: false, error: error instanceof Error ? error.message : String(error) }
       }
     }
   )

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -212,7 +212,8 @@ interface DataPeekApi {
       config: ConnectionConfig,
       query: string,
       executionId?: string,
-      queryTimeoutMs?: number
+      queryTimeoutMs?: number,
+      sessionId?: string
     ) => Promise<IpcResponse<unknown>>
     cancelQuery: (executionId: string) => Promise<IpcResponse<{ cancelled: boolean }>>
     schemas: (
@@ -220,6 +221,9 @@ interface DataPeekApi {
       forceRefresh?: boolean
     ) => Promise<IpcResponse<DatabaseSchemaResponse>>
     invalidateSchemaCache: (config: ConnectionConfig) => Promise<IpcResponse<void>>
+    beginTransaction: (config: ConnectionConfig, sessionId: string) => Promise<IpcResponse<void>>
+    commitTransaction: (config: ConnectionConfig, sessionId: string) => Promise<IpcResponse<void>>
+    rollbackTransaction: (config: ConnectionConfig, sessionId: string) => Promise<IpcResponse<void>>
     execute: (config: ConnectionConfig, batch: EditBatch) => Promise<IpcResponse<EditResult>>
     previewSql: (
       batch: EditBatch
@@ -233,7 +237,8 @@ interface DataPeekApi {
       config: ConnectionConfig,
       query: string,
       executionId?: string,
-      queryTimeoutMs?: number
+      queryTimeoutMs?: number,
+      sessionId?: string
     ) => Promise<IpcResponse<MultiStatementResultWithTelemetry & { results: unknown[] }>>
     benchmark: (
       config: ConnectionConfig,

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -27,7 +27,6 @@ import type {
   AIMultiProviderConfig,
   AIProviderConfig,
   BenchmarkResult,
-  MultiStatementResultWithTelemetry,
   PerformanceAnalysisResult,
   PerformanceAnalysisConfig,
   QueryHistoryItemForAnalysis,
@@ -126,9 +125,9 @@ const api = {
       config: ConnectionConfig,
       query: string,
       executionId?: string,
-      queryTimeoutMs?: number
-    ): Promise<IpcResponse<unknown>> =>
-      ipcRenderer.invoke('db:query', { config, query, executionId, queryTimeoutMs }),
+      queryTimeoutMs?: number,
+      sessionId?: string
+    ) => ipcRenderer.invoke('db:query', { config, query, executionId, queryTimeoutMs, sessionId }),
     cancelQuery: (executionId: string): Promise<IpcResponse<{ cancelled: boolean }>> =>
       ipcRenderer.invoke('db:cancel-query', executionId),
     schemas: (
@@ -136,8 +135,15 @@ const api = {
       forceRefresh?: boolean
     ): Promise<IpcResponse<DatabaseSchemaResponse>> =>
       ipcRenderer.invoke('db:schemas', { config, forceRefresh }),
-    invalidateSchemaCache: (config: ConnectionConfig): Promise<IpcResponse<void>> =>
+    invalidateSchemaCache: (config: ConnectionConfig) =>
       ipcRenderer.invoke('db:invalidate-schema-cache', config),
+    // Transactions
+    beginTransaction: (config: ConnectionConfig, sessionId: string) =>
+      ipcRenderer.invoke('db:begin-transaction', { config, sessionId }),
+    commitTransaction: (config: ConnectionConfig, sessionId: string) =>
+      ipcRenderer.invoke('db:commit-transaction', { config, sessionId }),
+    rollbackTransaction: (config: ConnectionConfig, sessionId: string) =>
+      ipcRenderer.invoke('db:rollback-transaction', { config, sessionId }),
     execute: (config: ConnectionConfig, batch: EditBatch): Promise<IpcResponse<EditResult>> =>
       ipcRenderer.invoke('db:execute', { config, batch }),
     previewSql: (
@@ -155,9 +161,16 @@ const api = {
       config: ConnectionConfig,
       query: string,
       executionId?: string,
-      queryTimeoutMs?: number
-    ): Promise<IpcResponse<MultiStatementResultWithTelemetry & { results: unknown[] }>> =>
-      ipcRenderer.invoke('db:query-with-telemetry', { config, query, executionId, queryTimeoutMs }),
+      queryTimeoutMs?: number,
+      sessionId?: string
+    ) =>
+      ipcRenderer.invoke('db:query-with-telemetry', {
+        config,
+        query,
+        executionId,
+        queryTimeoutMs,
+        sessionId
+      }),
     // Benchmark query with multiple runs
     benchmark: (
       config: ConnectionConfig,

--- a/apps/desktop/src/renderer/src/components/editable-data-table.tsx
+++ b/apps/desktop/src/renderer/src/components/editable-data-table.tsx
@@ -116,6 +116,10 @@ interface EditableDataTableProps<TData> {
   onColumnStatsClick?: (column: DataTableColumn) => void
   /** Called after changes are successfully committed */
   onChangesCommitted?: () => void
+  onToggleTimeMachine?: () => void
+  autoCommit?: boolean
+  hasActiveTransaction?: boolean
+  onTransactionStart?: () => void
   /** Server-side pagination: current page (1-indexed) */
   serverCurrentPage?: number
   /** Server-side pagination: total row count from database */
@@ -221,6 +225,10 @@ export function EditableDataTable<TData extends Record<string, unknown>>({
   onForeignKeyOpenTab,
   onColumnStatsClick,
   onChangesCommitted,
+  onToggleTimeMachine: _onToggleTimeMachine,
+  autoCommit = true,
+  hasActiveTransaction = false,
+  onTransactionStart,
   serverCurrentPage,
   serverTotalRowCount,
   onServerPaginationChange
@@ -614,6 +622,19 @@ export function EditableDataTable<TData extends Record<string, unknown>>({
     setCommitError(null)
 
     try {
+      if (!autoCommit && !hasActiveTransaction) {
+        const beginRes = await window.api.db.beginTransaction(connection, tabId)
+        if (beginRes.success) {
+          onTransactionStart?.()
+        } else {
+          throw new Error('Failed to begin transaction: ' + beginRes.error)
+        }
+      }
+
+      if (!autoCommit) {
+        batch.sessionId = tabId
+      }
+
       const response = await window.api.db.execute(connection, batch)
 
       if (response.success && response.data?.success) {

--- a/apps/desktop/src/renderer/src/components/editable-data-table.tsx
+++ b/apps/desktop/src/renderer/src/components/editable-data-table.tsx
@@ -116,7 +116,6 @@ interface EditableDataTableProps<TData> {
   onColumnStatsClick?: (column: DataTableColumn) => void
   /** Called after changes are successfully committed */
   onChangesCommitted?: () => void
-  onToggleTimeMachine?: () => void
   autoCommit?: boolean
   hasActiveTransaction?: boolean
   onTransactionStart?: () => void
@@ -225,7 +224,6 @@ export function EditableDataTable<TData extends Record<string, unknown>>({
   onForeignKeyOpenTab,
   onColumnStatsClick,
   onChangesCommitted,
-  onToggleTimeMachine: _onToggleTimeMachine,
   autoCommit = true,
   hasActiveTransaction = false,
   onTransactionStart,

--- a/apps/desktop/src/renderer/src/components/query-editor/editor-toolbar.tsx
+++ b/apps/desktop/src/renderer/src/components/query-editor/editor-toolbar.tsx
@@ -164,17 +164,22 @@ export function EditorToolbar({
           <div className="flex items-center gap-2 border-l border-border/60 pl-2 ml-1">
             <label
               className="flex items-center gap-1.5 text-xs text-muted-foreground cursor-pointer"
-              title="Automatically commit queries"
+              title={
+                hasActiveTransaction
+                  ? 'Commit or roll back the open transaction first'
+                  : 'Automatically commit queries'
+              }
             >
               <input
                 type="checkbox"
                 checked={autoCommit}
+                disabled={hasActiveTransaction}
                 onChange={(e) => setAutoCommit(e.target.checked)}
                 className="size-3"
               />
               <span>Auto-commit</span>
             </label>
-            {!autoCommit && (
+            {(!autoCommit || hasActiveTransaction) && (
               <>
                 <Button
                   size="sm"

--- a/apps/desktop/src/renderer/src/components/query-editor/editor-toolbar.tsx
+++ b/apps/desktop/src/renderer/src/components/query-editor/editor-toolbar.tsx
@@ -9,7 +9,9 @@ import {
   Share2,
   Maximize2,
   PanelTop,
-  PanelTopClose
+  PanelTopClose,
+  CheckCircle2,
+  Undo2
 } from 'lucide-react'
 import {
   Button,
@@ -38,6 +40,11 @@ interface EditorToolbarProps {
   inTransactionMode: boolean
   setInTransactionMode: (v: boolean) => void
   stepSession: StepSessionState | null | undefined
+  autoCommit: boolean
+  setAutoCommit: (v: boolean) => void
+  hasActiveTransaction: boolean
+  handleCommit: () => void
+  handleRollback: () => void
   handleExplainQuery: () => void
   isExplaining: boolean
   handleBenchmark: (runCount: number) => Promise<void>
@@ -66,6 +73,11 @@ export function EditorToolbar({
   inTransactionMode,
   setInTransactionMode,
   stepSession,
+  autoCommit,
+  setAutoCommit,
+  hasActiveTransaction,
+  handleCommit,
+  handleRollback,
   handleExplainQuery,
   isExplaining,
   handleBenchmark,
@@ -144,9 +156,49 @@ export function EditorToolbar({
                 disabled={!!stepSession}
                 className="size-3"
               />
-              <span>Run in transaction</span>
+              <span>Debug in transaction</span>
             </label>
           </>
+        )}
+        {tab.type === 'query' && tabConnection?.dbType === 'postgresql' && !stepSession && (
+          <div className="flex items-center gap-2 border-l border-border/60 pl-2 ml-1">
+            <label
+              className="flex items-center gap-1.5 text-xs text-muted-foreground cursor-pointer"
+              title="Automatically commit queries"
+            >
+              <input
+                type="checkbox"
+                checked={autoCommit}
+                onChange={(e) => setAutoCommit(e.target.checked)}
+                className="size-3"
+              />
+              <span>Auto-commit</span>
+            </label>
+            {!autoCommit && (
+              <>
+                <Button
+                  size="sm"
+                  variant={hasActiveTransaction ? 'default' : 'outline'}
+                  className="h-7 text-xs gap-1.5"
+                  disabled={!hasActiveTransaction}
+                  onClick={handleCommit}
+                >
+                  <CheckCircle2 className="size-3" />
+                  Commit
+                </Button>
+                <Button
+                  size="sm"
+                  variant={hasActiveTransaction ? 'destructive' : 'outline'}
+                  className="h-7 text-xs gap-1.5"
+                  disabled={!hasActiveTransaction}
+                  onClick={handleRollback}
+                >
+                  <Undo2 className="size-3" />
+                  Rollback
+                </Button>
+              </>
+            )}
+          </div>
         )}
         <TooltipProvider>
           <Tooltip>

--- a/apps/desktop/src/renderer/src/components/query-editor/query-results.tsx
+++ b/apps/desktop/src/renderer/src/components/query-editor/query-results.tsx
@@ -78,6 +78,9 @@ interface QueryResultsProps {
   getAllRows: () => Record<string, unknown>[]
   telemetry: QueryTelemetry | null | undefined
   benchmark: BenchmarkResult | null | undefined
+  autoCommit?: boolean
+  hasActiveTransaction?: boolean
+  onTransactionStart?: () => void
   showTelemetryPanel: boolean
   setShowTelemetryPanel: (v: boolean) => void
   showConnectionOverhead: boolean
@@ -134,6 +137,9 @@ export function QueryResults({
   getAllRows,
   telemetry,
   benchmark,
+  autoCommit,
+  hasActiveTransaction,
+  onTransactionStart,
   showTelemetryPanel,
   setShowTelemetryPanel,
   showConnectionOverhead,
@@ -308,6 +314,9 @@ export function QueryResults({
                         onForeignKeyOpenTab={handleFKOpenTab}
                         onColumnStatsClick={tabConnection ? handleColumnStatsClick : undefined}
                         onChangesCommitted={handleRunQuery}
+                        autoCommit={autoCommit}
+                        hasActiveTransaction={hasActiveTransaction}
+                        onTransactionStart={onTransactionStart}
                         serverCurrentPage={isTablePreview ? tab.currentPage : undefined}
                         serverTotalRowCount={isTablePreview ? tab.totalRowCount : undefined}
                         onServerPaginationChange={

--- a/apps/desktop/src/renderer/src/components/tab-query-editor.tsx
+++ b/apps/desktop/src/renderer/src/components/tab-query-editor.tsx
@@ -352,7 +352,9 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
           if (beginRes.success) {
             setHasActiveTransaction(true)
           } else {
-            console.error('Failed to begin transaction', beginRes.error)
+            // Abort the run — proceeding would hit the session map with no open
+            // transaction and surface a misleading "no active transaction" error.
+            throw new Error(`Failed to begin transaction: ${beginRes.error}`)
           }
         }
 
@@ -1292,6 +1294,21 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
     }
   }, [tabId])
 
+  // If the tab's connection changes while a transaction is open, roll it back on
+  // the previous connection — commit/rollback must never target the wrong database.
+  const prevConnectionRef = useRef(tabConnection)
+  useEffect(() => {
+    const prev = prevConnectionRef.current
+    prevConnectionRef.current = tabConnection
+    if (prev && tabConnection && prev.id !== tabConnection.id) {
+      if (transactionCleanupRef.current.hasActiveTransaction) {
+        window.api.db.rollbackTransaction(prev, tabId).catch(() => {})
+        setHasActiveTransaction(false)
+        notify.info('Open transaction rolled back — connection changed')
+      }
+    }
+  }, [tabConnection, tabId])
+
   if (!tab || tab.type === 'notebook') {
     return null
   }
@@ -1302,14 +1319,22 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
     const res = await window.api.db.commitTransaction(tabConnection, tab.id)
     if (res.success) {
       setHasActiveTransaction(false)
+      notify.success('Transaction committed')
+    } else {
+      // The adapter discards the client on COMMIT failure, so the session is gone.
+      setHasActiveTransaction(false)
+      notify.error('Commit failed', res.error || 'Transaction was not committed')
     }
   }
 
   const handleRollback = async (): Promise<void> => {
     if (!tabConnection) return
     const res = await window.api.db.rollbackTransaction(tabConnection, tab.id)
+    setHasActiveTransaction(false)
     if (res.success) {
-      setHasActiveTransaction(false)
+      notify.success('Transaction rolled back')
+    } else {
+      notify.error('Rollback failed', res.error || 'Transaction may still be open')
     }
   }
 

--- a/apps/desktop/src/renderer/src/components/tab-query-editor.tsx
+++ b/apps/desktop/src/renderer/src/components/tab-query-editor.tsx
@@ -116,6 +116,8 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
   const startStep = useStepStore((s) => s.startStep)
   const toggleBreakpoint = useStepStore((s) => s.toggleBreakpoint)
   const [inTransactionMode, setInTransactionMode] = useState(false)
+  const [autoCommit, setAutoCommit] = useState(true)
+  const [hasActiveTransaction, setHasActiveTransaction] = useState(false)
 
   const tabQuery = tab && 'query' in tab ? tab.query : ''
   const tabType = tab?.type
@@ -342,13 +344,25 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
       // Clear previous benchmark when running a new query
       setBenchmark(null)
 
+      const targetSessionId = !autoCommit && tab?.id ? tab.id : undefined
+
       try {
+        if (!autoCommit && !hasActiveTransaction && tab?.id) {
+          const beginRes = await window.api.db.beginTransaction(tabConnection, tab.id)
+          if (beginRes.success) {
+            setHasActiveTransaction(true)
+          } else {
+            console.error('Failed to begin transaction', beginRes.error)
+          }
+        }
+
         // Use telemetry-enabled query API with timeout from settings
         const response = await window.api.db.queryWithTelemetry(
           tabConnection,
           sqlToExecute,
           executionId,
-          queryTimeoutMs
+          queryTimeoutMs,
+          targetSessionId
         )
 
         if (!isStillCurrent()) return
@@ -517,7 +531,10 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
       setTelemetry,
       setBenchmark,
       queryTimeoutMs,
-      setTablePreviewTotalCount
+      setTablePreviewTotalCount,
+      autoCommit,
+      hasActiveTransaction,
+      tab?.id
     ]
   )
 
@@ -1214,7 +1231,7 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
         return undefined
       }
     }),
-    [tabId]
+    [tabId, tabConnection]
   )
 
   // Cmd+Shift+W is wired via the native menu (see main/menu.ts → 'Toggle
@@ -1262,8 +1279,38 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
     [handleToggleTimeMachine]
   )
 
+  // Roll back any open transaction when the tab unmounts. Refs keep the
+  // cleanup unmount-only without re-running on state changes.
+  const transactionCleanupRef = useRef({ hasActiveTransaction, tabConnection })
+  transactionCleanupRef.current = { hasActiveTransaction, tabConnection }
+  useEffect(() => {
+    return () => {
+      const { hasActiveTransaction: active, tabConnection: conn } = transactionCleanupRef.current
+      if (active && conn) {
+        window.api.db.rollbackTransaction(conn, tabId).catch(() => {})
+      }
+    }
+  }, [tabId])
+
   if (!tab || tab.type === 'notebook') {
     return null
+  }
+
+  // Handle explicit Commit and Rollback
+  const handleCommit = async (): Promise<void> => {
+    if (!tabConnection) return
+    const res = await window.api.db.commitTransaction(tabConnection, tab.id)
+    if (res.success) {
+      setHasActiveTransaction(false)
+    }
+  }
+
+  const handleRollback = async (): Promise<void> => {
+    if (!tabConnection) return
+    const res = await window.api.db.rollbackTransaction(tabConnection, tab.id)
+    if (res.success) {
+      setHasActiveTransaction(false)
+    }
   }
 
   if (!tabConnection) {
@@ -1412,6 +1459,11 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
           inTransactionMode={inTransactionMode}
           setInTransactionMode={setInTransactionMode}
           stepSession={stepSession}
+          autoCommit={autoCommit}
+          setAutoCommit={setAutoCommit}
+          hasActiveTransaction={hasActiveTransaction}
+          handleCommit={handleCommit}
+          handleRollback={handleRollback}
           handleExplainQuery={handleExplainQuery}
           isExplaining={isExplaining}
           handleBenchmark={handleBenchmark}
@@ -1471,6 +1523,9 @@ export function TabQueryEditor({ tabId }: TabQueryEditorProps) {
         getAllRows={getAllRows}
         telemetry={telemetry}
         benchmark={benchmark}
+        autoCommit={autoCommit}
+        hasActiveTransaction={hasActiveTransaction}
+        onTransactionStart={() => setHasActiveTransaction(true)}
         showTelemetryPanel={showTelemetryPanel}
         setShowTelemetryPanel={setShowTelemetryPanel}
         showConnectionOverhead={showConnectionOverhead}

--- a/apps/desktop/src/renderer/src/components/time-machine/time-machine-strip.tsx
+++ b/apps/desktop/src/renderer/src/components/time-machine/time-machine-strip.tsx
@@ -91,7 +91,10 @@ export function TimeMachineStrip({ tabId, connectionId, sql }: TimeMachineStripP
   }
 
   return (
-    <div className="flex items-center gap-2 border-b border-border/40 bg-muted/10 px-3 py-1.5 shrink-0">
+    <div
+      data-testid="time-machine-strip"
+      className="flex items-center gap-2 border-b border-border/40 bg-muted/10 px-3 py-1.5 shrink-0"
+    >
       <div className="flex items-center gap-1.5 text-xs text-muted-foreground shrink-0">
         <History className="size-3.5" />
         <span className="font-medium">Time Machine</span>

--- a/apps/desktop/tests/e2e/time-machine.spec.ts
+++ b/apps/desktop/tests/e2e/time-machine.spec.ts
@@ -67,17 +67,20 @@ test('run queries, open time machine strip, select past run', async ({ window })
   await expect(timeMachineBtn).toBeVisible({ timeout: 5000 })
   await timeMachineBtn.click()
 
-  // 4. Verify the Time Machine strip shows up
-  // The strip should show chips containing snippets of the query
-  await expect(window.getByText('LIMIT 3')).toBeVisible({ timeout: 5000 })
-  await expect(window.getByText('LIMIT 2')).toBeVisible({ timeout: 5000 })
+  // 4. Verify the Time Machine strip shows up with a chip per captured run.
+  // Chips show capture time + row count (not SQL), and are the strip's only
+  // font-mono buttons — the Live/close buttons aren't.
+  const strip = window.getByTestId('time-machine-strip')
+  await expect(strip).toBeVisible({ timeout: 5000 })
+  const chips = strip.locator('button.font-mono')
+  await expect(chips).toHaveCount(2, { timeout: 5000 })
 
-  // 5. Click the past run (LIMIT 3)
-  await window.getByText('LIMIT 3').click()
+  // 5. Click the past run — chips are chronological, so the first is LIMIT 3.
+  await chips.first().click()
 
   // 6. Verify that it restores the old results table (3 rows)
   await expect(window.locator('tbody tr')).toHaveCount(3, { timeout: 5000 })
-  
+
   // Verify it says Read-only
   await expect(window.getByText(/Read-only/i)).toBeVisible({ timeout: 5000 })
 })

--- a/apps/desktop/tests/e2e/transactions.spec.ts
+++ b/apps/desktop/tests/e2e/transactions.spec.ts
@@ -1,0 +1,233 @@
+import { test, expect } from './fixtures/electron-app'
+import { startSeededPostgres, type SeededPostgres } from './fixtures/postgres'
+
+/**
+ * Manual transaction (auto-commit off) tests against the seeded Postgres. These pin
+ * the session-pinned-client contract end-to-end: begin/commit/rollback IPC handlers →
+ * PostgresAdapter session map → a dedicated pool client held open across calls.
+ *
+ * Each test uses its own sessionId so a failed assertion can't leak an open
+ * transaction into the next test.
+ */
+
+let pg: SeededPostgres
+
+test.beforeAll(async () => {
+  pg = await startSeededPostgres()
+})
+
+test.afterAll(async () => {
+  await pg?.stop()
+})
+
+test('uncommitted changes are visible in-session but invisible outside it', async ({ window }) => {
+  const result = await window.evaluate(async (cfg) => {
+    const sessionId = 'e2e-tx-visibility'
+    const begin = await window.api.db.beginTransaction(cfg, sessionId)
+
+    await window.api.db.query(
+      cfg,
+      "UPDATE users SET name = 'TX Pending' WHERE email = (SELECT email FROM users ORDER BY email LIMIT 1)",
+      undefined,
+      undefined,
+      sessionId
+    )
+
+    const inSession = await window.api.db.query(
+      cfg,
+      "SELECT count(*)::int AS n FROM users WHERE name = 'TX Pending'",
+      undefined,
+      undefined,
+      sessionId
+    )
+    // No sessionId → separate pooled client → must not see the uncommitted row.
+    const outsideSession = await window.api.db.query(
+      cfg,
+      "SELECT count(*)::int AS n FROM users WHERE name = 'TX Pending'"
+    )
+
+    await window.api.db.rollbackTransaction(cfg, sessionId)
+
+    const afterRollback = await window.api.db.query(
+      cfg,
+      "SELECT count(*)::int AS n FROM users WHERE name = 'TX Pending'"
+    )
+
+    const count = (r: unknown): number =>
+      ((r as { data?: { results?: Array<{ rows: Array<{ n: number }> }> } }).data?.results?.[0]
+        ?.rows?.[0]?.n ?? -1) as number
+
+    return {
+      beginOk: begin.success,
+      inSession: count(inSession),
+      outsideSession: count(outsideSession),
+      afterRollback: count(afterRollback)
+    }
+  }, pg.config)
+
+  expect(result.beginOk).toBe(true)
+  expect(result.inSession).toBe(1)
+  expect(result.outsideSession).toBe(0)
+  expect(result.afterRollback).toBe(0)
+})
+
+test('commit persists in-session changes', async ({ window }) => {
+  const result = await window.evaluate(async (cfg) => {
+    const sessionId = 'e2e-tx-commit'
+    await window.api.db.beginTransaction(cfg, sessionId)
+
+    await window.api.db.query(
+      cfg,
+      "INSERT INTO users (email, name) VALUES ('tx-commit@example.com', 'TX Committed')",
+      undefined,
+      undefined,
+      sessionId
+    )
+
+    const commit = await window.api.db.commitTransaction(cfg, sessionId)
+
+    const afterCommit = await window.api.db.query(
+      cfg,
+      "SELECT count(*)::int AS n FROM users WHERE email = 'tx-commit@example.com'"
+    )
+
+    const n =
+      (
+        afterCommit as {
+          data?: { results?: Array<{ rows: Array<{ n: number }> }> }
+        }
+      ).data?.results?.[0]?.rows?.[0]?.n ?? -1
+
+    // Clean up so other specs' row-count expectations aren't disturbed.
+    await window.api.db.query(cfg, "DELETE FROM users WHERE email = 'tx-commit@example.com'")
+
+    return { commitOk: commit.success, afterCommit: n }
+  }, pg.config)
+
+  expect(result.commitOk).toBe(true)
+  expect(result.afterCommit).toBe(1)
+})
+
+test('a failed statement poisons the transaction until rollback', async ({ window }) => {
+  const result = await window.evaluate(async (cfg) => {
+    const sessionId = 'e2e-tx-poison'
+    await window.api.db.beginTransaction(cfg, sessionId)
+
+    const bad = await window.api.db.query(
+      cfg,
+      'SELECT * FROM nonexistent_table_xyzzy',
+      undefined,
+      undefined,
+      sessionId
+    )
+    // Postgres aborts the tx: further statements on the session must fail...
+    const afterError = await window.api.db.query(
+      cfg,
+      'SELECT 1 AS n',
+      undefined,
+      undefined,
+      sessionId
+    )
+
+    const rollback = await window.api.db.rollbackTransaction(cfg, sessionId)
+
+    // ...and after rollback the connection pool must still be healthy.
+    const afterRollback = await window.api.db.query(cfg, 'SELECT 1 AS n')
+
+    return {
+      badOk: bad.success,
+      afterErrorOk: afterError.success,
+      rollbackOk: rollback.success,
+      afterRollbackOk: afterRollback.success
+    }
+  }, pg.config)
+
+  expect(result.badOk).toBe(false)
+  expect(result.afterErrorOk).toBe(false)
+  expect(result.rollbackOk).toBe(true)
+  expect(result.afterRollbackOk).toBe(true)
+})
+
+test('double begin on the same session is rejected', async ({ window }) => {
+  const result = await window.evaluate(async (cfg) => {
+    const sessionId = 'e2e-tx-double-begin'
+    const first = await window.api.db.beginTransaction(cfg, sessionId)
+    const second = await window.api.db.beginTransaction(cfg, sessionId)
+    await window.api.db.rollbackTransaction(cfg, sessionId)
+    return { firstOk: first.success, secondOk: second.success, secondError: second.error }
+  }, pg.config)
+
+  expect(result.firstOk).toBe(true)
+  expect(result.secondOk).toBe(false)
+  expect(result.secondError).toContain('already has an active transaction')
+})
+
+test('commit and rollback without an active session are safe no-ops', async ({ window }) => {
+  const result = await window.evaluate(async (cfg) => {
+    const commit = await window.api.db.commitTransaction(cfg, 'e2e-tx-ghost')
+    const rollback = await window.api.db.rollbackTransaction(cfg, 'e2e-tx-ghost')
+    return { commitOk: commit.success, rollbackOk: rollback.success }
+  }, pg.config)
+
+  expect(result.commitOk).toBe(true)
+  expect(result.rollbackOk).toBe(true)
+})
+
+test('edit batch with a sessionId executes inside the open transaction', async ({ window }) => {
+  const result = await window.evaluate(async (cfg) => {
+    const sessionId = 'e2e-tx-edit-batch'
+    await window.api.db.beginTransaction(cfg, sessionId)
+
+    const columns = [
+      { name: 'email', dataType: 'character varying' },
+      { name: 'name', dataType: 'character varying' }
+    ]
+    const batch = {
+      sessionId,
+      context: {
+        schema: 'public',
+        table: 'users',
+        primaryKeyColumns: ['id'],
+        columns: columns.map((c) => ({ ...c, nullable: false }))
+      },
+      operations: [
+        {
+          type: 'insert',
+          id: 'op-1',
+          values: { email: 'tx-batch@example.com', name: 'TX Batch' },
+          columns
+        }
+      ]
+    }
+    const exec = await window.api.db.execute(cfg, batch as never)
+
+    // Visible in-session, not outside.
+    const outside = await window.api.db.query(
+      cfg,
+      "SELECT count(*)::int AS n FROM users WHERE email = 'tx-batch@example.com'"
+    )
+
+    await window.api.db.rollbackTransaction(cfg, sessionId)
+
+    const afterRollback = await window.api.db.query(
+      cfg,
+      "SELECT count(*)::int AS n FROM users WHERE email = 'tx-batch@example.com'"
+    )
+
+    const count = (r: unknown): number =>
+      ((r as { data?: { results?: Array<{ rows: Array<{ n: number }> }> } }).data?.results?.[0]
+        ?.rows?.[0]?.n ?? -1) as number
+
+    return {
+      execOk: exec.success && exec.data?.success,
+      rowsAffected: exec.data?.rowsAffected,
+      outside: count(outside),
+      afterRollback: count(afterRollback)
+    }
+  }, pg.config)
+
+  expect(result.execOk).toBe(true)
+  expect(result.rowsAffected).toBe(1)
+  expect(result.outside).toBe(0)
+  expect(result.afterRollback).toBe(0)
+})

--- a/apps/desktop/tests/e2e/watch-mode.spec.ts
+++ b/apps/desktop/tests/e2e/watch-mode.spec.ts
@@ -44,11 +44,24 @@ async function typeInMonaco(window: Page, sql: string) {
   await window.keyboard.type(sql)
 }
 
-test('start watch mode, see it running, and stop it', async ({ window }) => {
+test('start watch mode, see it running, and stop it', async ({ window, electronApp }) => {
+  // The default window is narrower than the editor layout's minimum width, so the
+  // page scrolls horizontally and the watch popover can land outside the viewport.
+  await electronApp.evaluate(({ BrowserWindow }) => {
+    const win = BrowserWindow.getAllWindows()[0]
+    win.setSize(1720, 1000)
+    win.center()
+  })
+
   await openQueryTab(window)
 
-  // 1. Type a query that is watchable
+  // 1. Type a watchable query and run it — Watch Mode overlays diff decorations
+  // on an existing results table; it never renders rows itself, so the table
+  // must be populated before the watch starts.
   await typeInMonaco(window, 'SELECT id, email, name FROM users ORDER BY email LIMIT 3')
+  const runShortcut = process.platform === 'darwin' ? 'Meta+Enter' : 'Control+Enter'
+  await window.keyboard.press(runShortcut)
+  await expect(window.locator('tbody tr')).toHaveCount(3, { timeout: 15000 })
 
   // 2. Start watch mode (the button is just labeled "Watch")
   // Using exact: true in case there are other things containing Watch
@@ -59,18 +72,24 @@ test('start watch mode, see it running, and stop it', async ({ window }) => {
   // 3. Verify it says "Watching…" or "Watching · 1s"
   await expect(window.getByText(/Watching/)).toBeVisible({ timeout: 5000 })
 
-  // 4. Wait for results table to appear (meaning it fired at least once)
+  // 4. The watch ticks against the same query — the table keeps its rows.
   await expect(window.locator('tbody tr')).toHaveCount(3, { timeout: 15000 })
 
-  // 5. Open the watch popover by right clicking (context menu) or clicking while enabled
-  const watchingBtn = window.getByRole('button', { name: /Watching/ })
+  // 5. Open the watch popover — target the toolbar button by its data attribute;
+  // the tab header also reads "Watching …" and trips strict mode.
+  const watchingBtn = window.locator('button[data-watch-active]')
   await watchingBtn.click()
 
-  // 6. Click the "Stop" button in the popover
+  // 6. Click the "Stop" button in the popover. Dispatch the click via the DOM:
+  // Playwright's viewport for Electron stays at the launch window size, so a
+  // popover near the right edge is judged "outside of the viewport" and a
+  // mouse click retries forever even though the button is on screen.
   const stopBtn = window.getByRole('button', { name: /Stop/i })
   await expect(stopBtn).toBeVisible({ timeout: 5000 })
-  await stopBtn.click()
+  await stopBtn.dispatchEvent('click')
 
   // 7. Verify it reverted back to "Watch"
-  await expect(window.getByRole('button', { name: 'Watch', exact: true })).toBeVisible({ timeout: 5000 })
+  await expect(window.getByRole('button', { name: 'Watch', exact: true })).toBeVisible({
+    timeout: 5000
+  })
 })

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -852,6 +852,7 @@ export interface EditContext {
 export interface EditBatch {
   context: EditContext;
   operations: EditOperation[];
+  sessionId?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds an **Auto-commit toggle** to the query editor toolbar (PostgreSQL only) with explicit **Commit** / **Rollback** buttons
- With auto-commit off, queries and inline edits run on a **session-pinned pool client** (one open `BEGIN` per tab), so changes can be reviewed before committing
- Open transactions are rolled back automatically when the tab unmounts

## Implementation
- `PostgresAdapter`: `beginTransaction` / `queryInTransaction` / `commitTransaction` / `rollbackTransaction` backed by a per-session client map; a client whose `ROLLBACK` fails is dropped from the pool (`release(true)`)
- IPC: new `db:begin/commit/rollback-transaction` handlers; `sessionId` threaded through `db:query`, `db:query-with-telemetry`, and `db:execute` edit batches
- Adapter interface methods are optional — non-Postgres adapters return a clean "not supported" error, and the UI is gated to `dbType === 'postgresql'`

## Testing
- New e2e spec `tests/e2e/transactions.spec.ts` (6 tests, real Electron → adapter → testcontainers Postgres): in-session visibility, commit persistence, poisoned-transaction recovery, double-begin rejection, ghost-session no-ops, edit batch in-session
- `pnpm typecheck` clean; lint clean on changed files
- Full e2e suite: 56/58 pass — the 2 failures (`watch-mode`, `time-machine`) reproduce on clean `main` and are unrelated (pre-existing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PostgreSQL transaction controls with explicit begin, commit, and rollback actions.
  * Added Auto-commit controls and transaction status indicators to the query editor.
  * Edits can now run within isolated sessions, allowing changes to be reviewed before committing.
  * Added support for session-scoped queries and telemetry.

* **Bug Fixes**
  * Open transactions are automatically rolled back when leaving the query editor.
  * Improved connection handling after failed transaction statements.

* **Tests**
  * Added end-to-end coverage for transaction isolation, commits, rollbacks, and failure recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->