### PR TITLE
feat: embedded MCP server — let AI agents query connected databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ A minimal, fast SQL client desktop application with AI-powered querying. Built f
 - **Charts & Insights** - Generate visualizations and metrics from query results
 - **Schema-Aware** - AI understands your database structure for accurate queries
 
+### MCP Server
+
+- **MCP server** - expose your connections to AI agents (read-only queries free, writes gated by in-app approval)
+- **Streamable HTTP** - local server on `127.0.0.1:4722` (configurable), secured with a bearer token, off by default
+- **Read-only tools** - `list_connections`, `list_schemas`, `run_query` (500-row cap, rollback-wrapped, Postgres additionally runs `READ ONLY` at the DB level), `explain_query`
+- **Approved writes** - `execute_statement` prompts an in-app Approve/Reject dialog for every write; 60s timeout auto-rejects
+- **One-command setup** - copy the ready-made `claude mcp add` snippet straight from Settings → MCP server
+
 ### Query Editor
 
 - **Monaco Editor** - SQL syntax highlighting with smart autocomplete

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -40,6 +40,7 @@
     "@faker-js/faker": "^9.9.0",
     "@fontsource-variable/geist": "^5.2.9",
     "@fontsource-variable/geist-mono": "^5.2.8",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@monaco-editor/react": "^4.7.0",
     "@radix-ui/react-alert-dialog": "^1.1.18",
     "@radix-ui/react-checkbox": "^1.3.6",

--- a/apps/desktop/src/main/__tests__/mcp-approval.test.ts
+++ b/apps/desktop/src/main/__tests__/mcp-approval.test.ts
@@ -48,4 +48,32 @@ describe('ApprovalManager', () => {
     const mgr = new ApprovalManager(() => undefined)
     expect(() => mgr.respond('nope', true)).not.toThrow()
   })
+
+  it('calls onResolved with the id on explicit respond', async () => {
+    const sent: McpApprovalRequest[] = []
+    const resolved: string[] = []
+    const mgr = new ApprovalManager(
+      (req) => sent.push(req),
+      60_000,
+      (id) => resolved.push(id)
+    )
+    const p = mgr.request('local', 'UPDATE t SET x = 1')
+    mgr.respond(sent[0].id, true)
+    await expect(p).resolves.toBe(true)
+    expect(resolved).toEqual([sent[0].id])
+  })
+
+  it('calls onResolved with the id on timeout', async () => {
+    const sent: McpApprovalRequest[] = []
+    const resolved: string[] = []
+    const mgr = new ApprovalManager(
+      (req) => sent.push(req),
+      60_000,
+      (id) => resolved.push(id)
+    )
+    const p = mgr.request('local', 'DELETE FROM t')
+    vi.advanceTimersByTime(60_001)
+    await expect(p).resolves.toBe(false)
+    expect(resolved).toEqual([sent[0].id])
+  })
 })

--- a/apps/desktop/src/main/__tests__/mcp-approval.test.ts
+++ b/apps/desktop/src/main/__tests__/mcp-approval.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { ApprovalManager } from '../mcp/approval'
+import type { McpApprovalRequest } from '@shared/index'
+
+describe('ApprovalManager', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it('resolves true when approved', async () => {
+    const sent: McpApprovalRequest[] = []
+    const mgr = new ApprovalManager((req) => sent.push(req))
+    const p = mgr.request('local', 'UPDATE t SET x = 1')
+    expect(sent).toHaveLength(1)
+    mgr.respond(sent[0].id, true)
+    await expect(p).resolves.toBe(true)
+  })
+
+  it('resolves false when rejected', async () => {
+    const sent: McpApprovalRequest[] = []
+    const mgr = new ApprovalManager((req) => sent.push(req))
+    const p = mgr.request('local', 'DROP TABLE t')
+    mgr.respond(sent[0].id, false)
+    await expect(p).resolves.toBe(false)
+  })
+
+  it('auto-rejects after the timeout', async () => {
+    const mgr = new ApprovalManager(() => undefined, 60_000)
+    const p = mgr.request('local', 'DELETE FROM t')
+    vi.advanceTimersByTime(60_001)
+    await expect(p).resolves.toBe(false)
+  })
+
+  it('serializes concurrent requests', async () => {
+    const sent: McpApprovalRequest[] = []
+    const mgr = new ApprovalManager((req) => sent.push(req))
+    const p1 = mgr.request('a', 'UPDATE a SET x=1')
+    const p2 = mgr.request('b', 'UPDATE b SET x=1')
+    expect(sent).toHaveLength(1) // second waits for first
+    mgr.respond(sent[0].id, true)
+    await expect(p1).resolves.toBe(true)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(sent).toHaveLength(2)
+    mgr.respond(sent[1].id, false)
+    await expect(p2).resolves.toBe(false)
+  })
+
+  it('ignores responses for unknown ids', () => {
+    const mgr = new ApprovalManager(() => undefined)
+    expect(() => mgr.respond('nope', true)).not.toThrow()
+  })
+})

