### PR TITLE
docs: continuity & trust pass — sustainability guarantee, security policy, docs + FAQ

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,12 @@ pnpm lint
 # Type checking (from apps/desktop)
 cd apps/desktop
 pnpm typecheck
+
+# Unit tests (from apps/desktop)
+pnpm test
+
+# End-to-end tests (from apps/desktop; builds first, needs Docker for the Postgres specs)
+pnpm test:e2e
 ```
 
 ## Project Structure
@@ -44,10 +50,18 @@ apps/
     src/main/        # Main process (Node.js)
     src/preload/     # IPC bridge
     src/renderer/    # React frontend
-  web/               # Marketing website
+  web/               # Marketing website + licence API
+  docs/              # Documentation site
 packages/
   shared/            # Shared TypeScript types
 ```
+
+## Where to start
+
+Issues labelled
+[good first issue](https://github.com/Rohithgilla12/data-peek/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+are scoped for newcomers. For bigger changes, open an issue first so we can
+agree on the approach before you invest time. Every PR gets maintainer review.
 
 ## Code Style
 

--- a/README.md
+++ b/README.md
@@ -300,6 +300,17 @@ MIT License - see [LICENSE](LICENSE) for details.
 
 Pre-built binaries require a license for commercial use. See the license file for details on free vs. commercial use.
 
+## Project continuity
+
+data-peek is a single-maintainer project, and we treat that honestly rather
+than hiding it. Two commitments are written down in
+[SUSTAINABILITY.md](SUSTAINABILITY.md): a **kill-switch-free guarantee** (if
+the licence server ever disappears, your activated version keeps working
+forever, offline) and a **dormancy pledge** (12 months of maintainer
+inactivity waives the commercial-licence requirement for all released
+versions). Releases are built by CI, and the MIT source means you can always
+build from source.
+
 ## Contributing
 
 Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,8 @@
 
 Please report vulnerabilities privately via
 [GitHub private vulnerability reporting](https://github.com/Rohithgilla12/data-peek/security/advisories/new).
-Do not open public issues for security problems.
+If you can't use GitHub, email gillarohith1@gmail.com with "security" in the
+subject. Do not open public issues for security problems.
 
 We aim to acknowledge reports within 7 days. data-peek is a
 single-maintainer project; this is a good-faith goal, not a contractual SLA.
@@ -17,7 +18,10 @@ version, update first and re-test.
 ## Scope notes
 
 - data-peek connects directly from your machine to your databases; there is no
-  intermediary service and no telemetry.
-- Credentials are stored via the OS keychain (Electron `safeStorage`).
+  intermediary service and nothing is phoned home. Query timing statistics are
+  collected locally for the performance panel and never leave your machine.
+- Credentials are encrypted with a key protected by the OS keychain (Electron
+  `safeStorage`) on platforms that provide one; on systems without OS-backed
+  secure storage the app degrades to plaintext storage with a logged warning.
 - The optional local MCP server binds to 127.0.0.1 only and requires a bearer
   token; write statements additionally require in-app approval.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report vulnerabilities privately via
+[GitHub private vulnerability reporting](https://github.com/Rohithgilla12/data-peek/security/advisories/new).
+Do not open public issues for security problems.
+
+We aim to acknowledge reports within 7 days. data-peek is a
+single-maintainer project; this is a good-faith goal, not a contractual SLA.
+
+## Supported versions
+
+Security fixes target the latest release only. If you are on an older
+version, update first and re-test.
+
+## Scope notes
+
+- data-peek connects directly from your machine to your databases; there is no
+  intermediary service and no telemetry.
+- Credentials are stored via the OS keychain (Electron `safeStorage`).
+- The optional local MCP server binds to 127.0.0.1 only and requires a bearer
+  token; write statements additionally require in-app approval.

--- a/SUSTAINABILITY.md
+++ b/SUSTAINABILITY.md
@@ -13,7 +13,7 @@ verifiable against the source code.
 - **Releases are not tied to one machine.** Every published binary is built by
   GitHub Actions ([build.yml](.github/workflows/build.yml),
   [build-artifacts.yml](.github/workflows/build-artifacts.yml)). Anyone with a
-  fork can produce identical builds.
+  fork can run the same workflows to produce their own builds.
 - **Your licence does not depend on our servers.** See the guarantee below.
 
 ## Kill-switch-free guarantee

--- a/SUSTAINABILITY.md
+++ b/SUSTAINABILITY.md
@@ -1,0 +1,54 @@
+# Sustainability & Continuity
+
+data-peek is built and maintained by a single developer. That is a fair thing
+to weigh before adopting any tool, so here is exactly what happens if this
+project ever stops being maintained — written down, versioned in git, and
+verifiable against the source code.
+
+## If data-peek stops being maintained
+
+- **The source stays yours.** The entire codebase is MIT-licensed. You can
+  build, patch, and redistribute it today — see
+  [Building from source](#building-from-source).
+- **Releases are not tied to one machine.** Every published binary is built by
+  GitHub Actions ([build.yml](.github/workflows/build.yml),
+  [build-artifacts.yml](.github/workflows/build-artifacts.yml)). Anyone with a
+  fork can produce identical builds.
+- **Your licence does not depend on our servers.** See the guarantee below.
+
+## Kill-switch-free guarantee
+
+data-peek's licence activation is designed to fail open for the versions you
+already have:
+
+- Activated licences revalidate roughly every 7 days. If the licence server is
+  unreachable, your licence remains fully valid for a 30-day grace window.
+- After that window, the licence falls back to **perpetual mode**: the version
+  you activated keeps working, with all commercial features, forever — fully
+  offline.
+
+In plain terms: if the licence server disappeared tomorrow, every activated
+installation would keep working on its current version indefinitely. This is
+how the code behaves today (`apps/desktop/src/main/license-service.ts`), not a
+promise about future behaviour.
+
+## Dormancy pledge
+
+If this repository has no maintainer activity — no commits, no releases, and
+no issue triage — for **12 consecutive months**, the commercial-licence
+requirement is waived for all versions released up to that point.
+
+This pledge is made by the maintainer, lives in version control, and applies
+to every copy of this file distributed with a release.
+
+## Building from source
+
+```bash
+git clone https://github.com/Rohithgilla12/data-peek.git
+cd data-peek
+pnpm install
+pnpm --filter @data-peek/desktop build:mac   # or build:win / build:linux
+```
+
+Binaries you build yourself are covered by the MIT licence alone — the
+commercial-licence terms apply only to the pre-built binaries we distribute.

--- a/apps/docs/content/docs/configuration/licensing.mdx
+++ b/apps/docs/content/docs/configuration/licensing.mdx
@@ -121,3 +121,9 @@ Solo founders (company of one) can use the free version.
 ### Can I get a refund?
 
 Yes, 30-day money-back guarantee. No questions asked.
+
+## What happens if data-peek stops being maintained?
+
+Your activated version keeps working forever — see
+[Project continuity](/docs/project/continuity) for the kill-switch-free
+guarantee and the dormancy pledge.

--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -10,6 +10,8 @@
     "configuration",
     "---Database Support---",
     "database-support",
+    "---Project---",
+    "project",
     "---Reference---",
     "reference"
   ]

--- a/apps/docs/content/docs/project/continuity.mdx
+++ b/apps/docs/content/docs/project/continuity.mdx
@@ -1,0 +1,40 @@
+---
+title: Continuity
+description: What happens to data-peek — and your licence — if the project stops being maintained
+---
+
+# Continuity
+
+data-peek is built by a single maintainer. Instead of pretending otherwise,
+the project makes two concrete commitments, both versioned in the repository
+as [SUSTAINABILITY.md](https://github.com/Rohithgilla12/data-peek/blob/main/SUSTAINABILITY.md).
+
+## The kill-switch-free guarantee
+
+Licence activation is designed to fail open for versions you already have:
+
+- Activated licences revalidate roughly every 7 days.
+- If the licence server is unreachable, your licence stays fully valid for a
+  30-day grace window.
+- After that, the licence falls back to **perpetual mode**: the version you
+  activated keeps working with all commercial features, forever, fully
+  offline.
+
+If the licence server disappeared tomorrow, every activated installation
+would keep working on its current version indefinitely. This describes how
+the shipped code behaves today — not a promise about future behaviour.
+
+## The dormancy pledge
+
+If the repository has no maintainer activity — no commits, no releases, no
+issue triage — for 12 consecutive months, the commercial-licence requirement
+is waived for all versions released up to that point.
+
+## Everything else that de-risks adoption
+
+- **MIT source.** Build it yourself, patch it, fork it — today, not just in a
+  doomsday scenario.
+- **CI-built releases.** Binaries come from GitHub Actions, not a laptop, so
+  a fork can reproduce them.
+- **Local-first.** No service dependency in day-to-day use: queries go from
+  your machine to your database.

--- a/apps/docs/content/docs/project/index.mdx
+++ b/apps/docs/content/docs/project/index.mdx
@@ -1,0 +1,12 @@
+---
+title: Project
+description: How data-peek is maintained, released, and kept trustworthy
+---
+
+# Project
+
+Pages about the project itself rather than the product: maintenance model,
+continuity commitments, and what happens to your licence in the worst case.
+
+- [Continuity](/docs/project/continuity) — the kill-switch-free guarantee and
+  the dormancy pledge.

--- a/apps/docs/content/docs/project/meta.json
+++ b/apps/docs/content/docs/project/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Project",
+  "pages": ["index", "continuity"]
+}

--- a/apps/web/src/components/marketing/faq.tsx
+++ b/apps/web/src/components/marketing/faq.tsx
@@ -30,6 +30,10 @@ const faqs = [
     a: "A Pro license includes one year of updates. If you don't renew, the version you have keeps working forever. Renew whenever you want new features.",
   },
   {
+    q: "What happens if data-peek stops being maintained?",
+    a: "Your activated version keeps working forever, fully offline — licence checks fail open, not closed. And if the project sees no maintainer activity for 12 months, the commercial-licence requirement is waived for every released version. The source is MIT, so you can always build it yourself.",
+  },
+  {
     q: "I'm a student or educator — can I use it for free?",
     a: "Yes, including for paid university coursework. DM @gillarohith on X or email gillarohith1@gmail.com for a free license.",
   },


### PR DESCRIPTION
## Summary

Addresses the continuity/trust concerns from the OpenTechHub review (2026-06-24) with concrete, verifiable commitments:

- **SUSTAINABILITY.md** (new): kill-switch-free guarantee (7-day revalidation → 30-day offline grace → perpetual mode; verified against `license-service.ts` before writing it down), a 12-month dormancy pledge (maintainer inactivity waives the commercial-licence requirement for released versions), CI-built-release note, build-from-source guide.
- **SECURITY.md** (new): GitHub private vulnerability reporting, latest-release support policy, 7-day acknowledgement stated as a good-faith goal (explicitly not a contractual SLA).
- **CONTRIBUTING.md**: added test/e2e commands, docs app, good-first-issue entry point (kept the existing guide, extended it).
- **README**: new Project continuity section linking SUSTAINABILITY.md.
- **Docs site**: new Project → Continuity page + sidebar section + cross-link from the licensing page.
- **Marketing FAQ**: one new entry on what happens if the project stops being maintained.

Every claim traces to verified licence-service behaviour; wording deliberately avoids promising future updates.

## Testing

- `apps/docs` and `apps/web` production builds pass; repo lint clean; Prettier clean on all new markdown.
- Claims audit grep: no overpromise patterns present.

https://claude.ai/code/session_01Khhdnw9aShE87ALovgMqax

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new Project continuity page detailing offline operation, licensing guarantees, revalidation/grace behavior, dormancy commitments, and reproducible CI releases.
  * Added a dedicated Project documentation section and navigation entry.
  * Added a SECURITY policy document with vulnerability reporting guidance and scope/handling notes.
  * Updated the licensing FAQ and marketing/FAQ content to reflect ongoing availability if maintenance stops.
  * Expanded contributor guidance with additional unit and end-to-end test commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->