--- a/apps/desktop/src/main/__tests__/mcp-handlers.test.ts
+++ b/apps/desktop/src/main/__tests__/mcp-handlers.test.ts
@@ -16,7 +16,7 @@ function makeStore(initial: McpSettings) {
     set: vi.fn((_k: string, v: McpSettings) => {
       value = v
     })
-  } as never
+  }
 }
 
 function makeService() {
@@ -38,7 +38,10 @@ describe('mcp handlers', () => {
 
   it('mcp:status returns persisted settings without starting the server', async () => {
     const svc = makeService()
-    registerMcpHandlers(makeStore({ enabled: false, port: 4722, token: 'tok' }), svc as never)
+    registerMcpHandlers(
+      makeStore({ enabled: false, port: 4722, token: 'tok' }) as never,
+      svc as never
+    )
     const res = (await invoke('mcp:status')) as { success: boolean; data: { port: number } }
     expect(res.success).toBe(true)
     expect(res.data.port).toBe(4722)
@@ -48,7 +51,7 @@ describe('mcp handlers', () => {
   it('mcp:setEnabled true starts the server and persists', async () => {
     const svc = makeService()
     const store = makeStore({ enabled: false, port: 4722, token: 'tok' })
-    registerMcpHandlers(store, svc as never)
+    registerMcpHandlers(store as never, svc as never)
     const res = (await invoke('mcp:setEnabled', { enabled: true })) as { success: boolean }
     expect(res.success).toBe(true)
     expect(svc.start).toHaveBeenCalledWith(4722, 'tok')
@@ -58,7 +61,7 @@ describe('mcp handlers', () => {
     const svc = makeService()
     svc.start.mockRejectedValue(new Error('EADDRINUSE'))
     const store = makeStore({ enabled: false, port: 4722, token: 'tok' })
-    registerMcpHandlers(store, svc as never)
+    registerMcpHandlers(store as never, svc as never)
     const res = (await invoke('mcp:setEnabled', { enabled: true })) as {
       success: boolean
       error?: string
@@ -69,9 +72,57 @@ describe('mcp handlers', () => {
 
   it('mcp:regenerateToken produces a new 64-char hex token', async () => {
     const store = makeStore({ enabled: false, port: 4722, token: 'old' })
-    registerMcpHandlers(store, makeService() as never)
+    registerMcpHandlers(store as never, makeService() as never)
     const res = (await invoke('mcp:regenerateToken')) as { data: { token: string } }
     expect(res.data.token).toMatch(/^[0-9a-f]{64}$/)
     expect(res.data.token).not.toBe('old')
+  })
+
+  it('mcp:setPort while running: new port start fails, keeps old port and restarts old', async () => {
+    const svc = makeService()
+    svc.running = true
+    svc.start.mockRejectedValueOnce(new Error('EADDRINUSE')).mockResolvedValueOnce(undefined)
+    const store = makeStore({ enabled: true, port: 4722, token: 'tok' })
+    registerMcpHandlers(store as never, svc as never)
+    const res = (await invoke('mcp:setPort', { port: 5000 })) as {
+      success: boolean
+      error?: string
+    }
+    expect(res.success).toBe(false)
+    expect(res.error).toContain('EADDRINUSE')
+    expect(store.set).not.toHaveBeenCalled()
+    expect(svc.start).toHaveBeenNthCalledWith(1, 5000, 'tok')
+    expect(svc.start).toHaveBeenNthCalledWith(2, 4722, 'tok')
+  })
+
+  it('mcp:regenerateToken while running: start fails, keeps old token and surfaces error', async () => {
+    const svc = makeService()
+    svc.running = true
+    svc.start.mockRejectedValue(new Error('start failed'))
+    const store = makeStore({ enabled: true, port: 4722, token: 'old' })
+    registerMcpHandlers(store as never, svc as never)
+    const res = (await invoke('mcp:regenerateToken')) as { success: boolean; error?: string }
+    expect(res.success).toBe(false)
+    expect(res.error).toContain('start failed')
+    expect(store.set).not.toHaveBeenCalled()
+  })
+
+  it('mcp:setPort while running succeeds: persists new port and starts with it', async () => {
+    const svc = makeService()
+    svc.running = true
+    const store = makeStore({ enabled: true, port: 4722, token: 'tok' })
+    registerMcpHandlers(store as never, svc as never)
+    const res = (await invoke('mcp:setPort', { port: 5000 })) as {
+      success: boolean
+      data: { port: number }
+    }
+    expect(res.success).toBe(true)
+    expect(res.data.port).toBe(5000)
+    expect(svc.start).toHaveBeenCalledWith(5000, 'tok')
+    expect(store.set).toHaveBeenCalledWith('mcpSettings', {
+      enabled: true,
+      port: 5000,
+      token: 'tok'
+    })
   })
 })

--- a/apps/desktop/src/main/__tests__/mcp-handlers.test.ts
+++ b/apps/desktop/src/main/__tests__/mcp-handlers.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const handlers = new Map<string, (event: unknown, args: unknown) => unknown>()
+vi.mock('electron', () => ({
+  ipcMain: { handle: vi.fn((channel: string, fn: never) => handlers.set(channel, fn)) },
+  app: { getVersion: () => '0.0.0' }
+}))
+vi.mock('../window-manager', () => ({ windowManager: { broadcastToAll: vi.fn() } }))
+
+import { registerMcpHandlers, type McpSettings } from '../ipc/mcp-handlers'
+
+function makeStore(initial: McpSettings) {
+  let value = initial
+  return {
+    get: vi.fn(() => value),
+    set: vi.fn((_k: string, v: McpSettings) => {
+      value = v
+    })
+  } as never
+}
+
+function makeService() {
+  return {
+    start: vi.fn().mockResolvedValue(undefined),
+    stop: vi.fn().mockResolvedValue(undefined),
+    running: false,
+    approval: { respond: vi.fn() }
+  }
+}
+
+const invoke = (channel: string, args?: unknown) => handlers.get(channel)!({}, args)
+
+describe('mcp handlers', () => {
+  beforeEach(() => {
+    handlers.clear()
+    vi.clearAllMocks()
+  })
+
+  it('mcp:status returns persisted settings without starting the server', async () => {
+    const svc = makeService()
+    registerMcpHandlers(makeStore({ enabled: false, port: 4722, token: 'tok' }), svc as never)
+    const res = (await invoke('mcp:status')) as { success: boolean; data: { port: number } }
+    expect(res.success).toBe(true)
+    expect(res.data.port).toBe(4722)
+    expect(svc.start).not.toHaveBeenCalled()
+  })
+
+  it('mcp:setEnabled true starts the server and persists', async () => {
+    const svc = makeService()
+    const store = makeStore({ enabled: false, port: 4722, token: 'tok' })
+    registerMcpHandlers(store, svc as never)
+    const res = (await invoke('mcp:setEnabled', { enabled: true })) as { success: boolean }
+    expect(res.success).toBe(true)
+    expect(svc.start).toHaveBeenCalledWith(4722, 'tok')
+  })
+
+  it('mcp:setEnabled surfaces start errors (port busy) and keeps enabled=false', async () => {
+    const svc = makeService()
+    svc.start.mockRejectedValue(new Error('EADDRINUSE'))
+    const store = makeStore({ enabled: false, port: 4722, token: 'tok' })
+    registerMcpHandlers(store, svc as never)
+    const res = (await invoke('mcp:setEnabled', { enabled: true })) as {
+      success: boolean
+      error?: string
+    }
+    expect(res.success).toBe(false)
+    expect(res.error).toContain('EADDRINUSE')
+  })
+
+  it('mcp:regenerateToken produces a new 64-char hex token', async () => {
+    const store = makeStore({ enabled: false, port: 4722, token: 'old' })
+    registerMcpHandlers(store, makeService() as never)
+    const res = (await invoke('mcp:regenerateToken')) as { data: { token: string } }
+    expect(res.data.token).toMatch(/^[0-9a-f]{64}$/)
+    expect(res.data.token).not.toBe('old')
+  })
+})

--- a/apps/desktop/src/main/__tests__/mcp-read-guard.test.ts
+++ b/apps/desktop/src/main/__tests__/mcp-read-guard.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { ConnectionConfig } from '@shared/index'
+
+const mockAdapter = {
+  dbType: 'postgresql',
+  query: vi.fn(),
+  beginTransaction: vi.fn(),
+  queryInTransaction: vi.fn(),
+  rollbackTransaction: vi.fn()
+}
+
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}))
+
+vi.mock('../db-adapter', () => ({
+  getAdapter: vi.fn(() => mockAdapter)
+}))
+
+import { assertSingleReadStatement, runReadOnlyQuery, MCP_MAX_ROWS } from '../mcp/read-guard'
+
+const pgConfig = {
+  id: 'c1',
+  name: 'local',
+  dbType: 'postgresql',
+  host: 'localhost',
+  port: 5432,
+  database: 'test'
+} as unknown as ConnectionConfig
+
+describe('assertSingleReadStatement', () => {
+  it('accepts a single SELECT', () => {
+    expect(assertSingleReadStatement('SELECT 1', 'postgresql')).toBe('SELECT 1')
+  })
+
+  it('rejects multiple statements', () => {
+    expect(() => assertSingleReadStatement('SELECT 1; DROP TABLE users', 'postgresql')).toThrow(
+      /single statement/i
+    )
+  })
+
+  it('rejects statements starting with a write keyword', () => {
+    expect(() => assertSingleReadStatement('DELETE FROM users', 'postgresql')).toThrow(
+      /read-only/i
+    )
+  })
+
+  it('rejects WITH ... INSERT (data-modifying CTE)', () => {
+    expect(() =>
+      assertSingleReadStatement('WITH x AS (SELECT 1) INSERT INTO t SELECT * FROM x', 'postgresql')
+    ).toThrow(/read-only/i)
+  })
+
+  it('accepts EXPLAIN and SHOW', () => {
+    expect(assertSingleReadStatement('EXPLAIN SELECT 1', 'postgresql')).toBe('EXPLAIN SELECT 1')
+    expect(assertSingleReadStatement('SHOW server_version', 'postgresql')).toBe(
+      'SHOW server_version'
+    )
+  })
+})
+
+describe('runReadOnlyQuery', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAdapter.beginTransaction.mockResolvedValue(undefined)
+    mockAdapter.queryInTransaction.mockResolvedValue({ rows: [], fields: [], rowCount: 0 })
+    mockAdapter.rollbackTransaction.mockResolvedValue(undefined)
+  })
+
+  it('runs postgres queries in a read-only transaction and rolls back', async () => {
+    mockAdapter.queryInTransaction
+      .mockResolvedValueOnce({ rows: [], fields: [], rowCount: null })
+      .mockResolvedValueOnce({ rows: [{ n: 1 }], fields: [], rowCount: 1 })
+
+    const result = await runReadOnlyQuery(pgConfig, 'SELECT 1')
+
+    expect(mockAdapter.beginTransaction).toHaveBeenCalledOnce()
+    expect(mockAdapter.queryInTransaction).toHaveBeenNthCalledWith(
+      1,
+      pgConfig,
+      expect.any(String),
+      'SET TRANSACTION READ ONLY'
+    )
+    expect(mockAdapter.rollbackTransaction).toHaveBeenCalledOnce()
+    expect(result.rows).toEqual([{ n: 1 }])
+  })
+
+  it('rolls back even when the query throws', async () => {
+    mockAdapter.queryInTransaction
+      .mockResolvedValueOnce({ rows: [], fields: [], rowCount: null })
+      .mockRejectedValueOnce(new Error('syntax error'))
+
+    await expect(runReadOnlyQuery(pgConfig, 'SELECT oops')).rejects.toThrow('syntax error')
+    expect(mockAdapter.rollbackTransaction).toHaveBeenCalledOnce()
+  })
+
+  it('caps returned rows at maxRows', async () => {
+    const rows = Array.from({ length: 600 }, (_, i) => ({ i }))
+    mockAdapter.queryInTransaction
+      .mockResolvedValueOnce({ rows: [], fields: [], rowCount: null })
+      .mockResolvedValueOnce({ rows, fields: [], rowCount: 600 })
+
+    const result = await runReadOnlyQuery(pgConfig, 'SELECT * FROM big')
+    expect(result.rows).toHaveLength(MCP_MAX_ROWS)
+  })
+
+  it('falls back to plain query with keyword guard when adapter has no transactions', async () => {
+    const bare = { dbType: 'mssql', query: vi.fn().mockResolvedValue({ rows: [], fields: [], rowCount: 0 }) }
+    const { getAdapter } = await import('../db-adapter')
+    vi.mocked(getAdapter).mockReturnValueOnce(bare as never)
+
+    const mssqlConfig = { ...pgConfig, dbType: 'mssql' } as ConnectionConfig
+    await runReadOnlyQuery(mssqlConfig, 'SELECT 1')
+    expect(bare.query).toHaveBeenCalledWith(mssqlConfig, 'SELECT 1')
+  })
+})

--- a/apps/desktop/src/main/__tests__/mcp-read-guard.test.ts
+++ b/apps/desktop/src/main/__tests__/mcp-read-guard.test.ts
@@ -67,6 +67,26 @@ describe('assertSingleReadStatement', () => {
       /read-only/i
     )
   })
+
+  it('accepts a SELECT wrapped in parentheses', () => {
+    expect(assertSingleReadStatement('(SELECT 1)', 'postgresql')).toBe('(SELECT 1)')
+  })
+
+  it('accepts SELECT with a write keyword inside a single-quoted string', () => {
+    expect(assertSingleReadStatement("SELECT 'insert'", 'postgresql')).toBe("SELECT 'insert'")
+  })
+
+  it('accepts SELECT with a write keyword inside a double-quoted identifier', () => {
+    expect(assertSingleReadStatement('SELECT "update" FROM t', 'postgresql')).toBe(
+      'SELECT "update" FROM t'
+    )
+  })
+
+  it('still rejects SELECT ... INTO after literal stripping', () => {
+    expect(() => assertSingleReadStatement('SELECT * INTO t2 FROM t1', 'mssql')).toThrow(
+      /read-only/i
+    )
+  })
 })
 
 describe('runReadOnlyQuery', () => {

--- a/apps/desktop/src/main/__tests__/mcp-read-guard.test.ts
+++ b/apps/desktop/src/main/__tests__/mcp-read-guard.test.ts
@@ -40,9 +40,7 @@ describe('assertSingleReadStatement', () => {
   })
 
   it('rejects statements starting with a write keyword', () => {
-    expect(() => assertSingleReadStatement('DELETE FROM users', 'postgresql')).toThrow(
-      /read-only/i
-    )
+    expect(() => assertSingleReadStatement('DELETE FROM users', 'postgresql')).toThrow(/read-only/i)
   })
 
   it('rejects WITH ... INSERT (data-modifying CTE)', () => {
@@ -55,6 +53,18 @@ describe('assertSingleReadStatement', () => {
     expect(assertSingleReadStatement('EXPLAIN SELECT 1', 'postgresql')).toBe('EXPLAIN SELECT 1')
     expect(assertSingleReadStatement('SHOW server_version', 'postgresql')).toBe(
       'SHOW server_version'
+    )
+  })
+
+  it('rejects SELECT ... INTO', () => {
+    expect(() => assertSingleReadStatement('SELECT * INTO t2 FROM t1', 'mssql')).toThrow(
+      /read-only/i
+    )
+  })
+
+  it('rejects PRAGMA', () => {
+    expect(() => assertSingleReadStatement('PRAGMA user_version = 5', 'postgresql')).toThrow(
+      /read-only/i
     )
   })
 })
@@ -105,7 +115,10 @@ describe('runReadOnlyQuery', () => {
   })
 
   it('falls back to plain query with keyword guard when adapter has no transactions', async () => {
-    const bare = { dbType: 'mssql', query: vi.fn().mockResolvedValue({ rows: [], fields: [], rowCount: 0 }) }
+    const bare = {
+      dbType: 'mssql',
+      query: vi.fn().mockResolvedValue({ rows: [], fields: [], rowCount: 0 })
+    }
     const { getAdapter } = await import('../db-adapter')
     vi.mocked(getAdapter).mockReturnValueOnce(bare as never)
 

--- a/apps/desktop/src/main/__tests__/mcp-server.test.ts
+++ b/apps/desktop/src/main/__tests__/mcp-server.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+
+vi.mock('../db-adapter', () => ({ getAdapter: vi.fn() }))
+vi.mock('../schema-cache', () => ({
+  getCachedSchema: vi.fn(),
+  isCacheValid: vi.fn(),
+  getOrFetchCachedSchema: vi.fn()
+}))
+vi.mock('electron', () => ({ app: { getVersion: () => '0.0.0' } }))
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() })
+}))
+
+import { McpService } from '../mcp/server'
+import { ApprovalManager } from '../mcp/approval'
+
+const TOKEN = 'test-token'
+const PORT = 47221
+
+function service(): McpService {
+  return new McpService({
+    getConnections: () => [],
+    approval: new ApprovalManager(() => undefined)
+  })
+}
+
+let svc: McpService
+afterEach(async () => {
+  await svc?.stop()
+})
+
+describe('McpService', () => {
+  it('rejects requests without a valid bearer token', async () => {
+    svc = service()
+    await svc.start(PORT, TOKEN)
+    const res = await fetch(`http://127.0.0.1:${PORT}/mcp`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{}'
+    })
+    expect(res.status).toBe(401)
+    const bad = await fetch(`http://127.0.0.1:${PORT}/mcp`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: 'Bearer wrong' },
+      body: '{}'
+    })
+    expect(bad.status).toBe(401)
+  })
+
+  it('answers an MCP initialize request with a valid token', async () => {
+    svc = service()
+    await svc.start(PORT, TOKEN)
+    const res = await fetch(`http://127.0.0.1:${PORT}/mcp`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+        authorization: `Bearer ${TOKEN}`
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-03-26',
+          capabilities: {},
+          clientInfo: { name: 'test', version: '0.0.0' }
+        }
+      })
+    })
+    expect(res.status).toBe(200)
+    const body = await res.text()
+    expect(body).toContain('data-peek')
+  })
+
+  it('returns 404 for other paths', async () => {
+    svc = service()
+    await svc.start(PORT, TOKEN)
+    const res = await fetch(`http://127.0.0.1:${PORT}/other`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${TOKEN}` }
+    })
+    expect(res.status).toBe(404)
+  })
+
+  it('rejects start when the port is in use, and stop is idempotent', async () => {
+    svc = service()
+    await svc.start(PORT, TOKEN)
+    const second = service()
+    await expect(second.start(PORT, TOKEN)).rejects.toThrow()
+    await svc.stop()
+    await svc.stop()
+    expect(svc.running).toBe(false)
+  })
+})

--- a/apps/desktop/src/main/__tests__/mcp-tools.test.ts
+++ b/apps/desktop/src/main/__tests__/mcp-tools.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
+import type { ConnectionConfig } from '@shared/index'
+
+const mockAdapter = vi.hoisted(() => ({
+  execute: vi.fn().mockResolvedValue({ rowCount: 1 }),
+  explain: vi.fn().mockResolvedValue({ plan: { cost: 1 }, durationMs: 2 }),
+  getSchemas: vi.fn().mockResolvedValue([]),
+  getTypes: vi.fn().mockResolvedValue([])
+}))
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}))
+vi.mock('../db-adapter', () => ({ getAdapter: vi.fn(() => mockAdapter) }))
+vi.mock('../mcp/read-guard', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  runReadOnlyQuery: vi.fn().mockResolvedValue({ rows: [{ n: 1 }], fields: [], rowCount: 1 })
+}))
+vi.mock('../schema-cache', () => ({
+  getCachedSchema: vi.fn(() => undefined),
+  isCacheValid: vi.fn(() => false),
+  getOrFetchCachedSchema: vi.fn(async (_c, fetcher) => fetcher())
+}))
+
+import { registerMcpTools } from '../mcp/tools'
+import { ApprovalManager } from '../mcp/approval'
+
+const conn = {
+  id: 'c1',
+  name: 'local pg',
+  dbType: 'postgresql',
+  host: 'localhost',
+  port: 5432,
+  database: 'app',
+  user: 'admin',
+  password: 'hunter2'
+} as unknown as ConnectionConfig
+
+async function connectedClient(approval: ApprovalManager) {
+  const server = new McpServer({ name: 'data-peek', version: '0.0.0' })
+  registerMcpTools(server, { getConnections: () => [conn], approval })
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+  const client = new Client({ name: 'test', version: '0.0.0' })
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)])
+  return client
+}
+
+describe('mcp tools', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('list_connections omits credentials', async () => {
+    const client = await connectedClient(new ApprovalManager(() => undefined))
+    const res = await client.callTool({ name: 'list_connections', arguments: {} })
+    const text = (res.content as Array<{ text: string }>)[0].text
+    expect(text).toContain('local pg')
+    expect(text).not.toContain('hunter2')
+    expect(text).not.toContain('admin')
+  })
+
+  it('run_query returns rows for a known connection', async () => {
+    const client = await connectedClient(new ApprovalManager(() => undefined))
+    const res = await client.callTool({
+      name: 'run_query',
+      arguments: { connectionId: 'c1', sql: 'SELECT 1' }
+    })
+    expect((res.content as Array<{ text: string }>)[0].text).toContain('"n": 1')
+  })
+
+  it('run_query errors on unknown connection', async () => {
+    const client = await connectedClient(new ApprovalManager(() => undefined))
+    const res = await client.callTool({
+      name: 'run_query',
+      arguments: { connectionId: 'nope', sql: 'SELECT 1' }
+    })
+    expect(res.isError).toBe(true)
+  })
+
+  it('execute_statement runs after approval', async () => {
+    const approval = new ApprovalManager((req) => approval.respond(req.id, true))
+    const client = await connectedClient(approval)
+    const res = await client.callTool({
+      name: 'execute_statement',
+      arguments: { connectionId: 'c1', sql: 'UPDATE t SET x = 1' }
+    })
+    expect(res.isError).toBeFalsy()
+    expect(mockAdapter.execute).toHaveBeenCalledWith(conn, 'UPDATE t SET x = 1', [])
+  })
+
+  it('execute_statement returns an error when rejected', async () => {
+    const approval = new ApprovalManager((req) => approval.respond(req.id, false))
+    const client = await connectedClient(approval)
+    const res = await client.callTool({
+      name: 'execute_statement',
+      arguments: { connectionId: 'c1', sql: 'DROP TABLE t' }
+    })
+    expect(res.isError).toBe(true)
+    expect((res.content as Array<{ text: string }>)[0].text).toMatch(/rejected/i)
+    expect(mockAdapter.execute).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/main/__tests__/mcp-tools.test.ts
+++ b/apps/desktop/src/main/__tests__/mcp-tools.test.ts
@@ -100,6 +100,20 @@ describe('mcp tools', () => {
     expect(mockAdapter.execute).not.toHaveBeenCalled()
   })
 
+  it('execute_statement rejects multiple statements without requesting approval', async () => {
+    const approvalSpy = vi.fn()
+    const approval = new ApprovalManager(approvalSpy)
+    const client = await connectedClient(approval)
+    const res = await client.callTool({
+      name: 'execute_statement',
+      arguments: { connectionId: 'c1', sql: 'UPDATE t SET x=1; DROP TABLE t' }
+    })
+    expect(res.isError).toBe(true)
+    expect((res.content as Array<{ text: string }>)[0].text).toMatch(/single statement/i)
+    expect(approvalSpy).not.toHaveBeenCalled()
+    expect(mockAdapter.execute).not.toHaveBeenCalled()
+  })
+
   it('explain_query rejects statement injection without calling explain', async () => {
     const client = await connectedClient(new ApprovalManager(() => undefined))
     const res = await client.callTool({

--- a/apps/desktop/src/main/__tests__/mcp-tools.test.ts
+++ b/apps/desktop/src/main/__tests__/mcp-tools.test.ts
@@ -99,4 +99,24 @@ describe('mcp tools', () => {
     expect((res.content as Array<{ text: string }>)[0].text).toMatch(/rejected/i)
     expect(mockAdapter.execute).not.toHaveBeenCalled()
   })
+
+  it('explain_query rejects statement injection without calling explain', async () => {
+    const client = await connectedClient(new ApprovalManager(() => undefined))
+    const res = await client.callTool({
+      name: 'explain_query',
+      arguments: { connectionId: 'c1', sql: 'SELECT 1; DELETE FROM t' }
+    })
+    expect(res.isError).toBe(true)
+    expect(mockAdapter.explain).not.toHaveBeenCalled()
+  })
+
+  it('explain_query returns the plan for a single statement', async () => {
+    const client = await connectedClient(new ApprovalManager(() => undefined))
+    const res = await client.callTool({
+      name: 'explain_query',
+      arguments: { connectionId: 'c1', sql: 'SELECT 1' }
+    })
+    expect(res.isError).toBeFalsy()
+    expect((res.content as Array<{ text: string }>)[0].text).toContain('"cost": 1')
+  })
 })

--- a/apps/desktop/src/main/__tests__/register-all-handlers.test.ts
+++ b/apps/desktop/src/main/__tests__/register-all-handlers.test.ts
@@ -110,6 +110,14 @@ vi.mock('../ipc/intel-handlers', () => ({
   registerIntelHandlers: hoisted.registerIntelHandlers
 }))
 vi.mock('../ipc/step-handlers', () => ({ registerStepHandlers: hoisted.registerStepHandlers }))
+// mcp-handlers isn't called by registerAllHandlers, but the barrel re-exports it and its
+// real module pulls in window-manager → electron, which can't load under node vitest.
+vi.mock('../ipc/mcp-handlers', () => ({
+  registerMcpHandlers: vi.fn(),
+  startMcpIfEnabled: vi.fn(),
+  createMcpService: vi.fn(),
+  MCP_SETTINGS_DEFAULTS: { enabled: false, port: 4722, token: '' }
+}))
 
 import { registerAllHandlers } from '../ipc'
 import type { DpStorage } from '../storage'

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -111,6 +111,33 @@ async function createConnectionsStore(): Promise<
 }
 
 /**
+ * Create the MCP settings store, preferring OS-encrypted storage. This store holds a
+ * bearer token that grants read access to every configured DB connection, so it should
+ * be encrypted just like connection credentials. Falls back to plaintext if secure
+ * storage is unavailable (e.g. a Linux box without a keyring), logging the degradation.
+ */
+async function createMcpSettingsStore(): Promise<PersistentStore<{ mcpSettings: McpSettings }>> {
+  try {
+    return await DpSecureStorage.create<{ mcpSettings: McpSettings }>({
+      name: 'data-peek-mcp-secure',
+      defaults: { mcpSettings: MCP_SETTINGS_DEFAULTS }
+    })
+  } catch (error) {
+    if (error instanceof EncryptionUnavailableError) {
+      log.warn(
+        'Secure storage unavailable — the MCP bearer token will be stored unencrypted on this machine.'
+      )
+    } else {
+      log.error('Failed to open encrypted MCP settings store, falling back to plaintext:', error)
+    }
+    return DpStorage.create<{ mcpSettings: McpSettings }>({
+      name: 'data-peek-mcp',
+      defaults: { mcpSettings: MCP_SETTINGS_DEFAULTS }
+    })
+  }
+}
+
+/**
  * Initialize all persistent stores
  */
 async function initStores(): Promise<void> {
@@ -140,10 +167,7 @@ async function initStores(): Promise<void> {
   // Initialize schema cache
   await initSchemaCache()
 
-  mcpStore = await DpStorage.create<{ mcpSettings: McpSettings }>({
-    name: 'data-peek-mcp',
-    defaults: { mcpSettings: MCP_SETTINGS_DEFAULTS }
-  })
+  mcpStore = await createMcpSettingsStore()
   mcpService = createMcpService(() => store.get('connections', []))
 }
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -20,7 +20,15 @@ import {
 import { NotebookStorage } from './notebook-storage'
 import { TimeMachineStorage } from './time-machine-storage'
 import { initSchemaCache } from './schema-cache'
-import { registerAllHandlers } from './ipc'
+import {
+  registerAllHandlers,
+  createMcpService,
+  registerMcpHandlers,
+  startMcpIfEnabled,
+  MCP_SETTINGS_DEFAULTS,
+  type McpSettings
+} from './ipc'
+import type { McpServiceWithApproval } from './ipc/mcp-handlers'
 import { setForceQuit } from './app-state'
 import { windowManager } from './window-manager'
 import { initSchedulerService, stopAllSchedules } from './scheduler-service'
@@ -40,6 +48,8 @@ let savedQueriesStore: DpStorage<{ savedQueries: SavedQuery[] }>
 let snippetsStore: DpStorage<{ snippets: Snippet[] }>
 let queryHistoryStore: DpStorage<{ queryHistory: QueryHistoryEntry[] }>
 let timeMachineStorage: TimeMachineStorage | null = null
+let mcpStore: PersistentStore<{ mcpSettings: McpSettings }>
+let mcpService: McpServiceWithApproval
 
 const stepSessionRegistry = new StepSessionRegistry()
 
@@ -129,6 +139,12 @@ async function initStores(): Promise<void> {
 
   // Initialize schema cache
   await initSchemaCache()
+
+  mcpStore = await DpStorage.create<{ mcpSettings: McpSettings }>({
+    name: 'data-peek-mcp',
+    defaults: { mcpSettings: MCP_SETTINGS_DEFAULTS }
+  })
+  mcpService = createMcpService(() => store.get('connections', []))
 }
 
 // Set app name for macOS dock and Mission Control
@@ -242,6 +258,9 @@ app.whenReady().then(async () => {
     stepSessionRegistry
   )
 
+  registerMcpHandlers(mcpStore, mcpService)
+  void startMcpIfEnabled(mcpStore, mcpService)
+
   // Create initial window
   await windowManager.createWindow()
 
@@ -277,6 +296,7 @@ app.on('before-quit', (event) => {
   stopPeriodicChecks()
   stopAllSchedules()
   cleanupPgNotify()
+  void mcpService?.stop()
 
   // Roll back any open manual transactions first — their checked-out clients
   // would otherwise block pool.end() and leave transactions open server-side.

--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -145,3 +145,10 @@ export { registerNotebookHandlers } from './notebook-handlers'
 export { registerIntelHandlers } from './intel-handlers'
 export { registerStepHandlers } from './step-handlers'
 export { registerTimeMachineHandlers } from './time-machine-handlers'
+export {
+  registerMcpHandlers,
+  startMcpIfEnabled,
+  createMcpService,
+  MCP_SETTINGS_DEFAULTS,
+  type McpSettings
+} from './mcp-handlers'

--- a/apps/desktop/src/main/ipc/mcp-handlers.ts
+++ b/apps/desktop/src/main/ipc/mcp-handlers.ts
@@ -1,0 +1,135 @@
+import { ipcMain } from 'electron'
+import { randomBytes } from 'crypto'
+import type { ConnectionConfig, McpServerStatus } from '@shared/index'
+import type { PersistentStore } from '../storage'
+import { windowManager } from '../window-manager'
+import { wrapHandler } from './types'
+import { McpService, MCP_DEFAULT_PORT } from '../mcp/server'
+import { ApprovalManager } from '../mcp/approval'
+
+export interface McpSettings {
+  enabled: boolean
+  port: number
+  token: string
+}
+
+export const MCP_SETTINGS_DEFAULTS: McpSettings = {
+  enabled: false,
+  port: MCP_DEFAULT_PORT,
+  token: ''
+}
+
+type McpStore = PersistentStore<{ mcpSettings: McpSettings }>
+
+// The approval manager lives on the service instance so tools and IPC share it
+export interface McpServiceWithApproval extends McpService {
+  approval: ApprovalManager
+}
+
+export function createMcpService(getConnections: () => ConnectionConfig[]): McpServiceWithApproval {
+  const approval = new ApprovalManager((req) =>
+    windowManager.broadcastToAll('mcp:approval:request', req)
+  )
+  const service = new McpService({ getConnections, approval }) as McpServiceWithApproval
+  service.approval = approval
+  return service
+}
+
+function ensureToken(store: McpStore): McpSettings {
+  const settings = store.get('mcpSettings', MCP_SETTINGS_DEFAULTS)
+  if (!settings.token) {
+    const updated = { ...settings, token: randomBytes(32).toString('hex') }
+    store.set('mcpSettings', updated)
+    return updated
+  }
+  return settings
+}
+
+function toStatus(settings: McpSettings, service: McpService): McpServerStatus {
+  return {
+    enabled: settings.enabled,
+    running: service.running,
+    port: settings.port,
+    token: settings.token,
+    url: `http://127.0.0.1:${settings.port}/mcp`
+  }
+}
+
+async function applyEnabled(
+  store: McpStore,
+  service: McpService,
+  enabled: boolean
+): Promise<McpServerStatus> {
+  const settings = ensureToken(store)
+  if (enabled) {
+    await service.start(settings.port, settings.token) // throws on port busy; enabled stays false
+    store.set('mcpSettings', { ...settings, enabled: true })
+    return toStatus({ ...settings, enabled: true }, service)
+  }
+  await service.stop()
+  store.set('mcpSettings', { ...settings, enabled: false })
+  return toStatus({ ...settings, enabled: false }, service)
+}
+
+export async function startMcpIfEnabled(store: McpStore, service: McpService): Promise<void> {
+  const settings = store.get('mcpSettings', MCP_SETTINGS_DEFAULTS)
+  if (!settings.enabled) return
+  const withToken = ensureToken(store)
+  try {
+    await service.start(withToken.port, withToken.token)
+  } catch {
+    // Port taken at launch: stay stopped; the settings UI shows running=false
+  }
+}
+
+export function registerMcpHandlers(store: McpStore, service: McpServiceWithApproval): void {
+  ipcMain.handle(
+    'mcp:status',
+    wrapHandler(async () => toStatus(ensureToken(store), service))
+  )
+
+  ipcMain.handle(
+    'mcp:setEnabled',
+    wrapHandler(async (_e, { enabled }: { enabled: boolean }) =>
+      applyEnabled(store, service, enabled)
+    )
+  )
+
+  ipcMain.handle(
+    'mcp:setPort',
+    wrapHandler(async (_e, { port }: { port: number }) => {
+      if (!Number.isInteger(port) || port < 1024 || port > 65535) {
+        throw new Error('Port must be between 1024 and 65535')
+      }
+      const settings = ensureToken(store)
+      const updated = { ...settings, port }
+      store.set('mcpSettings', updated)
+      if (service.running) {
+        await service.stop()
+        await service.start(updated.port, updated.token)
+      }
+      return toStatus(updated, service)
+    })
+  )
+
+  ipcMain.handle(
+    'mcp:regenerateToken',
+    wrapHandler(async () => {
+      const settings = store.get('mcpSettings', MCP_SETTINGS_DEFAULTS)
+      const updated = { ...settings, token: randomBytes(32).toString('hex') }
+      store.set('mcpSettings', updated)
+      if (service.running) {
+        await service.stop()
+        await service.start(updated.port, updated.token)
+      }
+      return toStatus(updated, service)
+    })
+  )
+
+  ipcMain.handle(
+    'mcp:approval:respond',
+    wrapHandler(async (_e, { id, approved }: { id: string; approved: boolean }) => {
+      service.approval.respond(id, approved)
+    })
+  )
+}

--- a/apps/desktop/src/main/ipc/mcp-handlers.ts
+++ b/apps/desktop/src/main/ipc/mcp-handlers.ts
@@ -27,8 +27,10 @@ export interface McpServiceWithApproval extends McpService {
 }
 
 export function createMcpService(getConnections: () => ConnectionConfig[]): McpServiceWithApproval {
-  const approval = new ApprovalManager((req) =>
-    windowManager.broadcastToAll('mcp:approval:request', req)
+  const approval = new ApprovalManager(
+    (req) => windowManager.broadcastToAll('mcp:approval:request', req),
+    undefined,
+    (id) => windowManager.broadcastToAll('mcp:approval:resolved', { id })
   )
   const service = new McpService({ getConnections, approval }) as McpServiceWithApproval
   service.approval = approval

--- a/apps/desktop/src/main/ipc/mcp-handlers.ts
+++ b/apps/desktop/src/main/ipc/mcp-handlers.ts
@@ -103,11 +103,20 @@ export function registerMcpHandlers(store: McpStore, service: McpServiceWithAppr
       }
       const settings = ensureToken(store)
       const updated = { ...settings, port }
-      store.set('mcpSettings', updated)
       if (service.running) {
         await service.stop()
-        await service.start(updated.port, updated.token)
+        try {
+          await service.start(updated.port, updated.token)
+        } catch (err) {
+          try {
+            await service.start(settings.port, settings.token)
+          } catch {
+            // Best-effort restart with old settings failed; leave stopped
+          }
+          throw err
+        }
       }
+      store.set('mcpSettings', updated)
       return toStatus(updated, service)
     })
   )
@@ -117,11 +126,20 @@ export function registerMcpHandlers(store: McpStore, service: McpServiceWithAppr
     wrapHandler(async () => {
       const settings = store.get('mcpSettings', MCP_SETTINGS_DEFAULTS)
       const updated = { ...settings, token: randomBytes(32).toString('hex') }
-      store.set('mcpSettings', updated)
       if (service.running) {
         await service.stop()
-        await service.start(updated.port, updated.token)
+        try {
+          await service.start(updated.port, updated.token)
+        } catch (err) {
+          try {
+            await service.start(settings.port, settings.token)
+          } catch {
+            // Best-effort restart with old settings failed; leave stopped
+          }
+          throw err
+        }
       }
+      store.set('mcpSettings', updated)
       return toStatus(updated, service)
     })
   )

--- a/apps/desktop/src/main/mcp/approval.ts
+++ b/apps/desktop/src/main/mcp/approval.ts
@@ -8,7 +8,8 @@ interface Pending {
 
 export class ApprovalManager {
   private pending = new Map<string, Pending>()
-  private chain: Promise<unknown> = Promise.resolve()
+  private queue: Promise<unknown> = Promise.resolve()
+  private inFlight = 0
 
   constructor(
     private send: (req: McpApprovalRequest) => void,
@@ -27,8 +28,13 @@ export class ApprovalManager {
         this.send({ id, connectionName, sql })
       })
 
-    const result = this.chain.then(run, run)
-    this.chain = result.catch(() => undefined)
+    const exec = (): Promise<boolean> =>
+      run().finally(() => {
+        this.inFlight--
+      })
+    this.inFlight++
+    const result = this.inFlight === 1 ? exec() : this.queue.then(exec, exec)
+    this.queue = result.catch(() => undefined)
     return result
   }
 

--- a/apps/desktop/src/main/mcp/approval.ts
+++ b/apps/desktop/src/main/mcp/approval.ts
@@ -1,0 +1,42 @@
+import { randomUUID } from 'crypto'
+import type { McpApprovalRequest } from '@shared/index'
+
+interface Pending {
+  resolve: (approved: boolean) => void
+  timer: NodeJS.Timeout
+}
+
+export class ApprovalManager {
+  private pending = new Map<string, Pending>()
+  private chain: Promise<unknown> = Promise.resolve()
+
+  constructor(
+    private send: (req: McpApprovalRequest) => void,
+    private timeoutMs = 60_000
+  ) {}
+
+  request(connectionName: string, sql: string): Promise<boolean> {
+    const run = (): Promise<boolean> =>
+      new Promise<boolean>((resolve) => {
+        const id = randomUUID()
+        const timer = setTimeout(() => {
+          this.pending.delete(id)
+          resolve(false)
+        }, this.timeoutMs)
+        this.pending.set(id, { resolve, timer })
+        this.send({ id, connectionName, sql })
+      })
+
+    const result = this.chain.then(run, run)
+    this.chain = result.catch(() => undefined)
+    return result
+  }
+
+  respond(id: string, approved: boolean): void {
+    const entry = this.pending.get(id)
+    if (!entry) return
+    clearTimeout(entry.timer)
+    this.pending.delete(id)
+    entry.resolve(approved)
+  }
+}

--- a/apps/desktop/src/main/mcp/approval.ts
+++ b/apps/desktop/src/main/mcp/approval.ts
@@ -13,7 +13,8 @@ export class ApprovalManager {
 
   constructor(
     private send: (req: McpApprovalRequest) => void,
-    private timeoutMs = 60_000
+    private timeoutMs = 60_000,
+    private onResolved?: (id: string) => void
   ) {}
 
   request(connectionName: string, sql: string): Promise<boolean> {
@@ -23,6 +24,7 @@ export class ApprovalManager {
         const timer = setTimeout(() => {
           this.pending.delete(id)
           resolve(false)
+          this.onResolved?.(id)
         }, this.timeoutMs)
         this.pending.set(id, { resolve, timer })
         this.send({ id, connectionName, sql })
@@ -44,5 +46,6 @@ export class ApprovalManager {
     clearTimeout(entry.timer)
     this.pending.delete(id)
     entry.resolve(approved)
+    this.onResolved?.(id)
   }
 }

--- a/apps/desktop/src/main/mcp/read-guard.ts
+++ b/apps/desktop/src/main/mcp/read-guard.ts
@@ -1,0 +1,61 @@
+import { randomUUID } from 'crypto'
+import type { ConnectionConfig, DatabaseType } from '@shared/index'
+import { getAdapter, type AdapterQueryResult } from '../db-adapter'
+import { parseStatementsWithLines } from '../lib/parse-statements'
+
+export const MCP_MAX_ROWS = 500
+
+const READ_FIRST_KEYWORDS = new Set([
+  'select',
+  'show',
+  'explain',
+  'describe',
+  'desc',
+  'with',
+  'pragma',
+  'values',
+  'table'
+])
+const WRITE_KEYWORDS =
+  /\b(insert|update|delete|merge|drop|alter|create|truncate|grant|revoke|vacuum|exec|execute|call|copy)\b/i
+
+export function assertSingleReadStatement(sql: string, dbType: DatabaseType): string {
+  const statements = parseStatementsWithLines(sql, dbType)
+  if (statements.length !== 1) {
+    throw new Error('run_query accepts a single statement; use one tool call per statement')
+  }
+  const stmt = statements[0].sql.trim()
+  const first = stmt.split(/[\s(]+/)[0]?.toLowerCase() ?? ''
+  if (!READ_FIRST_KEYWORDS.has(first) || WRITE_KEYWORDS.test(stmt)) {
+    throw new Error('run_query is read-only; use execute_statement for writes or DDL')
+  }
+  return stmt
+}
+
+export async function runReadOnlyQuery(
+  config: ConnectionConfig,
+  sql: string,
+  maxRows: number = MCP_MAX_ROWS
+): Promise<AdapterQueryResult> {
+  const dbType = config.dbType || 'postgresql'
+  const stmt = assertSingleReadStatement(sql, dbType)
+  const adapter = getAdapter(config)
+  const cap = Math.min(Math.max(1, maxRows), MCP_MAX_ROWS)
+
+  if (adapter.beginTransaction && adapter.queryInTransaction && adapter.rollbackTransaction) {
+    const sessionId = `mcp-ro-${randomUUID()}`
+    await adapter.beginTransaction(config, sessionId)
+    try {
+      if (dbType === 'postgresql') {
+        await adapter.queryInTransaction(config, sessionId, 'SET TRANSACTION READ ONLY')
+      }
+      const result = await adapter.queryInTransaction(config, sessionId, stmt)
+      return { ...result, rows: result.rows.slice(0, cap) }
+    } finally {
+      await adapter.rollbackTransaction(config, sessionId).catch(() => undefined)
+    }
+  }
+
+  const result = await adapter.query(config, stmt)
+  return { ...result, rows: result.rows.slice(0, cap) }
+}

--- a/apps/desktop/src/main/mcp/read-guard.ts
+++ b/apps/desktop/src/main/mcp/read-guard.ts
@@ -12,12 +12,11 @@ const READ_FIRST_KEYWORDS = new Set([
   'describe',
   'desc',
   'with',
-  'pragma',
   'values',
   'table'
 ])
 const WRITE_KEYWORDS =
-  /\b(insert|update|delete|merge|drop|alter|create|truncate|grant|revoke|vacuum|exec|execute|call|copy)\b/i
+  /\b(insert|update|delete|merge|drop|alter|create|truncate|grant|revoke|vacuum|exec|execute|call|copy|into)\b/i
 
 export function assertSingleReadStatement(sql: string, dbType: DatabaseType): string {
   const statements = parseStatementsWithLines(sql, dbType)

--- a/apps/desktop/src/main/mcp/read-guard.ts
+++ b/apps/desktop/src/main/mcp/read-guard.ts
@@ -21,12 +21,13 @@ const WRITE_KEYWORDS =
 export function assertSingleReadStatement(sql: string, dbType: DatabaseType): string {
   const statements = parseStatementsWithLines(sql, dbType)
   if (statements.length !== 1) {
-    throw new Error('run_query accepts a single statement; use one tool call per statement')
+    throw new Error('This tool accepts a single statement; use one tool call per statement')
   }
   const stmt = statements[0].sql.trim()
-  const first = stmt.split(/[\s(]+/)[0]?.toLowerCase() ?? ''
-  if (!READ_FIRST_KEYWORDS.has(first) || WRITE_KEYWORDS.test(stmt)) {
-    throw new Error('run_query is read-only; use execute_statement for writes or DDL')
+  const first = stmt.match(/^[\s(]*([a-z]+)/i)?.[1]?.toLowerCase() ?? ''
+  const stripped = stmt.replace(/'(?:[^']|'')*'/g, '').replace(/"[^"]*"/g, '')
+  if (!READ_FIRST_KEYWORDS.has(first) || WRITE_KEYWORDS.test(stripped)) {
+    throw new Error('This tool is read-only; use execute_statement for writes or DDL')
   }
   return stmt
 }

--- a/apps/desktop/src/main/mcp/server.ts
+++ b/apps/desktop/src/main/mcp/server.ts
@@ -1,0 +1,86 @@
+import http from 'http'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
+import { app } from 'electron'
+import { createLogger } from '../lib/logger'
+import { registerMcpTools, type McpToolDeps } from './tools'
+
+const log = createLogger('mcp-server')
+
+export const MCP_DEFAULT_PORT = 4722
+
+export class McpService {
+  private httpServer: http.Server | null = null
+
+  constructor(private deps: McpToolDeps) {}
+
+  get running(): boolean {
+    return this.httpServer !== null
+  }
+
+  async start(port: number, token: string): Promise<void> {
+    if (this.httpServer) await this.stop()
+
+    const server = http.createServer((req, res) => {
+      void this.handleRequest(req, res, token)
+    })
+    server.keepAliveTimeout = 0
+
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(port, '127.0.0.1', () => {
+        server.removeListener('error', reject)
+        resolve()
+      })
+    })
+
+    this.httpServer = server
+    log.debug(`MCP server listening on 127.0.0.1:${port}`)
+  }
+
+  async stop(): Promise<void> {
+    const server = this.httpServer
+    if (!server) return
+    this.httpServer = null
+    await new Promise<void>((resolve) => {
+      server.closeAllConnections()
+      server.close(() => resolve())
+    })
+    log.debug('MCP server stopped')
+  }
+
+  private async handleRequest(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    token: string
+  ): Promise<void> {
+    try {
+      res.setHeader('Connection', 'close')
+      if (req.headers.authorization !== `Bearer ${token}`) {
+        res.writeHead(401).end()
+        return
+      }
+      const url = new URL(req.url ?? '/', 'http://127.0.0.1')
+      if (url.pathname !== '/mcp') {
+        res.writeHead(404).end()
+        return
+      }
+
+      const mcpServer = new McpServer({
+        name: 'data-peek',
+        version: app?.getVersion?.() ?? '0.0.0'
+      })
+      registerMcpTools(mcpServer, this.deps)
+      const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined })
+      res.on('close', () => {
+        void transport.close()
+        void mcpServer.close()
+      })
+      await mcpServer.connect(transport)
+      await transport.handleRequest(req, res)
+    } catch (err) {
+      log.error('MCP request failed:', err)
+      if (!res.headersSent) res.writeHead(500).end()
+    }
+  }
+}

--- a/apps/desktop/src/main/mcp/tools.ts
+++ b/apps/desktop/src/main/mcp/tools.ts
@@ -1,0 +1,134 @@
+import { z } from 'zod'
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { ConnectionConfig } from '@shared/index'
+import { getAdapter } from '../db-adapter'
+import { getCachedSchema, isCacheValid, getOrFetchCachedSchema } from '../schema-cache'
+import { runReadOnlyQuery, MCP_MAX_ROWS } from './read-guard'
+import type { ApprovalManager } from './approval'
+
+export interface McpToolDeps {
+  getConnections: () => ConnectionConfig[]
+  approval: ApprovalManager
+}
+
+type ToolResult = {
+  content: Array<{ type: 'text'; text: string }>
+  isError?: boolean
+}
+
+function ok(payload: unknown): ToolResult {
+  return { content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }] }
+}
+
+function fail(message: string): ToolResult {
+  return { isError: true, content: [{ type: 'text', text: message }] }
+}
+
+function findConnection(deps: McpToolDeps, connectionId: string): ConnectionConfig {
+  const conn = deps.getConnections().find((c) => c.id === connectionId)
+  if (!conn) {
+    throw new Error(`Unknown connectionId "${connectionId}". Call list_connections first.`)
+  }
+  return conn
+}
+
+async function withToolErrors(fn: () => Promise<ToolResult>): Promise<ToolResult> {
+  try {
+    return await fn()
+  } catch (err) {
+    return fail(err instanceof Error ? err.message : String(err))
+  }
+}
+
+export function registerMcpTools(server: McpServer, deps: McpToolDeps): void {
+  server.registerTool(
+    'list_connections',
+    {
+      description:
+        'List saved database connections. Returns id, name, dbType, host, port, database. Never returns credentials.'
+    },
+    async () =>
+      ok(
+        deps.getConnections().map((c) => ({
+          id: c.id,
+          name: c.name,
+          dbType: c.dbType || 'postgresql',
+          host: c.host,
+          port: c.port,
+          database: c.database
+        }))
+      )
+  )
+
+  server.registerTool(
+    'list_schemas',
+    {
+      description: 'List schemas, tables, and columns for a connection.',
+      inputSchema: { connectionId: z.string() }
+    },
+    async ({ connectionId }) =>
+      withToolErrors(async () => {
+        const conn = findConnection(deps, connectionId)
+        const cached = getCachedSchema(conn)
+        if (cached && isCacheValid(cached)) return ok(cached.schemas)
+        const fresh = await getOrFetchCachedSchema(conn, async () => {
+          const adapter = getAdapter(conn)
+          const [schemas, customTypes] = await Promise.all([
+            adapter.getSchemas(conn),
+            adapter.getTypes(conn)
+          ])
+          return { schemas, customTypes, timestamp: Date.now() }
+        })
+        return ok(fresh.schemas)
+      })
+  )
+
+  server.registerTool(
+    'run_query',
+    {
+      description: `Run a single read-only SQL statement. Executes inside a transaction that is always rolled back; PostgreSQL additionally enforces READ ONLY at the database level. Rows are capped at ${MCP_MAX_ROWS}. Use execute_statement for writes/DDL.`,
+      inputSchema: {
+        connectionId: z.string(),
+        sql: z.string(),
+        maxRows: z.number().int().min(1).max(MCP_MAX_ROWS).optional()
+      }
+    },
+    async ({ connectionId, sql, maxRows }) =>
+      withToolErrors(async () => {
+        const conn = findConnection(deps, connectionId)
+        const result = await runReadOnlyQuery(conn, sql, maxRows)
+        return ok({ rows: result.rows, rowCount: result.rowCount })
+      })
+  )
+
+  server.registerTool(
+    'explain_query',
+    {
+      description: 'Get the execution plan for a SQL statement (EXPLAIN, no ANALYZE).',
+      inputSchema: { connectionId: z.string(), sql: z.string() }
+    },
+    async ({ connectionId, sql }) =>
+      withToolErrors(async () => {
+        const conn = findConnection(deps, connectionId)
+        const result = await getAdapter(conn).explain(conn, sql, false)
+        return ok(result.plan)
+      })
+  )
+
+  server.registerTool(
+    'execute_statement',
+    {
+      description:
+        'Execute a write or DDL statement. The data-peek user must approve each statement in the app; the call blocks until they respond (60s timeout = rejection). Do not retry a rejected statement.',
+      inputSchema: { connectionId: z.string(), sql: z.string() }
+    },
+    async ({ connectionId, sql }) =>
+      withToolErrors(async () => {
+        const conn = findConnection(deps, connectionId)
+        const approved = await deps.approval.request(conn.name, sql)
+        if (!approved) return fail('User rejected the statement')
+        const result = await getAdapter(conn).execute(conn, sql, [])
+        return ok({ rowCount: result.rowCount })
+      })
+  )
+}

--- a/apps/desktop/src/main/mcp/tools.ts
+++ b/apps/desktop/src/main/mcp/tools.ts
@@ -3,7 +3,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import type { ConnectionConfig } from '@shared/index'
 import { getAdapter } from '../db-adapter'
 import { getCachedSchema, isCacheValid, getOrFetchCachedSchema } from '../schema-cache'
-import { runReadOnlyQuery, MCP_MAX_ROWS } from './read-guard'
+import { runReadOnlyQuery, assertSingleReadStatement, MCP_MAX_ROWS } from './read-guard'
 import type { ApprovalManager } from './approval'
 
 export interface McpToolDeps {
@@ -110,7 +110,8 @@ export function registerMcpTools(server: McpServer, deps: McpToolDeps): void {
     async ({ connectionId, sql }) =>
       withToolErrors(async () => {
         const conn = findConnection(deps, connectionId)
-        const result = await getAdapter(conn).explain(conn, sql, false)
+        const stmt = assertSingleReadStatement(sql, conn.dbType || 'postgresql')
+        const result = await getAdapter(conn).explain(conn, stmt, false)
         return ok(result.plan)
       })
   )

--- a/apps/desktop/src/main/mcp/tools.ts
+++ b/apps/desktop/src/main/mcp/tools.ts
@@ -5,6 +5,7 @@ import { getAdapter } from '../db-adapter'
 import { getCachedSchema, isCacheValid, getOrFetchCachedSchema } from '../schema-cache'
 import { runReadOnlyQuery, assertSingleReadStatement, MCP_MAX_ROWS } from './read-guard'
 import type { ApprovalManager } from './approval'
+import { parseStatementsWithLines } from '../lib/parse-statements'
 
 export interface McpToolDeps {
   getConnections: () => ConnectionConfig[]
@@ -126,9 +127,16 @@ export function registerMcpTools(server: McpServer, deps: McpToolDeps): void {
     async ({ connectionId, sql }) =>
       withToolErrors(async () => {
         const conn = findConnection(deps, connectionId)
-        const approved = await deps.approval.request(conn.name, sql)
+        const statements = parseStatementsWithLines(sql, conn.dbType || 'postgresql')
+        if (statements.length !== 1) {
+          return fail(
+            'execute_statement accepts a single statement; use one tool call per statement'
+          )
+        }
+        const stmt = statements[0].sql.trim()
+        const approved = await deps.approval.request(conn.name, stmt)
         if (!approved) return fail('User rejected the statement')
-        const result = await getAdapter(conn).execute(conn, sql, [])
+        const result = await getAdapter(conn).execute(conn, stmt, [])
         return ok({ rowCount: result.rowCount })
       })
   )

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -542,6 +542,7 @@ interface DataPeekApi {
     regenerateToken: () => Promise<IpcResponse<McpServerStatus>>
     respondToApproval: (id: string, approved: boolean) => Promise<IpcResponse<void>>
     onApprovalRequest: (callback: (req: McpApprovalRequest) => void) => () => void
+    onApprovalResolved: (callback: (payload: { id: string }) => void) => () => void
   }
 }
 

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -76,7 +76,9 @@ import type {
   TimeMachineRunMeta,
   TimeMachineSnapshot,
   TimeMachineListResult,
-  TimeMachineStats
+  TimeMachineStats,
+  McpServerStatus,
+  McpApprovalRequest
 } from '@shared/index'
 
 // AI Types
@@ -532,6 +534,14 @@ interface DataPeekApi {
     maximize: () => Promise<void>
     close: () => Promise<void>
     setConnectionInfo: (connectionName: string | null) => void
+  }
+  mcp: {
+    status: () => Promise<IpcResponse<McpServerStatus>>
+    setEnabled: (enabled: boolean) => Promise<IpcResponse<McpServerStatus>>
+    setPort: (port: number) => Promise<IpcResponse<McpServerStatus>>
+    regenerateToken: () => Promise<IpcResponse<McpServerStatus>>
+    respondToApproval: (id: string, approved: boolean) => Promise<IpcResponse<void>>
+    onApprovalRequest: (callback: (req: McpApprovalRequest) => void) => () => void
   }
 }
 

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -719,6 +719,11 @@ const api = {
       const listener = (_event: unknown, req: McpApprovalRequest): void => callback(req)
       ipcRenderer.on('mcp:approval:request', listener)
       return () => ipcRenderer.removeListener('mcp:approval:request', listener)
+    },
+    onApprovalResolved: (callback: (payload: { id: string }) => void): (() => void) => {
+      const listener = (_event: unknown, payload: { id: string }): void => callback(payload)
+      ipcRenderer.on('mcp:approval:resolved', listener)
+      return () => ipcRenderer.removeListener('mcp:approval:resolved', listener)
     }
   }
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -84,7 +84,9 @@ import type {
   TimeMachineRunMeta,
   TimeMachineSnapshot,
   TimeMachineListResult,
-  TimeMachineStats
+  TimeMachineStats,
+  McpServerStatus,
+  McpApprovalRequest
 } from '@shared/index'
 
 // Re-export AI types for renderer consumers
@@ -702,6 +704,22 @@ const api = {
     close: (): Promise<void> => ipcRenderer.invoke('close-window'),
     setConnectionInfo: (connectionName: string | null): void =>
       ipcRenderer.send('window:set-connection-info', connectionName)
+  },
+  mcp: {
+    status: (): Promise<IpcResponse<McpServerStatus>> => ipcRenderer.invoke('mcp:status'),
+    setEnabled: (enabled: boolean): Promise<IpcResponse<McpServerStatus>> =>
+      ipcRenderer.invoke('mcp:setEnabled', { enabled }),
+    setPort: (port: number): Promise<IpcResponse<McpServerStatus>> =>
+      ipcRenderer.invoke('mcp:setPort', { port }),
+    regenerateToken: (): Promise<IpcResponse<McpServerStatus>> =>
+      ipcRenderer.invoke('mcp:regenerateToken'),
+    respondToApproval: (id: string, approved: boolean): Promise<IpcResponse<void>> =>
+      ipcRenderer.invoke('mcp:approval:respond', { id, approved }),
+    onApprovalRequest: (callback: (req: McpApprovalRequest) => void): (() => void) => {
+      const listener = (_event: unknown, req: McpApprovalRequest): void => callback(req)
+      ipcRenderer.on('mcp:approval:request', listener)
+      return () => ipcRenderer.removeListener('mcp:approval:request', listener)
+    }
   }
 }
 

--- a/apps/desktop/src/renderer/src/components/mcp-approval-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/mcp-approval-dialog.tsx
@@ -22,6 +22,16 @@ export function McpApprovalDialog(): React.JSX.Element | null {
     })
   }, [])
 
+  useEffect(() => {
+    return window.api.mcp.onApprovalResolved(({ id }) => {
+      setRequest((current) => {
+        if (current?.id !== id) return current
+        respondedRef.current = true
+        return null
+      })
+    })
+  }, [])
+
   if (!request) return null
 
   const respond = (approved: boolean): void => {

--- a/apps/desktop/src/renderer/src/components/mcp-approval-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/mcp-approval-dialog.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react'
+import type { McpApprovalRequest } from '@shared/index'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from '@/components/ui/alert-dialog'
+
+export function McpApprovalDialog(): React.JSX.Element | null {
+  const [request, setRequest] = useState<McpApprovalRequest | null>(null)
+
+  useEffect(() => window.api.mcp.onApprovalRequest(setRequest), [])
+
+  if (!request) return null
+
+  const respond = (approved: boolean): void => {
+    void window.api.mcp.respondToApproval(request.id, approved)
+    setRequest(null)
+  }
+
+  return (
+    <AlertDialog open onOpenChange={(open) => !open && respond(false)}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Agent wants to run a write statement</AlertDialogTitle>
+          <AlertDialogDescription>
+            An MCP client is asking to execute this on <strong>{request.connectionName}</strong>. It
+            auto-rejects in 60 seconds.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <pre className="max-h-64 overflow-auto rounded bg-muted p-3 font-mono text-xs">
+          {request.sql}
+        </pre>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={() => respond(false)}>Reject</AlertDialogCancel>
+          <AlertDialogAction onClick={() => respond(true)}>Approve & run</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/apps/desktop/src/renderer/src/components/mcp-approval-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/mcp-approval-dialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type { McpApprovalRequest } from '@shared/index'
 import {
   AlertDialog,
@@ -9,16 +9,24 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle
-} from '@/components/ui/alert-dialog'
+} from '@data-peek/ui'
 
 export function McpApprovalDialog(): React.JSX.Element | null {
   const [request, setRequest] = useState<McpApprovalRequest | null>(null)
+  const respondedRef = useRef(false)
 
-  useEffect(() => window.api.mcp.onApprovalRequest(setRequest), [])
+  useEffect(() => {
+    return window.api.mcp.onApprovalRequest((next) => {
+      respondedRef.current = false
+      setRequest(next)
+    })
+  }, [])
 
   if (!request) return null
 
   const respond = (approved: boolean): void => {
+    if (respondedRef.current) return
+    respondedRef.current = true
     void window.api.mcp.respondToApproval(request.id, approved)
     setRequest(null)
   }
@@ -37,7 +45,7 @@ export function McpApprovalDialog(): React.JSX.Element | null {
           {request.sql}
         </pre>
         <AlertDialogFooter>
-          <AlertDialogCancel onClick={() => respond(false)}>Reject</AlertDialogCancel>
+          <AlertDialogCancel>Reject</AlertDialogCancel>
           <AlertDialogAction onClick={() => respond(true)}>Approve & run</AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/apps/desktop/src/renderer/src/components/mcp-settings-section.tsx
+++ b/apps/desktop/src/renderer/src/components/mcp-settings-section.tsx
@@ -62,7 +62,7 @@ export function McpSettingsSection() {
         </div>
         <Switch
           id="mcp-enabled"
-          checked={status.enabled && status.running}
+          checked={status.enabled}
           onCheckedChange={(enabled) => window.api.mcp.setEnabled(enabled).then(applyResult)}
         />
       </div>
@@ -81,8 +81,8 @@ export function McpSettingsSection() {
           value={portDraft}
           onChange={(e) => setPortDraft(e.target.value)}
           onBlur={() => {
-            const port = Number(portDraft)
-            if (Number.isFinite(port) && port !== status.port) {
+            const port = Number.parseInt(portDraft, 10)
+            if (Number.isInteger(port) && port !== status.port) {
               window.api.mcp.setPort(port).then(applyResult)
             } else {
               setPortDraft(String(status.port))

--- a/apps/desktop/src/renderer/src/components/mcp-settings-section.tsx
+++ b/apps/desktop/src/renderer/src/components/mcp-settings-section.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useState } from 'react'
+import { Button, Input, Label, Switch } from '@data-peek/ui'
+import type { IpcResponse, McpServerStatus } from '@shared/index'
+
+export function McpSettingsSection() {
+  const [status, setStatus] = useState<McpServerStatus | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [portDraft, setPortDraft] = useState('')
+  const [copied, setCopied] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    window.api.mcp
+      .status()
+      .then((response) => {
+        if (cancelled) return
+        if (response.success && response.data) {
+          setStatus(response.data)
+          setPortDraft(String(response.data.port))
+        }
+      })
+      .catch(() => {})
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const applyResult = (response: IpcResponse<McpServerStatus>) => {
+    if (response.success && response.data) {
+      setStatus(response.data)
+      setPortDraft(String(response.data.port))
+      setError(null)
+    } else {
+      setError(response.error ?? 'Unknown error')
+    }
+  }
+
+  if (!status) {
+    return (
+      <div className="space-y-4">
+        <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">
+          MCP Server
+        </h3>
+        <p className="text-xs text-muted-foreground">Loading...</p>
+      </div>
+    )
+  }
+
+  const snippet = `claude mcp add --transport http data-peek ${status.url} --header "Authorization: Bearer ${status.token}"`
+
+  return (
+    <div className="space-y-4">
+      <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">
+        MCP Server
+      </h3>
+      <div className="flex items-center justify-between">
+        <div className="space-y-0.5">
+          <Label htmlFor="mcp-enabled">Enable MCP server</Label>
+          <p className="text-xs text-muted-foreground">
+            Let local AI agents query your connections. Writes always require approval here.
+          </p>
+        </div>
+        <Switch
+          id="mcp-enabled"
+          checked={status.enabled && status.running}
+          onCheckedChange={(enabled) => window.api.mcp.setEnabled(enabled).then(applyResult)}
+        />
+      </div>
+
+      {error && <p className="text-xs text-destructive">{error}</p>}
+
+      <div className="flex items-center justify-between">
+        <div className="space-y-0.5">
+          <Label htmlFor="mcp-port">Port</Label>
+          <p className="text-xs text-muted-foreground">Local port the MCP server listens on</p>
+        </div>
+        <Input
+          id="mcp-port"
+          type="number"
+          className="w-24 font-mono"
+          value={portDraft}
+          onChange={(e) => setPortDraft(e.target.value)}
+          onBlur={() => {
+            const port = Number(portDraft)
+            if (Number.isFinite(port) && port !== status.port) {
+              window.api.mcp.setPort(port).then(applyResult)
+            } else {
+              setPortDraft(String(status.port))
+            }
+          }}
+        />
+      </div>
+
+      <div className="flex items-center justify-between">
+        <div className="space-y-0.5">
+          <Label htmlFor="mcp-token">Access token</Label>
+          <p className="text-xs text-muted-foreground">Bearer token for MCP client setup</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Input id="mcp-token" readOnly className="w-40 font-mono text-xs" value={status.token} />
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 text-xs"
+            onClick={() => window.api.mcp.regenerateToken().then(applyResult)}
+          >
+            Regenerate
+          </Button>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label>Setup command</Label>
+        <div className="flex items-center gap-2">
+          <code className="flex-1 truncate rounded bg-muted px-2 py-1.5 text-xs">{snippet}</code>
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 text-xs"
+            onClick={() => {
+              navigator.clipboard.writeText(snippet)
+              setCopied(true)
+              setTimeout(() => setCopied(false), 1500)
+            }}
+          >
+            {copied ? 'Copied' : 'Copy'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/src/components/settings-modal.tsx
+++ b/apps/desktop/src/renderer/src/components/settings-modal.tsx
@@ -14,6 +14,7 @@ import {
 import type { TimeMachineStats } from '@data-peek/shared'
 
 import { useSettingsStore } from '@/stores/settings-store'
+import { McpSettingsSection } from '@/components/mcp-settings-section'
 
 interface SettingsModalProps {
   open: boolean
@@ -222,6 +223,8 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
               </div>
             </div>
           </div>
+
+          <McpSettingsSection />
 
           {/* Time Machine Section */}
           <div className="space-y-4">

--- a/apps/desktop/src/renderer/src/router.tsx
+++ b/apps/desktop/src/renderer/src/router.tsx
@@ -14,6 +14,7 @@ import { useAutoUpdater } from '@/hooks/use-auto-updater'
 import { usePokemonTracker } from '@/hooks/use-pokemon-tracker'
 import { ThemeProvider, useTheme } from '@/components/theme-provider'
 import { CommandPalette } from '@/components/command-palette'
+import { McpApprovalDialog } from '@/components/mcp-approval-dialog'
 import { SavedQueriesDialog } from '@/components/saved-queries-dialog'
 import { DatabaseIcon } from '@/components/database-icons'
 import { AppSidebar } from '@/components/app-sidebar'
@@ -261,6 +262,8 @@ function LayoutContent() {
         onOpenAddConnection={() => setIsAddConnectionOpen(true)}
         onOpenEditConnection={(id) => setEditConnectionId(id)}
       />
+
+      <McpApprovalDialog />
 
       {/* Global Connection Picker */}
       <ConnectionPicker open={isConnectionPickerOpen} onOpenChange={setIsConnectionPickerOpen} />

--- a/apps/web/src/components/marketing/features.tsx
+++ b/apps/web/src/components/marketing/features.tsx
@@ -83,6 +83,10 @@ const categories: { id: string; label: string; items: Feature[] }[] = [
         title: "Bring your own key",
         body: "OpenAI, Anthropic, Google, Groq — or Ollama for a local model. Keys never leave your machine.",
       },
+      {
+        title: "MCP server",
+        body: "Read-only queries run free. Writes are gated behind an in-app approval before they touch the database.",
+      },
     ],
   },
   {

--- a/docs/features.md
+++ b/docs/features.md
@@ -160,6 +160,19 @@ For power users and teams:
 | Groq | Speed | Ultra-fast inference |
 | Ollama | Privacy | Local models, no API key needed |
 
+### MCP Server (New)
+
+| Feature | Description |
+|---------|-------------|
+| **MCP server** | Expose your connections to AI agents (read-only queries free, writes gated by in-app approval) |
+| **Streamable HTTP** | Local server on `127.0.0.1:4722` (configurable), off by default |
+| **Bearer Token Auth** | Requests without a valid `Authorization: Bearer <token>` header are rejected |
+| **list_connections / list_schemas** | Agents can enumerate saved connections and browse schema without seeing credentials |
+| **run_query (read-only)** | 500-row cap, wrapped in a rollback transaction; PostgreSQL connections additionally run `SET TRANSACTION READ ONLY` |
+| **explain_query** | Agents can fetch query plans the same way they would in the app |
+| **execute_statement (writes)** | Every write pops an Approve/Reject dialog in data-peek; a 60s timeout auto-rejects |
+| **Copyable Setup Snippet** | Settings → MCP server generates the `claude mcp add` command with your token pre-filled |
+
 ### Column Statistics
 
 | Feature | Description |

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -2577,3 +2577,18 @@ export const TM_MAX_SNAPSHOT_ROWS = 2000;
 export const TM_MAX_SNAPSHOT_PAYLOAD_BYTES = 6 * 1024 * 1024;
 export const TM_MAX_RUNS_PER_QUERY = 50;
 export const TM_GLOBAL_BUDGET_BYTES = 512 * 1024 * 1024;
+
+export interface McpApprovalRequest {
+  id: string;
+  connectionName: string;
+  sql: string;
+}
+
+export interface McpServerStatus {
+  enabled: boolean;
+  running: boolean;
+  port: number;
+  token: string;
+  url: string;
+  error?: string;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       '@fontsource-variable/geist-mono':
         specifier: ^5.2.8
         version: 5.2.8
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@3.25.76)
       '@monaco-editor/react':
         specifier: ^4.7.0
         version: 4.7.0(monaco-editor@0.55.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -339,19 +342,19 @@ importers:
         version: 1.168.27(crossws@0.4.9(srvx@0.9.8))(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.62.2)(vite@7.3.6(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(webpack@5.105.0(esbuild@0.28.1)(lightningcss@1.32.0))
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(next@16.0.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 2.0.1(next@16.0.7(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       framer-motion:
         specifier: 12.38.0
         version: 12.38.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       fumadocs-core:
         specifier: ^16.10.7
-        version: 16.10.7(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.23.0(react@19.2.7))(next@16.0.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+        version: 16.10.7(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.23.0(react@19.2.7))(next@16.0.7(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       fumadocs-mdx:
         specifier: ^14.3.2
-        version: 14.3.2(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.10.7(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.23.0(react@19.2.7))(next@16.0.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.0.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(vite@7.3.6(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 14.3.2(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.10.7(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.23.0(react@19.2.7))(next@16.0.7(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.0.7(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(vite@7.3.6(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
       fumadocs-ui:
         specifier: ^16.10.7
-        version: 16.10.7(@tailwindcss/oxide@4.3.2)(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.10.7(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.23.0(react@19.2.7))(next@16.0.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.0.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2)
+        version: 16.10.7(@tailwindcss/oxide@4.3.2)(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.10.7(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.23.0(react@19.2.7))(next@16.0.7(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.0.7(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2)
       lucide-static:
         specifier: ^0.552.0
         version: 0.552.0
@@ -567,7 +570,7 @@ importers:
         version: 9.39.4(jiti@2.7.0)
       eslint-config-next:
         specifier: 16.0.5
-        version: 16.0.5(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+        version: 16.0.5(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       react-scan:
         specifier: ^0.5.7
         version: 0.5.7(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@rspack/core@1.7.6(@swc/helpers@0.5.15))(esbuild@0.28.1)(eslint@9.39.4(jiti@2.7.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.62.2)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(webpack@5.105.0(esbuild@0.28.1)(lightningcss@1.32.0))
@@ -645,7 +648,7 @@ importers:
         version: 3.22.5(@types/node@22.20.0)
       next:
         specifier: 16.0.7
-        version: 16.0.7(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 16.0.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       nuqs:
         specifier: ^2.9.0
         version: 2.9.0(@tanstack/react-router@1.170.17(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(next@16.0.7(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
@@ -2069,6 +2072,12 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -2357,6 +2366,16 @@ packages:
     peerDependencies:
       mediabunny: ^1.0.0
 
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
+
   '@module-federation/error-codes@0.22.0':
     resolution: {integrity: sha512-xF9SjnEy7vTdx+xekjPCV5cIHOGCkdn3pIxo9vU7gEZMIw0SvAEdsy6Uh17xaCpm8V0FWvR0SZoK9Ik6jGOaug==}
 
@@ -2631,249 +2650,127 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oxc-parser/binding-android-arm-eabi@0.132.0':
-    resolution: {integrity: sha512-KrLaPWa5c9Y7LkW+rKkaUE3y7DBDrQtaf7rlsSDfv6KAHUjgzAIRA761Lrrp6//Yd/Rlie/yEOt9YENCoJnOcw==}
+  '@oxc-parser/binding-android-arm-eabi@0.138.0':
+    resolution: {integrity: sha512-hSYAD+F9W2Qh8SETMqBsQRx6YHvB4z+i/i36shlC7tfdZQauMs4vf3G/EQwKOkNlN7rkTiKINvsNmQb9q2MWcQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
 
-  '@oxc-parser/binding-android-arm-eabi@0.135.0':
-    resolution: {integrity: sha512-sHeZItACNcA5WRAWqF6ixriR4GkZDyY10gVgnZU7pXku1DjHFATSqnwZM809jl0gXPHxb6fKzYQCK7bNK5cACQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [android]
-
-  '@oxc-parser/binding-android-arm64@0.132.0':
-    resolution: {integrity: sha512-SThDrSeamB/kG2+NxcJ5/wSLcV6dUqDknrPLqFYQ0ST/55mtBP4M7Q/f3QbubH6aAd11wpzZn/nwbVRSdobOpg==}
+  '@oxc-parser/binding-android-arm64@0.138.0':
+    resolution: {integrity: sha512-Ns5LLTp8cVyP8DsYqD482h0HE84xiGYRgtm7g4LtTinq209NAiMF768e/8r2NHaa0UMirS5mrT1m1VwiVmBi4Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@oxc-parser/binding-android-arm64@0.135.0':
-    resolution: {integrity: sha512-wPte+SzgzWWFgMSF8YZDNM+tBXtJg0AXBi7+tU3yS2z1f2Af9kRLZLKuJojADmuD/cZexmnMHHC3SDItTW77Iw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [android]
-
-  '@oxc-parser/binding-darwin-arm64@0.132.0':
-    resolution: {integrity: sha512-Lc0f/TYoKBghE5/2Gsv7bLXk+TJZunx2Tf61X8hG4ARXdc8UYI26dCGccFSd1AyFbK3jfaNXtMnupggDbjPXdQ==}
+  '@oxc-parser/binding-darwin-arm64@0.138.0':
+    resolution: {integrity: sha512-Yka0m4YhKUHBIZufafSLAeO+DUrfHPtNXBlZSj7DxshquIl41x/a+i/MbRnbOy8heuLiYU1STa6h0FAAzT7Pbw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxc-parser/binding-darwin-arm64@0.135.0':
-    resolution: {integrity: sha512-BmKz3lHIsqVos+9aPcdYCT9MG3APoUyM43KlEFhJMWNVDOGG8FKyiFz81Bc+mGz2o0hpuQ3PfXLfVWJrKXjo2g==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@oxc-parser/binding-darwin-x64@0.132.0':
-    resolution: {integrity: sha512-RG2eJIpf7C21z9HSSXFw1bTArdpKe7Y4fwcJTwRq1yCSe1vSavaN9GA1sm9KqzemTLAGVktQ+7qBTGp0vQeUZg==}
+  '@oxc-parser/binding-darwin-x64@0.138.0':
+    resolution: {integrity: sha512-MWLUZZzmNRUqTWueZF27ncreaZ1wZ0gboWL2QMPxRQA2xgOmBPlGg2H9pAKJSPBlwEHcWa9TdWRiehAS+yls8w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@oxc-parser/binding-darwin-x64@0.135.0':
-    resolution: {integrity: sha512-dM8BS+8+Br1fNvmh2QZbGiHaYttwLebRa6J4Uz9vuFzMNmvsdRYwf7993ptOaV0JTrR63AaoVLjX7nhWbijxjQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [darwin]
-
-  '@oxc-parser/binding-freebsd-x64@0.132.0':
-    resolution: {integrity: sha512-wQIPntPLtJ8NcBpvKPbEv3NqzV6k8eP8tP/jE9Rg8HTg/j7urZGFSsTCPCW5k77Qfw2DM4vRvc9p3I4yq/Shvw==}
+  '@oxc-parser/binding-freebsd-x64@0.138.0':
+    resolution: {integrity: sha512-Vae5tzsrzZ/lCDVCZUMi/vzSiiHEgcOEfsyIfWOHmjZ2ji+gT+n96T757yX5/f7/7JIJuiannAHJKV5ARaF6ng==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxc-parser/binding-freebsd-x64@0.135.0':
-    resolution: {integrity: sha512-xlZnvvJdR9bGu2pOhvR5hMuKPHCE6Sa9owK5A484mzjHdm75VRV5nCs5w/jkmGODMMTFc+KN7EnZqEieM813kw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@oxc-parser/binding-linux-arm-gnueabihf@0.132.0':
-    resolution: {integrity: sha512-PixKEpeSe3yxQWqNyOCBALRYc72+Tj7ILDofUl3iXo25cVOzLA6jHUhmOINRtWIPh7dbUie3QNeabwaQpZTw6w==}
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.138.0':
+    resolution: {integrity: sha512-qkU8wv5mYexrCw0X4DHFgxGbRScwGLIIKUkHXU7xXEiLoMnQzELak2gujxfa9GFrlEgPjbyLUDFHWm67Zs38ng==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxc-parser/binding-linux-arm-gnueabihf@0.135.0':
-    resolution: {integrity: sha512-PSR8LmBK/H/PQRiN8g7RebQgZX/ntVCrdT/JBfNxE5ezdHG1s2i4rbazsRJYD83TTI1MmgTpC0MGL42PLtskQQ==}
+  '@oxc-parser/binding-linux-arm-musleabihf@0.138.0':
+    resolution: {integrity: sha512-3HgULIvoDV7h2ZfVYzxQwOSOJnAjMwYmyUBzndNuLRGgBNI549ED0P6AGmN9y2TnSvrwJ+Q8zqdxqssMnGXitA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxc-parser/binding-linux-arm-musleabihf@0.132.0':
-    resolution: {integrity: sha512-sCR+DzGHlyHKnbA2z9zWjTUhIo8Sy0enJl4RDsBwPmkxYynPatpwOAWe8W5127SlW0boqUWHGtr1NWn5UwIhXQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
-  '@oxc-parser/binding-linux-arm-musleabihf@0.135.0':
-    resolution: {integrity: sha512-I85GJXzfUsigkkk7Ngdz95C217M4FdUi1Z2HrX5UyPmURobwQZ7m2bbUvwFkz4VGZd+lymFGKHvDZ3RQC9qOzA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
-  '@oxc-parser/binding-linux-arm64-gnu@0.132.0':
-    resolution: {integrity: sha512-sQBix5P2cW+IpzTcCwYxnh9yALrKSIkKJThspBvMGcygSMnbzkSvhN7SfuX1hvBk8y1XEChsdkU3ET0V5DmzUw==}
+  '@oxc-parser/binding-linux-arm64-gnu@0.138.0':
+    resolution: {integrity: sha512-pIonbH2p0KLCwz4CNPCi0xGqci4numpMQDCLJwLfsrEky7NUuByKDFhCjzE0E7vR3aj/lBjyMoTskHBo/qSg8g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@oxc-parser/binding-linux-arm64-gnu@0.135.0':
-    resolution: {integrity: sha512-zqEY0npz0g0aGZj/8a5BclunjVDytsBQHYtIC10Gd26HcrLwbVF6YDbqRQjunMGYdSo97u6xOBl05aTDI2diDQ==}
+  '@oxc-parser/binding-linux-arm64-musl@0.138.0':
+    resolution: {integrity: sha512-cT5L1Xz/5m6Ga1hD3922gLc+fePOauJZJdApPTI/2Vu0EmYo62uHG9V5Dq65hhgU9TW10oDi2840y9cGdd7BIg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@oxc-parser/binding-linux-arm64-musl@0.132.0':
-    resolution: {integrity: sha512-WozHg3Kc//8Sk756HXXgMbEAvqtG+Lzb9JOojwQzIGDtN78Az2dLttkb71akWYUF/8IgYfDSlfKh4Uot8is5Vw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-
-  '@oxc-parser/binding-linux-arm64-musl@0.135.0':
-    resolution: {integrity: sha512-mWAfprP819gQ2qYst1RxgTI8b/z0b29OpoKfRflIXLHde2dZLihQD4g47Onuvtpo5GPIkMYPRlX9QoeZfs/GnQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-
-  '@oxc-parser/binding-linux-ppc64-gnu@0.132.0':
-    resolution: {integrity: sha512-CmX/ulNBOEwWTyVRmcpYKAcAizW6+OjtLJgo7fXoL9OqQvjF4VER8tPomv44vwzfSCy1BHbsB0ZlZYzYJNj4cA==}
+  '@oxc-parser/binding-linux-ppc64-gnu@0.138.0':
+    resolution: {integrity: sha512-hKy/vvejKk3LNE/FsRbekWejLa046//TnLWtSo7ur29NIsNbSIvnOVYIirSVC7fsd6NO8UFzwDdcoZfCyBvSBA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
 
-  '@oxc-parser/binding-linux-ppc64-gnu@0.135.0':
-    resolution: {integrity: sha512-gri8c2AOmJKJwOux2KTHFBfUaXoJURuVMKhmKEi/2hTF55cQteTDV2XNfTiE5oCC+Tnem1Y4/MWzcyDadtsSag==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@oxc-parser/binding-linux-riscv64-gnu@0.132.0':
-    resolution: {integrity: sha512-j9oQS+hM90SdhviNGWbPgT4+Rlq+ac++q/zjgwPD1mVHgxHzATvoRGtDx0sXGmFOQ9J9YkwAhYGb5MAHL6TAsA==}
+  '@oxc-parser/binding-linux-riscv64-gnu@0.138.0':
+    resolution: {integrity: sha512-bh6tjNGq0v0b9GAMu0pTv/YpTqepCFy0TIOtQHm8+41fZwLXTaB6xiEWVUSarNCXqc5kyzYcH6EOfwW1sJxJOw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
 
-  '@oxc-parser/binding-linux-riscv64-gnu@0.135.0':
-    resolution: {integrity: sha512-Y2tkupCG5wo0SxH2rMLG4d4Kmv6DaM3sBp+GuM5lox0S8Za6VxKgQrY2Mut088QQxKkEE89n/4CCCgmw2o0e3Q==}
+  '@oxc-parser/binding-linux-riscv64-musl@0.138.0':
+    resolution: {integrity: sha512-HhOkddcClSTtTxY10f/mACblKcQdxWy4lYYwX12G23j+S5eiJ5y1kpo1r7kKng+2bdnCBO+lCDWOVVc9kVl9+g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
 
-  '@oxc-parser/binding-linux-riscv64-musl@0.132.0':
-    resolution: {integrity: sha512-bLz+Xi+Agnfmd7kWPEsSVwCn2k4EyIalZkNBcQ0OGIv9rqn8VgCPLNd03tM9mKX/5TdlvDXalz0q71BIrOPNqg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@oxc-parser/binding-linux-riscv64-musl@0.135.0':
-    resolution: {integrity: sha512-xDRJq6i6WTynjeP+ISbDpyH4p9BaJ0wuQcL0lCSDkt9qOXC9dmwpOu1VG/TlwmPI3KpYntmO9nJCuc3TMTsNBA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@oxc-parser/binding-linux-s390x-gnu@0.132.0':
-    resolution: {integrity: sha512-U6t2qbJU0ypTfyj9QV3W1Y6mITDTL8ai/OR6NUn85vyHthOvobKWgXzU4tu0EskSzlpuVFz1g0jFGulDIUKHxQ==}
+  '@oxc-parser/binding-linux-s390x-gnu@0.138.0':
+    resolution: {integrity: sha512-5mi+wtbeJiEa4waGG88EcEGgJBBNJdDeIcayPPcrLNMXbCrgdtbb80q0Nrat7A8NglLUVzhuTAAp7K6PjmUO8Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
 
-  '@oxc-parser/binding-linux-s390x-gnu@0.135.0':
-    resolution: {integrity: sha512-V4MoUuiCRNvihxhIufRxvK+ka013V4joTSK0FAGA1KEjLuNprfH6N/Qw2uxQEVIFuNYMhD/hV6xJ/ptbzlKdHg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [s390x]
-    os: [linux]
-
-  '@oxc-parser/binding-linux-x64-gnu@0.132.0':
-    resolution: {integrity: sha512-WcEaSNHFk8yz5YFlQQAlhq6jOFmZBB/RKE7uzhyCIf+pF1Lmv9gUH4221mle2Gd9iHyWT3ySNph8yZgb1xYdWg==}
+  '@oxc-parser/binding-linux-x64-gnu@0.138.0':
+    resolution: {integrity: sha512-ckbq3AMI7lI8AhQtE8KdqYRmzmzwKfCU12QN/PBKXO72PfWdvvZQN0hFShDX/XRNsPqjddLmvXaQMT3zfYtNlw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@oxc-parser/binding-linux-x64-gnu@0.135.0':
-    resolution: {integrity: sha512-JCFZ7zM7KXOKoPAbK/ZB4wY0M1jxRECiem2UQuiXLjzGqS9+hno7mtX+qyK2F7HWK2xPhyJb+frpcOtk5DKOtg==}
+  '@oxc-parser/binding-linux-x64-musl@0.138.0':
+    resolution: {integrity: sha512-JrCOzHO9BYEs5Xz5JHYBxSc/hYKxfXUj5QQb64sERSbkQot6+KEgMTOR2C9hLrhaqOui65OYcFyTTS+YxXDtnA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@oxc-parser/binding-linux-x64-musl@0.132.0':
-    resolution: {integrity: sha512-iQrV4iJzQgRwK3BWRmQl1C3C6g3wYpXN2WLdQdyR+efoUnncdShZAVp9OgcojtlD3MDRbuOMGG3SjxF4fL4nlQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-
-  '@oxc-parser/binding-linux-x64-musl@0.135.0':
-    resolution: {integrity: sha512-9jSVS1b3hOV7sdKH4aA2DFfnTz0RgQd0v2BefR+LYbH8yIlmSM22JJZbAAjVeVXmFgUAk3zJQ1tpE/Nd+Vi2YQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-
-  '@oxc-parser/binding-openharmony-arm64@0.132.0':
-    resolution: {integrity: sha512-FWzmUGrZ6GUby4U7WIwcCtab6tdmlTO3xTRRKyb5kjIJVEiaUAT8animUG/nK8ZCA8gkRkPOTId4rl6uTqUmJQ==}
+  '@oxc-parser/binding-openharmony-arm64@0.138.0':
+    resolution: {integrity: sha512-eASMMfOOIfLHkWJRPSu8llByvVRM+c1M/lh18KjsjELM3y10+7B5iBbbrht9LdtsJXQ+mRuP/lJ7UWe3Ok3ehw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxc-parser/binding-openharmony-arm64@0.135.0':
-    resolution: {integrity: sha512-M857ZLBSdn1Uy/SJJz5zh0qGu67B4P9omCgXGBU2LLqTzraX6ZjVNaKq5yW1PDw/LgJXDXR/dbZfgmB310f11Q==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@oxc-parser/binding-wasm32-wasi@0.132.0':
-    resolution: {integrity: sha512-TlbMppxJI5CjWDes0QaP6G3aneVg1yikBu5QYI+DUShF9WDL66ccgKFNNGmi/Wybtszw6hxwAvv76T4DaPKnHw==}
+  '@oxc-parser/binding-wasm32-wasi@0.138.0':
+    resolution: {integrity: sha512-BnTCO87Iwc57NufXS7vcrkrmpN+daeCeYr1+/xgPT6HjwNs0lBmJYeFrcOs4WkNN8yscdd6Rc4FxWh3+59hAFw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@oxc-parser/binding-wasm32-wasi@0.135.0':
-    resolution: {integrity: sha512-2w6DVcntQZX9U5RhXtgiWb3FLWFB5EcwI1U8yr3htOCJUJjagN4BFUHz/Y/d9ZsumndZ6ByxxWEtbUZNE1bfFw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [wasm32]
-
-  '@oxc-parser/binding-win32-arm64-msvc@0.132.0':
-    resolution: {integrity: sha512-RH/NbFjGKqdUAUi7Oh3LQPxUk2hsWFEEQ38HSnbRQT8QjBZFKqL1fMbmsB3N4jy/KPh9iX94+9dmkEMBBbambw==}
+  '@oxc-parser/binding-win32-arm64-msvc@0.138.0':
+    resolution: {integrity: sha512-+Zi47boD2wKNL0hOA47Vkwk6njMZ8sOsr4Geu/56EUtlooDh9crNOU41U6bXGS0UjC4Y72HtRA1iuB6qx1ARUw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@oxc-parser/binding-win32-arm64-msvc@0.135.0':
-    resolution: {integrity: sha512-rX1U8+IH2Z37EJjDXKa1iifvUQAdba+vZ4Ewj1iaG5eA/QaSybzclCOwtWa0/5BuUQnnK/T2JHUEFrwhL6Ck2Q==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [win32]
-
-  '@oxc-parser/binding-win32-ia32-msvc@0.132.0':
-    resolution: {integrity: sha512-JUr4jQY9jxoIB/YTLXr6XofSi5xikj6p5/Ns1h0VOBDT0j1jKU+kMsv2xxv51RwnETcXpA1Yw/9oUAfcqfaqEA==}
+  '@oxc-parser/binding-win32-ia32-msvc@0.138.0':
+    resolution: {integrity: sha512-SYcV674Wi2WuoBefUFgf0PBMNlZe5IF0YZ0TnP7DK+EusMVpEWq6iz+7r64svjAb7vjthzlas0FUCSlz8YkqYg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
-  '@oxc-parser/binding-win32-ia32-msvc@0.135.0':
-    resolution: {integrity: sha512-9FAisBbH1QICGAjlJobiuKGd/jOuVmyqniWdQMwTa5SkCl6hhuotBCJf1n46B0flYbSOR5TzfV9HZCWSyb3c/Q==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ia32]
-    os: [win32]
-
-  '@oxc-parser/binding-win32-x64-msvc@0.132.0':
-    resolution: {integrity: sha512-2dapgHpA5X8DSXF4AU36hJWYf6zP0tKjMXFRAZFBD62pkevW/uhFDXoFH9Y/3Fd2EtDrw5ByNnR1wVE9X9y0SQ==}
+  '@oxc-parser/binding-win32-x64-msvc@0.138.0':
+    resolution: {integrity: sha512-QZplnCxS4vPe4StAVBtvD2bW3pELlidf0Ek6iQ/HHiCjbEtrs5pFZZfLAoPhKLJyDzyxoGAdic9bSIYrJYTZcg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@oxc-parser/binding-win32-x64-msvc@0.135.0':
-    resolution: {integrity: sha512-wYF+A2AzJ2n7ul6q+Z2G/ia0S2+8cUp0AgWZzoFvF4WmUcl1P7p+o6se1Gdr5wGnWuF0iAMIkGddrjCarNr2yA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [win32]
-
-  '@oxc-project/types@0.132.0':
-    resolution: {integrity: sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==}
-
-  '@oxc-project/types@0.135.0':
-    resolution: {integrity: sha512-wR+xRdFkUBMvcAjBJ2q2kcZM6d+DKu2NgoOyxZgYwZdLhmiv6+rnO8PZ/P68kMiZtIKm+pW7zyEJ4kSOs0vo+Q==}
+  '@oxc-project/types@0.138.0':
+    resolution: {integrity: sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==}
 
   '@oxc-resolver/binding-android-arm-eabi@11.23.0':
     resolution: {integrity: sha512-8IJyWRLVAyhTfe9/TIEbQqSQnl5rUqYJrUOS6Dkr+Mq9FGHMxDGeiEmwkBqCvDP5KckpPh/GYSgbag66O6JsCw==}
@@ -5213,6 +5110,10 @@ packages:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-import-phases@1.0.4:
     resolution: {integrity: sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==}
     engines: {node: '>=10.13.0'}
@@ -5591,6 +5492,10 @@ packages:
   bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
 
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
+
   boolean@3.2.0:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
@@ -5656,6 +5561,10 @@ packages:
   byline@5.0.0:
     resolution: {integrity: sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==}
     engines: {node: '>=0.10.0'}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
 
   c12@3.3.4:
     resolution: {integrity: sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==}
@@ -5896,11 +5805,31 @@ packages:
   console-control-strings@1.1.0:
     resolution: {integrity: sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cookie-es@3.1.1:
     resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
 
   copy-anything@4.0.5:
     resolution: {integrity: sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==}
@@ -5911,6 +5840,10 @@ packages:
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cosmiconfig@8.3.6:
     resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
@@ -6182,12 +6115,16 @@ packages:
     resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
     engines: {node: '>=0.10'}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
-  deslop-js@0.7.1:
-    resolution: {integrity: sha512-HsEoRI/bzuD0o2OVczYz42SXTCl5of3ax6eiojZbC/7gJsPNxxjPRvBysP88LXsHujYrIGJnGtFRnHwCmKWuxQ==}
+  deslop-js@0.7.8:
+    resolution: {integrity: sha512-QMmb3Z/ARvYZmZneudb8cnY/4mVvZTdhUyA9TC2skwOcm7KvY9zyOdn0TApQc4rL0VM2TffFkmo3ky/lJZX7qw==}
 
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
@@ -6392,6 +6329,9 @@ packages:
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   ejs@3.1.10:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
     engines: {node: '>=0.10.0'}
@@ -6447,6 +6387,10 @@ packages:
   emojis-list@3.0.0:
     resolution: {integrity: sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==}
     engines: {node: '>= 4'}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   encoding@0.1.13:
     resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
@@ -6557,6 +6501,9 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -6761,6 +6708,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
@@ -6779,6 +6730,10 @@ packages:
     resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
     engines: {node: '>=18.0.0'}
 
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -6793,6 +6748,16 @@ packages:
 
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
+
+  express-rate-limit@8.5.2:
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   exsolve@1.1.0:
     resolution: {integrity: sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==}
@@ -6881,6 +6846,10 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
@@ -6907,6 +6876,10 @@ packages:
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
 
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
@@ -6938,6 +6911,10 @@ packages:
         optional: true
       react-dom:
         optional: true
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -7320,6 +7297,10 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
+  hono@4.12.30:
+    resolution: {integrity: sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==}
+    engines: {node: '>=16.9.0'}
+
   hosted-git-info@4.1.0:
     resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
     engines: {node: '>=10'}
@@ -7341,6 +7322,10 @@ packages:
 
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
 
   http-proxy-agent@5.0.0:
     resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
@@ -7445,6 +7430,10 @@ packages:
   ip-address@10.2.0:
     resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
@@ -7578,6 +7567,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
   is-property@1.0.2:
     resolution: {integrity: sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==}
 
@@ -7700,6 +7692,9 @@ packages:
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
+
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
   js-base64@3.8.0:
     resolution: {integrity: sha512-65kvbemyZhj+ExQt1PEFyBEjL5vAHysu1lJdW1AwhhChkO8ZBPizYk/m9GVrpbS2Je1hF+UYZ+6KywqtZV8mHw==}
@@ -8122,12 +8117,20 @@ packages:
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
   mediabunny@1.37.0:
     resolution: {integrity: sha512-eV7M9IJ29pr/8RNL1sYtIxNbdMfDMN1hMwMaOFfNLhwuKKGSC+eKwiJFpdVjEJ3zrMA4LGerF4Hps0SENFSAlg==}
 
   memfs@3.4.3:
     resolution: {integrity: sha512-eivjfi7Ahr6eQTn44nvTnR60e4a1Fs1Via2kCR5lHo/kyNoiMWaXCNJ/GpSd0ilXas2JSOl9B5FTIhflXu0hlg==}
     engines: {node: '>= 4.0.0'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -8253,9 +8256,17 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mime@2.6.0:
     resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
@@ -8431,6 +8442,10 @@ packages:
 
   negotiator@0.6.4:
     resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
+    engines: {node: '>= 0.6'}
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
   neo-async@2.6.2:
@@ -8633,6 +8648,10 @@ packages:
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
 
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
@@ -8678,12 +8697,8 @@ packages:
     resolution: {integrity: sha512-dXeeGrfPJJ4rMdw+NrqiCRtbzVX2ogq//R0Xns08zql2HjV3Zi2SBJ65saqfDaJzd2bcHqvGWH+M44EQCHPAcA==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  oxc-parser@0.132.0:
-    resolution: {integrity: sha512-+0LAPHaqtfQlvWdpaAa09SmOaZZgP8C552xosEkGJ4+ruEwP1Vgx+sqBgcBCNfR6KDCmagGOZTde8wmAvcI/Hg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-
-  oxc-parser@0.135.0:
-    resolution: {integrity: sha512-/DaPStu0s2zzNSRRniKyTPM6Z/o+DapOp2JYNKDL8AsgaBGPK2IdZyB87SQjVH+xeQPz+Qr9mrjglfkYgtbVRA==}
+  oxc-parser@0.138.0:
+    resolution: {integrity: sha512-c25lvfpZ2+WY1yk6NkP0X0RTQg0ZxgSVaZHDa7lt6fEe1jwZjPWkRWvTyZ1xyaM7roVJMdtRCfbhUj/d4ims3Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   oxc-resolver@11.23.0:
@@ -8693,8 +8708,8 @@ packages:
     resolution: {integrity: sha512-dQPNIF+gHpSkmC0+Vg9IktNyhcn28Y8R3eTLyzn52UNymkasLicl3sFAtz7oEVuFmCpgGjaUTKkwk+jW2cHpDQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  oxlint-plugin-react-doctor@0.7.1:
-    resolution: {integrity: sha512-fvARsCESDZYvDIlhuB/JlDeUhTOLHYstoDJCKm0pzh4HQQJVVV6gcrQajBjYo/hdHC1ukl7btKTK3rk4uZwuew==}
+  oxlint-plugin-react-doctor@0.7.8:
+    resolution: {integrity: sha512-3f9/jFLIC/KRLPYqxiXSk20cq47luGy9Oz5Ru7nK7w0EI9B9zuMvAU92bK9jFiwFE7Lc9PA8ER6Y+naYaGFQGw==}
     engines: {node: ^20.19.0 || >=22.13.0}
 
   oxlint@1.66.0:
@@ -8752,6 +8767,10 @@ packages:
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -8774,6 +8793,9 @@ packages:
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -8844,6 +8866,10 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pkg-types@2.3.1:
     resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
@@ -9223,6 +9249,10 @@ packages:
     resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
     engines: {node: '>=12.0.0'}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
@@ -9232,6 +9262,10 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+    engines: {node: '>=0.6'}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -9247,6 +9281,14 @@ packages:
     resolution: {integrity: sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==}
     engines: {node: '>=0.12'}
 
+  range-parser@1.3.0:
+    resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
+
   rc9@3.0.1:
     resolution: {integrity: sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==}
 
@@ -9254,8 +9296,8 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
-  react-doctor@0.7.1:
-    resolution: {integrity: sha512-Gmty7Enyrh6GPlz6Paq+UoL2O7YkTzNeHdflbqdp6fspX1UbUem5ejPyIUgo1jf77D6kB+INqsi2K+Mk/K8uBQ==}
+  react-doctor@0.7.8:
+    resolution: {integrity: sha512-G3spmtZJE/gWWPRJ3rpgUWTPRDJpEmdRja7iNZ7RAXlfpEO+NWVzPTca/cPI9hLwPo2Aq5/BZggo5JDBrwGrlA==}
     engines: {node: ^20.19.0 || >=22.13.0}
     hasBin: true
 
@@ -9605,6 +9647,10 @@ packages:
   rou3@0.8.1:
     resolution: {integrity: sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA==}
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   run-applescript@7.1.0:
     resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
     engines: {node: '>=18'}
@@ -9683,6 +9729,10 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
   serialize-error@7.0.1:
     resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
     engines: {node: '>=10'}
@@ -9696,6 +9746,10 @@ packages:
   seroval@1.5.4:
     resolution: {integrity: sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==}
     engines: {node: '>=10'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
 
   server-only@0.0.1:
     resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
@@ -9714,6 +9768,9 @@ packages:
   set-proto@1.0.0:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
@@ -9880,6 +9937,10 @@ packages:
 
   state-local@1.0.7:
     resolution: {integrity: sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
@@ -10188,6 +10249,10 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
@@ -10262,6 +10327,10 @@ packages:
   type-fest@5.8.0:
     resolution: {integrity: sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==}
     engines: {node: '>=20'}
+
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
 
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
@@ -10369,6 +10438,10 @@ packages:
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
 
   unplugin@3.3.0:
     resolution: {integrity: sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg==}
@@ -10533,6 +10606,10 @@ packages:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   verror@1.10.1:
     resolution: {integrity: sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==}
@@ -10841,6 +10918,11 @@ packages:
   zip-stream@6.0.1:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
     engines: {node: '>= 14'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
 
   zod-validation-error@4.0.2:
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
@@ -12072,6 +12154,10 @@ snapshots:
       protobufjs: 7.6.5
       yargs: 17.7.3
 
+  '@hono/node-server@1.19.14(hono@4.12.30)':
+    dependencies:
+      hono: 4.12.30
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -12360,6 +12446,28 @@ snapshots:
     dependencies:
       mediabunny: 1.37.0
 
+  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.30)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.30
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
+
   '@module-federation/error-codes@0.22.0': {}
 
   '@module-federation/runtime-core@0.22.0':
@@ -12602,137 +12710,71 @@ snapshots:
   '@oxc-minify/binding-win32-x64-msvc@0.96.0':
     optional: true
 
-  '@oxc-parser/binding-android-arm-eabi@0.132.0':
+  '@oxc-parser/binding-android-arm-eabi@0.138.0':
     optional: true
 
-  '@oxc-parser/binding-android-arm-eabi@0.135.0':
+  '@oxc-parser/binding-android-arm64@0.138.0':
     optional: true
 
-  '@oxc-parser/binding-android-arm64@0.132.0':
+  '@oxc-parser/binding-darwin-arm64@0.138.0':
     optional: true
 
-  '@oxc-parser/binding-android-arm64@0.135.0':
+  '@oxc-parser/binding-darwin-x64@0.138.0':
     optional: true
 
-  '@oxc-parser/binding-darwin-arm64@0.132.0':
+  '@oxc-parser/binding-freebsd-x64@0.138.0':
     optional: true
 
-  '@oxc-parser/binding-darwin-arm64@0.135.0':
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.138.0':
     optional: true
 
-  '@oxc-parser/binding-darwin-x64@0.132.0':
+  '@oxc-parser/binding-linux-arm-musleabihf@0.138.0':
     optional: true
 
-  '@oxc-parser/binding-darwin-x64@0.135.0':
+  '@oxc-parser/binding-linux-arm64-gnu@0.138.0':
     optional: true
 
-  '@oxc-parser/binding-freebsd-x64@0.132.0':
+  '@oxc-parser/binding-linux-arm64-musl@0.138.0':
     optional: true
 
-  '@oxc-parser/binding-freebsd-x64@0.135.0':
+  '@oxc-parser/binding-linux-ppc64-gnu@0.138.0':
     optional: true
 
-  '@oxc-parser/binding-linux-arm-gnueabihf@0.132.0':
+  '@oxc-parser/binding-linux-riscv64-gnu@0.138.0':
     optional: true
 
-  '@oxc-parser/binding-linux-arm-gnueabihf@0.135.0':
+  '@oxc-parser/binding-linux-riscv64-musl@0.138.0':
     optional: true
 
-  '@oxc-parser/binding-linux-arm-musleabihf@0.132.0':
+  '@oxc-parser/binding-linux-s390x-gnu@0.138.0':
     optional: true
 
-  '@oxc-parser/binding-linux-arm-musleabihf@0.135.0':
+  '@oxc-parser/binding-linux-x64-gnu@0.138.0':
     optional: true
 
-  '@oxc-parser/binding-linux-arm64-gnu@0.132.0':
+  '@oxc-parser/binding-linux-x64-musl@0.138.0':
     optional: true
 
-  '@oxc-parser/binding-linux-arm64-gnu@0.135.0':
+  '@oxc-parser/binding-openharmony-arm64@0.138.0':
     optional: true
 
-  '@oxc-parser/binding-linux-arm64-musl@0.132.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-arm64-musl@0.135.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-ppc64-gnu@0.132.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-ppc64-gnu@0.135.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-riscv64-gnu@0.132.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-riscv64-gnu@0.135.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-riscv64-musl@0.132.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-riscv64-musl@0.135.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-s390x-gnu@0.132.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-s390x-gnu@0.135.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-x64-gnu@0.132.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-x64-gnu@0.135.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-x64-musl@0.132.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-x64-musl@0.135.0':
-    optional: true
-
-  '@oxc-parser/binding-openharmony-arm64@0.132.0':
-    optional: true
-
-  '@oxc-parser/binding-openharmony-arm64@0.135.0':
-    optional: true
-
-  '@oxc-parser/binding-wasm32-wasi@0.132.0':
+  '@oxc-parser/binding-wasm32-wasi@0.138.0':
     dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
-  '@oxc-parser/binding-wasm32-wasi@0.135.0':
-    dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+  '@oxc-parser/binding-win32-arm64-msvc@0.138.0':
     optional: true
 
-  '@oxc-parser/binding-win32-arm64-msvc@0.132.0':
+  '@oxc-parser/binding-win32-ia32-msvc@0.138.0':
     optional: true
 
-  '@oxc-parser/binding-win32-arm64-msvc@0.135.0':
+  '@oxc-parser/binding-win32-x64-msvc@0.138.0':
     optional: true
 
-  '@oxc-parser/binding-win32-ia32-msvc@0.132.0':
-    optional: true
-
-  '@oxc-parser/binding-win32-ia32-msvc@0.135.0':
-    optional: true
-
-  '@oxc-parser/binding-win32-x64-msvc@0.132.0':
-    optional: true
-
-  '@oxc-parser/binding-win32-x64-msvc@0.135.0':
-    optional: true
-
-  '@oxc-project/types@0.132.0': {}
-
-  '@oxc-project/types@0.135.0': {}
+  '@oxc-project/types@0.138.0': {}
 
   '@oxc-resolver/binding-android-arm-eabi@11.23.0':
     optional: true
@@ -15170,15 +15212,15 @@ snapshots:
       next: 16.0.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react: 19.2.0
 
-  '@vercel/analytics@2.0.1(next@16.0.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
-    optionalDependencies:
-      next: 16.0.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react: 19.2.7
-
   '@vercel/analytics@2.0.1(next@16.0.7(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)':
     optionalDependencies:
       next: 16.0.7(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react: 19.2.0
+
+  '@vercel/analytics@2.0.1(next@16.0.7(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
+    optionalDependencies:
+      next: 16.0.7(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
 
   '@vercel/oidc@3.1.0': {}
 
@@ -15383,6 +15425,11 @@ snapshots:
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
+
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
 
   acorn-import-phases@1.0.4(acorn@8.17.0):
     dependencies:
@@ -15838,6 +15885,20 @@ snapshots:
 
   bluebird@3.7.2: {}
 
+  body-parser@2.3.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.0.0
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      on-finished: 2.4.1
+      qs: 6.15.3
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   boolean@3.2.0:
     optional: true
 
@@ -15940,6 +16001,8 @@ snapshots:
       run-applescript: 7.1.0
 
   byline@5.0.0: {}
+
+  bytes@3.1.2: {}
 
   c12@3.3.4(magicast@0.5.3):
     dependencies:
@@ -16205,9 +16268,19 @@ snapshots:
 
   console-control-strings@1.1.0: {}
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  content-type@2.0.0: {}
+
   convert-source-map@2.0.0: {}
 
   cookie-es@3.1.1: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
 
   copy-anything@4.0.5:
     dependencies:
@@ -16217,6 +16290,11 @@ snapshots:
     optional: true
 
   core-util-is@1.0.3: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cosmiconfig@8.3.6(typescript@5.9.3):
     dependencies:
@@ -16453,14 +16531,16 @@ snapshots:
 
   denque@2.1.0: {}
 
+  depd@2.0.0: {}
+
   dequal@2.0.3: {}
 
-  deslop-js@0.7.1:
+  deslop-js@0.7.8:
     dependencies:
-      '@oxc-project/types': 0.132.0
+      '@oxc-project/types': 0.138.0
       fast-glob: 3.3.3
       minimatch: 10.2.5
-      oxc-parser: 0.132.0
+      oxc-parser: 0.138.0
       oxc-resolver: 11.23.0
       typescript: 5.9.3
 
@@ -16628,6 +16708,8 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  ee-first@1.1.1: {}
+
   ejs@3.1.10:
     dependencies:
       jake: 10.9.4
@@ -16719,6 +16801,8 @@ snapshots:
   emoji-regex@9.2.2: {}
 
   emojis-list@3.0.0: {}
+
+  encodeurl@2.0.0: {}
 
   encoding@0.1.13:
     dependencies:
@@ -17000,36 +17084,18 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-html@1.0.3: {}
+
   escape-string-regexp@4.0.0: {}
 
   escape-string-regexp@5.0.0: {}
-
-  eslint-config-next@16.0.5(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3):
-    dependencies:
-      '@next/eslint-plugin-next': 16.0.5
-      eslint: 9.39.4(jiti@2.7.0)
-      eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0))
-      globals: 16.4.0
-      typescript-eslint: 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@typescript-eslint/parser'
-      - eslint-import-resolver-webpack
-      - eslint-plugin-import-x
-      - supports-color
 
   eslint-config-next@16.0.5(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3):
     dependencies:
       '@next/eslint-plugin-next': 16.0.5
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
@@ -17056,22 +17122,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3
-      eslint: 9.39.4(jiti@2.7.0)
-      get-tsconfig: 4.14.0
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.17
-      unrs-resolver: 1.12.2
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -17086,54 +17137,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      eslint: 9.39.4(jiti@2.7.0)
-      eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-module-utils@2.14.0(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-module-utils@2.14.0(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
-      - supports-color
-
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
-    dependencies:
-      '@rtsao/scc': 1.1.0
-      array-includes: 3.1.9
-      array.prototype.findlastindex: 1.2.6
-      array.prototype.flat: 1.3.3
-      array.prototype.flatmap: 1.3.3
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 9.39.4(jiti@2.7.0)
-      eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
-      hasown: 2.0.4
-      is-core-module: 2.16.2
-      is-glob: 4.0.3
-      minimatch: 3.1.5
-      object.fromentries: 2.0.8
-      object.groupby: 1.0.3
-      object.values: 1.2.1
-      semver: 6.3.1
-      string.prototype.trimend: 1.0.10
-      tsconfig-paths: 3.15.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
       - supports-color
 
   eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
@@ -17147,7 +17158,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.14.0(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-module-utils: 2.14.0(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -17358,6 +17369,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  etag@1.8.1: {}
+
   event-target-shim@5.0.1: {}
 
   eventemitter3@5.0.4: {}
@@ -17371,6 +17384,10 @@ snapshots:
   events@3.3.0: {}
 
   eventsource-parser@3.1.0: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.0
 
   execa@5.1.1:
     dependencies:
@@ -17389,6 +17406,44 @@ snapshots:
   expect-type@1.4.0: {}
 
   exponential-backoff@3.1.3: {}
+
+  express-rate-limit@8.5.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.2.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.3
+      range-parser: 1.3.0
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   exsolve@1.1.0: {}
 
@@ -17477,6 +17532,17 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-up@5.0.0:
     dependencies:
       locate-path: 6.0.0
@@ -17511,6 +17577,8 @@ snapshots:
       fetch-blob: 3.2.0
     optional: true
 
+  forwarded@0.2.0: {}
+
   fraction.js@4.3.7: {}
 
   framer-motion@12.38.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
@@ -17539,6 +17607,8 @@ snapshots:
     optionalDependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
+
+  fresh@2.0.0: {}
 
   fs-constants@1.0.0: {}
 
@@ -17581,7 +17651,7 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  fumadocs-core@16.10.7(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.23.0(react@19.2.7))(next@16.0.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3):
+  fumadocs-core@16.10.7(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.23.0(react@19.2.7))(next@16.0.7(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3):
     dependencies:
       '@orama/orama': 3.1.18
       estree-util-value-to-estree: 3.5.0
@@ -17608,21 +17678,21 @@ snapshots:
       '@types/mdast': 4.0.4
       '@types/react': 19.2.17
       lucide-react: 1.23.0(react@19.2.7)
-      next: 16.0.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.0.7(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       zod: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@14.3.2(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.10.7(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.23.0(react@19.2.7))(next@16.0.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.0.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(vite@7.3.6(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)):
+  fumadocs-mdx@14.3.2(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.10.7(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.23.0(react@19.2.7))(next@16.0.7(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.0.7(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(vite@7.3.6(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
       chokidar: 5.0.0
       esbuild: 0.28.1
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.10.7(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.23.0(react@19.2.7))(next@16.0.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+      fumadocs-core: 16.10.7(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.23.0(react@19.2.7))(next@16.0.7(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       js-yaml: 4.3.0
       mdast-util-mdx: 3.0.0
       mdast-util-to-markdown: 2.1.2
@@ -17639,13 +17709,13 @@ snapshots:
       '@types/mdast': 4.0.4
       '@types/mdx': 2.0.14
       '@types/react': 19.2.17
-      next: 16.0.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.0.7(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       vite: 7.3.6(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-ui@16.10.7(@tailwindcss/oxide@4.3.2)(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.10.7(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.23.0(react@19.2.7))(next@16.0.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.0.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2):
+  fumadocs-ui@16.10.7(@tailwindcss/oxide@4.3.2)(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.10.7(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.23.0(react@19.2.7))(next@16.0.7(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.0.7(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2):
     dependencies:
       '@fuma-translate/react': 1.0.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@fumadocs/tailwind': 0.0.5(@tailwindcss/oxide@4.3.2)(tailwindcss@4.3.2)
@@ -17661,7 +17731,7 @@ snapshots:
       '@radix-ui/react-tabs': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       class-variance-authority: 0.7.1
       cnfast: 0.0.8
-      fumadocs-core: 16.10.7(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.23.0(react@19.2.7))(next@16.0.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+      fumadocs-core: 16.10.7(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.23.0(react@19.2.7))(next@16.0.7(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       lucide-react: 1.23.0(react@19.2.7)
       motion: 12.42.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-themes: 0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -17675,7 +17745,7 @@ snapshots:
     optionalDependencies:
       '@types/mdx': 2.0.14
       '@types/react': 19.2.17
-      next: 16.0.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.0.7(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - '@tailwindcss/oxide'
@@ -18024,6 +18094,8 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
+  hono@4.12.30: {}
+
   hosted-git-info@4.1.0:
     dependencies:
       lru-cache: 6.0.0
@@ -18039,6 +18111,14 @@ snapshots:
   html-void-elements@3.0.0: {}
 
   http-cache-semantics@4.2.0: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
 
   http-proxy-agent@5.0.0:
     dependencies:
@@ -18143,6 +18223,8 @@ snapshots:
   internmap@2.0.3: {}
 
   ip-address@10.2.0: {}
+
+  ipaddr.js@1.9.1: {}
 
   is-alphabetical@2.0.1: {}
 
@@ -18262,6 +18344,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-promise@4.0.0: {}
+
   is-property@1.0.2: {}
 
   is-reference@1.2.1:
@@ -18378,6 +18462,8 @@ snapshots:
   jiti@1.21.7: {}
 
   jiti@2.7.0: {}
+
+  jose@6.2.3: {}
 
   js-base64@3.8.0:
     optional: true
@@ -18885,6 +18971,8 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
 
+  media-typer@1.1.0: {}
+
   mediabunny@1.37.0:
     dependencies:
       '@types/dom-mediacapture-transform': 0.1.11
@@ -18893,6 +18981,8 @@ snapshots:
   memfs@3.4.3:
     dependencies:
       fs-monkey: 1.0.3
+
+  merge-descriptors@2.0.0: {}
 
   merge-stream@2.0.0: {}
 
@@ -19171,9 +19261,15 @@ snapshots:
 
   mime-db@1.52.0: {}
 
+  mime-db@1.54.0: {}
+
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   mime@2.6.0: {}
 
@@ -19356,6 +19452,8 @@ snapshots:
 
   negotiator@0.6.4: {}
 
+  negotiator@1.0.0: {}
+
   neo-async@2.6.2: {}
 
   next-mdx-remote@6.0.0(@types/react@19.2.17)(react@19.2.0):
@@ -19402,7 +19500,32 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@16.0.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  next@16.0.7(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+    dependencies:
+      '@next/env': 16.0.7
+      '@swc/helpers': 0.5.15
+      caniuse-lite: 1.0.30001802
+      postcss: 8.4.31
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.0)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 16.0.7
+      '@next/swc-darwin-x64': 16.0.7
+      '@next/swc-linux-arm64-gnu': 16.0.7
+      '@next/swc-linux-arm64-musl': 16.0.7
+      '@next/swc-linux-x64-gnu': 16.0.7
+      '@next/swc-linux-x64-musl': 16.0.7
+      '@next/swc-win32-arm64-msvc': 16.0.7
+      '@next/swc-win32-x64-msvc': 16.0.7
+      '@opentelemetry/api': 1.9.1
+      '@playwright/test': 1.61.1
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
+  next@16.0.7(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       '@next/env': 16.0.7
       '@swc/helpers': 0.5.15
@@ -19410,7 +19533,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.7)
+      styled-jsx: 5.1.6(react@19.2.7)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.0.7
       '@next/swc-darwin-x64': 16.0.7
@@ -19427,31 +19550,6 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
     optional: true
-
-  next@16.0.7(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
-    dependencies:
-      '@next/env': 16.0.7
-      '@swc/helpers': 0.5.15
-      caniuse-lite: 1.0.30001802
-      postcss: 8.4.31
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
-      styled-jsx: 5.1.6(react@19.2.0)
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 16.0.7
-      '@next/swc-darwin-x64': 16.0.7
-      '@next/swc-linux-arm64-gnu': 16.0.7
-      '@next/swc-linux-arm64-musl': 16.0.7
-      '@next/swc-linux-x64-gnu': 16.0.7
-      '@next/swc-linux-x64-musl': 16.0.7
-      '@next/swc-win32-arm64-msvc': 16.0.7
-      '@next/swc-win32-x64-msvc': 16.0.7
-      '@opentelemetry/api': 1.9.1
-      '@playwright/test': 1.61.1
-      sharp: 0.34.5
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
 
   nf3@0.1.12: {}
 
@@ -19645,6 +19743,10 @@ snapshots:
 
   ohash@2.0.11: {}
 
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -19737,55 +19839,30 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  oxc-parser@0.132.0:
+  oxc-parser@0.138.0:
     dependencies:
-      '@oxc-project/types': 0.132.0
+      '@oxc-project/types': 0.138.0
     optionalDependencies:
-      '@oxc-parser/binding-android-arm-eabi': 0.132.0
-      '@oxc-parser/binding-android-arm64': 0.132.0
-      '@oxc-parser/binding-darwin-arm64': 0.132.0
-      '@oxc-parser/binding-darwin-x64': 0.132.0
-      '@oxc-parser/binding-freebsd-x64': 0.132.0
-      '@oxc-parser/binding-linux-arm-gnueabihf': 0.132.0
-      '@oxc-parser/binding-linux-arm-musleabihf': 0.132.0
-      '@oxc-parser/binding-linux-arm64-gnu': 0.132.0
-      '@oxc-parser/binding-linux-arm64-musl': 0.132.0
-      '@oxc-parser/binding-linux-ppc64-gnu': 0.132.0
-      '@oxc-parser/binding-linux-riscv64-gnu': 0.132.0
-      '@oxc-parser/binding-linux-riscv64-musl': 0.132.0
-      '@oxc-parser/binding-linux-s390x-gnu': 0.132.0
-      '@oxc-parser/binding-linux-x64-gnu': 0.132.0
-      '@oxc-parser/binding-linux-x64-musl': 0.132.0
-      '@oxc-parser/binding-openharmony-arm64': 0.132.0
-      '@oxc-parser/binding-wasm32-wasi': 0.132.0
-      '@oxc-parser/binding-win32-arm64-msvc': 0.132.0
-      '@oxc-parser/binding-win32-ia32-msvc': 0.132.0
-      '@oxc-parser/binding-win32-x64-msvc': 0.132.0
-
-  oxc-parser@0.135.0:
-    dependencies:
-      '@oxc-project/types': 0.135.0
-    optionalDependencies:
-      '@oxc-parser/binding-android-arm-eabi': 0.135.0
-      '@oxc-parser/binding-android-arm64': 0.135.0
-      '@oxc-parser/binding-darwin-arm64': 0.135.0
-      '@oxc-parser/binding-darwin-x64': 0.135.0
-      '@oxc-parser/binding-freebsd-x64': 0.135.0
-      '@oxc-parser/binding-linux-arm-gnueabihf': 0.135.0
-      '@oxc-parser/binding-linux-arm-musleabihf': 0.135.0
-      '@oxc-parser/binding-linux-arm64-gnu': 0.135.0
-      '@oxc-parser/binding-linux-arm64-musl': 0.135.0
-      '@oxc-parser/binding-linux-ppc64-gnu': 0.135.0
-      '@oxc-parser/binding-linux-riscv64-gnu': 0.135.0
-      '@oxc-parser/binding-linux-riscv64-musl': 0.135.0
-      '@oxc-parser/binding-linux-s390x-gnu': 0.135.0
-      '@oxc-parser/binding-linux-x64-gnu': 0.135.0
-      '@oxc-parser/binding-linux-x64-musl': 0.135.0
-      '@oxc-parser/binding-openharmony-arm64': 0.135.0
-      '@oxc-parser/binding-wasm32-wasi': 0.135.0
-      '@oxc-parser/binding-win32-arm64-msvc': 0.135.0
-      '@oxc-parser/binding-win32-ia32-msvc': 0.135.0
-      '@oxc-parser/binding-win32-x64-msvc': 0.135.0
+      '@oxc-parser/binding-android-arm-eabi': 0.138.0
+      '@oxc-parser/binding-android-arm64': 0.138.0
+      '@oxc-parser/binding-darwin-arm64': 0.138.0
+      '@oxc-parser/binding-darwin-x64': 0.138.0
+      '@oxc-parser/binding-freebsd-x64': 0.138.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.138.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.138.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.138.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.138.0
+      '@oxc-parser/binding-linux-ppc64-gnu': 0.138.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.138.0
+      '@oxc-parser/binding-linux-riscv64-musl': 0.138.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.138.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.138.0
+      '@oxc-parser/binding-linux-x64-musl': 0.138.0
+      '@oxc-parser/binding-openharmony-arm64': 0.138.0
+      '@oxc-parser/binding-wasm32-wasi': 0.138.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.138.0
+      '@oxc-parser/binding-win32-ia32-msvc': 0.138.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.138.0
 
   oxc-resolver@11.23.0:
     optionalDependencies:
@@ -19830,12 +19907,12 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  oxlint-plugin-react-doctor@0.7.1:
+  oxlint-plugin-react-doctor@0.7.8:
     dependencies:
       '@typescript-eslint/types': 8.62.1
       eslint-scope: 9.1.2
       eslint-visitor-keys: 5.0.1
-      oxc-parser: 0.135.0
+      oxc-parser: 0.138.0
 
   oxlint@1.66.0:
     optionalDependencies:
@@ -19915,6 +19992,8 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  parseurl@1.3.3: {}
+
   path-exists@4.0.0: {}
 
   path-is-absolute@1.0.1: {}
@@ -19932,6 +20011,8 @@ snapshots:
     dependencies:
       lru-cache: 11.5.1
       minipass: 7.1.3
+
+  path-to-regexp@8.4.2: {}
 
   path-type@4.0.0: {}
 
@@ -19987,6 +20068,8 @@ snapshots:
   pify@2.3.0: {}
 
   pirates@4.0.7: {}
+
+  pkce-challenge@5.0.1: {}
 
   pkg-types@2.3.1:
     dependencies:
@@ -20419,6 +20502,11 @@ snapshots:
       '@types/node': 22.20.0
       long: 5.3.2
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   proxy-from-env@1.1.0: {}
 
   pump@3.0.4:
@@ -20427,6 +20515,11 @@ snapshots:
       once: 1.4.0
 
   punycode@2.3.1: {}
+
+  qs@6.15.3:
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
 
   queue-microtask@1.2.3: {}
 
@@ -20438,6 +20531,15 @@ snapshots:
     dependencies:
       discontinuous-range: 1.0.0
       ret: 0.1.15
+
+  range-parser@1.3.0: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      unpipe: 1.0.0
 
   rc9@3.0.1:
     dependencies:
@@ -20451,19 +20553,19 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
-  react-doctor@0.7.1(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(eslint@9.39.4(jiti@2.7.0)):
+  react-doctor@0.7.8(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@babel/code-frame': 7.29.7
       '@sentry/node': 10.63.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))
       agent-install: 0.0.5
       conf: 15.1.0
       confbox: 0.2.4
-      deslop-js: 0.7.1
+      deslop-js: 0.7.8
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0))
       jiti: 2.7.0
       magicast: 0.5.3
       oxlint: 1.66.0
-      oxlint-plugin-react-doctor: 0.7.1
+      oxlint-plugin-react-doctor: 0.7.8
       prompts: 2.4.2
       typescript: 5.9.3
       vscode-languageserver: 9.0.1
@@ -20600,7 +20702,7 @@ snapshots:
       preact: 10.29.4
       prompts: 2.4.2
       react: 19.2.0
-      react-doctor: 0.7.1(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(eslint@9.39.4(jiti@2.7.0))
+      react-doctor: 0.7.8(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(eslint@9.39.4(jiti@2.7.0))
       react-dom: 19.2.0(react@19.2.0)
       react-grab: 0.1.48(react@19.2.0)
     optionalDependencies:
@@ -21014,6 +21116,16 @@ snapshots:
 
   rou3@0.8.1: {}
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   run-applescript@7.1.0: {}
 
   run-parallel@1.2.0:
@@ -21090,6 +21202,22 @@ snapshots:
 
   semver@7.8.5: {}
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.3.0
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   serialize-error@7.0.1:
     dependencies:
       type-fest: 0.13.1
@@ -21100,6 +21228,15 @@ snapshots:
       seroval: 1.5.4
 
   seroval@1.5.4: {}
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
 
   server-only@0.0.1: {}
 
@@ -21126,6 +21263,8 @@ snapshots:
       dunder-proto: 1.0.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.2
+
+  setprototypeof@1.2.0: {}
 
   sharp@0.34.5:
     dependencies:
@@ -21330,6 +21469,8 @@ snapshots:
 
   state-local@1.0.7: {}
 
+  statuses@2.0.2: {}
+
   std-env@3.10.0: {}
 
   std-env@4.1.0: {}
@@ -21474,18 +21615,11 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.29.7
 
-  styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.7):
+  styled-jsx@5.1.6(react@19.2.7):
     dependencies:
       client-only: 0.0.1
       react: 19.2.7
-    optionalDependencies:
-      '@babel/core': 7.29.7
     optional: true
-
-  styled-jsx@5.1.6(react@19.2.0):
-    dependencies:
-      client-only: 0.0.1
-      react: 19.2.0
 
   sucrase@3.35.1:
     dependencies:
@@ -21703,16 +21837,6 @@ snapshots:
       esbuild: 0.28.1
       lightningcss: 1.32.0
 
-  terser-webpack-plugin@5.6.1(postcss@8.5.16)(webpack@5.105.0(postcss@8.5.16)):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      jest-worker: 27.5.1
-      schema-utils: 4.3.3
-      terser: 5.48.0
-      webpack: 5.105.0(postcss@8.5.16)
-    optionalDependencies:
-      postcss: 8.5.16
-
   terser@5.48.0:
     dependencies:
       '@jridgewell/source-map': 0.3.11
@@ -21782,6 +21906,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  toidentifier@1.0.1: {}
+
   tr46@0.0.3: {}
 
   tr46@1.0.1:
@@ -21850,6 +21976,12 @@ snapshots:
   type-fest@5.8.0:
     dependencies:
       tagged-tag: 1.0.0
+
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.0
+      mime-types: 3.0.2
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -21991,6 +22123,8 @@ snapshots:
 
   universalify@2.0.1: {}
 
+  unpipe@1.0.0: {}
+
   unplugin@3.3.0(@rspack/core@1.7.6(@swc/helpers@0.5.15))(esbuild@0.28.1)(rollup@4.62.2)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(webpack@5.105.0(esbuild@0.28.1)(lightningcss@1.32.0)):
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -22107,6 +22241,8 @@ snapshots:
   uuid@11.1.1: {}
 
   uuid@8.3.2: {}
+
+  vary@1.1.2: {}
 
   verror@1.10.1:
     dependencies:
@@ -22392,7 +22528,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.1(postcss@8.5.16)(webpack@5.105.0(postcss@8.5.16))
+      terser-webpack-plugin: 5.6.1(esbuild@0.25.0)(postcss@8.5.16)(webpack@5.105.0(postcss@8.5.16))
       watchpack: 2.5.2
       webpack-sources: 3.5.1
     transitivePeerDependencies:
@@ -22552,6 +22688,10 @@ snapshots:
       archiver-utils: 5.0.2
       compress-commons: 6.0.2
       readable-stream: 4.7.0
+
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
 
   zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:


### PR DESCRIPTION
## Summary

data-peek's main process can now expose a local MCP server so agents (Claude Code, Claude Desktop, etc.) can inspect schemas and query connected databases.

- **Transport/auth**: Streamable HTTP on `127.0.0.1:4722` (configurable), bearer token (regenerable), 401 with no detail otherwise. Off by default — Settings toggle, state persists (token in encrypted storage with safeStorage fallback).
- **Tools**: `list_connections` (credential-free), `list_schemas` (schema cache), `run_query` (single-statement read-only, 500-row cap, rollback-wrapped tx; Postgres additionally `SET TRANSACTION READ ONLY`), `explain_query` (read-guarded), `execute_statement` (every write requires clicking Approve in a data-peek dialog; 60 s timeout auto-rejects; requests serialized).
- **UI**: Settings section with copyable `claude mcp add` snippet; global approval dialog that closes on resolution/timeout across windows.
- Docs updated in README, docs/features.md, and the marketing features list.

## Review

Built task-by-task with per-task spec+quality reviews and a final whole-branch review (verdict: ready to merge). The final review caught and fixed a statement-injection hole in `explain_query`, `SELECT … INTO`/`PRAGMA` keyword-guard gaps, plaintext token storage, and stale approval dialogs.

## Testing

- 1017/1017 vitest tests pass (60 new across read-guard, approval manager, tools via InMemoryTransport, HTTP server, IPC handlers)
- `pnpm typecheck` clean; lint clean in touched files (5 pre-existing errors in unrelated files)
- Manual verification pending (needs a running instance): enable in Settings → `claude mcp add …` → list/query/approve-write flow

https://claude.ai/code/session_01Khhdnw9aShE87ALovgMqax

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an MCP server for AI/agent database integrations via a local HTTP endpoint secured with a bearer token.
  * Added desktop MCP settings (enable/disable, port configuration, token regeneration) plus a copyable setup command.
  * Added read-only MCP tools for listing connections/schemas, running safe read queries with row limits, and fetching query plans.
  * Added in-app approval prompts for write execution, with automatic timeout-based resolution and serialized approval handling.

* **Documentation**
  * Updated feature documentation and marketing materials with MCP server capabilities and setup details.

* **Tests**
  * Added end-to-end test coverage for the MCP server, tools, approval flow, and read-only SQL enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->