### PR TITLE
feat: tamper-evident audit log with CSV/JSON export

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,5 +53,11 @@ jobs:
       - name: Run desktop tests
         run: pnpm --filter @data-peek/desktop test
 
+      # better-sqlite3 is compiled for Electron's ABI, so the audit/time-machine/
+      # notebook storage suites (hash-chain, prune, export logic) skip under
+      # plain node above and only run for real here, under the Electron binary.
+      - name: Run desktop tests (Electron ABI)
+        run: pnpm --filter @data-peek/desktop test:electron
+
       - name: Typecheck desktop
         run: pnpm --filter @data-peek/desktop typecheck

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ A minimal, fast SQL client desktop application with AI-powered querying. Built f
 - **Read-only tools** - `list_connections`, `list_schemas`, `run_query` (500-row cap, rollback-wrapped, Postgres additionally runs `READ ONLY` at the DB level), `explain_query`
 - **Approved writes** - `execute_statement` prompts an in-app Approve/Reject dialog for every write; 60s timeout auto-rejects
 - **One-command setup** - copy the ready-made `claude mcp add` snippet straight from Settings → MCP server
+- **Audit log** - tamper-evident (hash-chained) local record of every executed statement, with CSV/JSON export and integrity verification. Off by default. Stored locally, never uploaded; SQL text can contain data values.
 
 ### Query Editor
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ A minimal, fast SQL client desktop application with AI-powered querying. Built f
 - **Read-only tools** - `list_connections`, `list_schemas`, `run_query` (500-row cap, rollback-wrapped, Postgres additionally runs `READ ONLY` at the DB level), `explain_query`
 - **Approved writes** - `execute_statement` prompts an in-app Approve/Reject dialog for every write; 60s timeout auto-rejects
 - **One-command setup** - copy the ready-made `claude mcp add` snippet straight from Settings → MCP server
+
+### Audit Log
+
 - **Audit log** - tamper-evident (hash-chained) local record of every executed statement, with CSV/JSON export and integrity verification. Off by default. Stored locally, never uploaded; SQL text can contain data values.
 
 ### Query Editor

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -12,7 +12,7 @@
     "typecheck:web": "tsc --noEmit -p tsconfig.web.json --composite false",
     "typecheck": "pnpm run typecheck:node && pnpm run typecheck:web",
     "test": "vitest run",
-    "test:electron": "ELECTRON_RUN_AS_NODE=1 electron ../../node_modules/vitest/vitest.mjs run src/main/__tests__/time-machine-storage.test.ts src/main/__tests__/audit-storage.test.ts src/main/__tests__/notebook-storage.test.ts",
+    "test:electron": "ELECTRON_RUN_AS_NODE=1 electron $(node -e \"console.log(require('node:path').join(require('node:path').dirname(require.resolve('vitest/package.json')), 'vitest.mjs'))\") run src/main/__tests__/time-machine-storage.test.ts src/main/__tests__/audit-storage.test.ts src/main/__tests__/notebook-storage.test.ts",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "pnpm run build && playwright test",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -12,7 +12,7 @@
     "typecheck:web": "tsc --noEmit -p tsconfig.web.json --composite false",
     "typecheck": "pnpm run typecheck:node && pnpm run typecheck:web",
     "test": "vitest run",
-    "test:electron": "ELECTRON_RUN_AS_NODE=1 electron ../../node_modules/vitest/vitest.mjs run src/main/__tests__/time-machine-storage.test.ts",
+    "test:electron": "ELECTRON_RUN_AS_NODE=1 electron ../../node_modules/vitest/vitest.mjs run src/main/__tests__/time-machine-storage.test.ts src/main/__tests__/audit-storage.test.ts src/main/__tests__/notebook-storage.test.ts",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "pnpm run build && playwright test",

--- a/apps/desktop/src/main/__tests__/audit-capture.test.ts
+++ b/apps/desktop/src/main/__tests__/audit-capture.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-const recordAudit = vi.fn()
+const recordAudit = vi.hoisted(() => vi.fn())
 vi.mock('../audit-service', () => ({ recordAudit }))
 vi.mock('../lib/logger', () => ({
   createLogger: () => ({ debug: vi.fn(), warn: vi.fn(), error: vi.fn(), info: vi.fn() })

--- a/apps/desktop/src/main/__tests__/audit-capture.test.ts
+++ b/apps/desktop/src/main/__tests__/audit-capture.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const recordAudit = vi.fn()
+vi.mock('../audit-service', () => ({ recordAudit }))
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), warn: vi.fn(), error: vi.fn(), info: vi.fn() })
+}))
+
+const mockAdapter = vi.hoisted(() => ({
+  execute: vi.fn(),
+  queryMultiple: vi.fn()
+}))
+vi.mock('../db-adapter', () => ({ getAdapter: vi.fn(() => mockAdapter) }))
+vi.mock('../mcp/read-guard', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  runReadOnlyQuery: vi.fn().mockResolvedValue({ rows: [{ n: 1 }], fields: [], rowCount: 1 })
+}))
+vi.mock('../schema-cache', () => ({
+  getCachedSchema: vi.fn(),
+  isCacheValid: vi.fn(),
+  getOrFetchCachedSchema: vi.fn()
+}))
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
+import { registerMcpTools } from '../mcp/tools'
+import { ApprovalManager } from '../mcp/approval'
+import type { ConnectionConfig } from '@shared/index'
+
+const conn = {
+  id: 'c1',
+  name: 'local',
+  dbType: 'postgresql',
+  host: 'localhost',
+  port: 5432,
+  database: 'app'
+} as unknown as ConnectionConfig
+
+async function connectedClient(approval: ApprovalManager) {
+  const server = new McpServer({ name: 'data-peek', version: '0.0.0' })
+  registerMcpTools(server, { getConnections: () => [conn], approval })
+  const [ct, st] = InMemoryTransport.createLinkedPair()
+  const client = new Client({ name: 'test', version: '0.0.0' })
+  await Promise.all([server.connect(st), client.connect(ct)])
+  return client
+}
+
+describe('audit capture', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('mcp run_query records an editor-free mcp entry on success', async () => {
+    const client = await connectedClient(new ApprovalManager(() => undefined))
+    await client.callTool({ name: 'run_query', arguments: { connectionId: 'c1', sql: 'SELECT 1' } })
+    expect(recordAudit).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'mcp', sql: 'SELECT 1', success: true, rowCount: 1 })
+    )
+  })
+
+  it('mcp execute_statement records approved writes and does not record rejected ones', async () => {
+    mockAdapter.execute.mockResolvedValue({ rowCount: 2 })
+    const approve = new ApprovalManager((req) => approve.respond(req.id, true))
+    let client = await connectedClient(approve)
+    await client.callTool({
+      name: 'execute_statement',
+      arguments: { connectionId: 'c1', sql: 'UPDATE t SET x = 1' }
+    })
+    expect(recordAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'mcp',
+        sql: 'UPDATE t SET x = 1',
+        success: true,
+        rowCount: 2
+      })
+    )
+
+    recordAudit.mockClear()
+    const reject = new ApprovalManager((req) => reject.respond(req.id, false))
+    client = await connectedClient(reject)
+    await client.callTool({
+      name: 'execute_statement',
+      arguments: { connectionId: 'c1', sql: 'DROP TABLE t' }
+    })
+    expect(recordAudit).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/main/__tests__/audit-service.test.ts
+++ b/apps/desktop/src/main/__tests__/audit-service.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), warn: vi.fn(), error: vi.fn(), info: vi.fn() })
+}))
+
+import {
+  initAuditService,
+  recordAudit,
+  getAuditStatus,
+  setAuditEnabled,
+  setAuditRetention,
+  AUDIT_SETTINGS_DEFAULTS
+} from '../audit-service'
+
+function makeStore(initial = { ...AUDIT_SETTINGS_DEFAULTS }) {
+  let value = { ...initial }
+  return {
+    get: vi.fn(() => value),
+    set: vi.fn((_k: string, v: typeof value) => {
+      value = v
+    })
+  } as never
+}
+
+function makeStorage() {
+  return {
+    record: vi.fn(),
+    count: vi.fn(() => 0),
+    prune: vi.fn(() => 0),
+    verify: vi.fn(),
+    list: vi.fn(),
+    exportTo: vi.fn(),
+    close: vi.fn()
+  } as never
+}
+
+describe('audit-service', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('recordAudit is a no-op while disabled', () => {
+    const storage = makeStorage()
+    initAuditService(makeStore(), storage)
+    recordAudit({
+      source: 'editor',
+      connectionId: 'c1',
+      connectionName: 'x',
+      dbType: 'postgresql',
+      sql: 'SELECT 1',
+      rowCount: 1,
+      success: true
+    })
+    expect((storage as { record: ReturnType<typeof vi.fn> }).record).not.toHaveBeenCalled()
+  })
+
+  it('records after enabling, and never throws when storage.record throws', () => {
+    const storage = makeStorage()
+    ;(storage as { record: ReturnType<typeof vi.fn> }).record.mockImplementation(() => {
+      throw new Error('disk full')
+    })
+    initAuditService(makeStore(), storage)
+    setAuditEnabled(true)
+    expect(() =>
+      recordAudit({
+        source: 'mcp',
+        connectionId: 'c1',
+        connectionName: 'x',
+        dbType: 'postgresql',
+        sql: 'SELECT 1',
+        rowCount: null,
+        success: false,
+        error: 'boom'
+      })
+    ).not.toThrow()
+    expect((storage as { record: ReturnType<typeof vi.fn> }).record).toHaveBeenCalledOnce()
+  })
+
+  it('reports unavailable when storage is null and setEnabled still persists', () => {
+    initAuditService(makeStore(), null)
+    expect(getAuditStatus().available).toBe(false)
+    const status = setAuditEnabled(true)
+    expect(status.enabled).toBe(true)
+  })
+
+  it('validates retention bounds', () => {
+    initAuditService(makeStore(), makeStorage())
+    expect(() => setAuditRetention(3)).toThrow(/between 7 and 3650/)
+    expect(setAuditRetention(30).retentionDays).toBe(30)
+  })
+})

--- a/apps/desktop/src/main/__tests__/audit-service.test.ts
+++ b/apps/desktop/src/main/__tests__/audit-service.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 vi.mock('../lib/logger', () => ({
   createLogger: () => ({ debug: vi.fn(), warn: vi.fn(), error: vi.fn(), info: vi.fn() })
 }))
@@ -36,6 +36,23 @@ function makeStorage() {
 
 describe('audit-service', () => {
   beforeEach(() => vi.clearAllMocks())
+  afterEach(() => vi.useRealTimers())
+
+  it('prunes daily with the current retention settings', () => {
+    vi.useFakeTimers()
+    const store = makeStore({ enabled: true, retentionDays: 30 })
+    const storage = makeStorage()
+    initAuditService(store, storage)
+    const pruneMock = (storage as { prune: ReturnType<typeof vi.fn> }).prune
+    expect(pruneMock).toHaveBeenCalledWith(30)
+    pruneMock.mockClear()
+
+    setAuditRetention(45)
+    pruneMock.mockClear()
+
+    vi.advanceTimersByTime(24 * 60 * 60 * 1000 + 1000)
+    expect(pruneMock).toHaveBeenCalledWith(45)
+  })
 
   it('recordAudit is a no-op while disabled', () => {
     const storage = makeStorage()

--- a/apps/desktop/src/main/__tests__/audit-storage.test.ts
+++ b/apps/desktop/src/main/__tests__/audit-storage.test.ts
@@ -97,6 +97,17 @@ describe.skipIf(!sqliteAvailable)('AuditStorage', () => {
     expect(result.firstBrokenId).toBe(second.id)
   })
 
+  it('verify detects tampering with connectionName', () => {
+    for (let i = 0; i < 3; i++) store.record(entry({ sql: `SELECT ${i}` }))
+    const second = store.list({ limit: 10, offset: 0 })[1]
+    const raw = new Database(join(dir, 'audit.db'))
+    raw.prepare('UPDATE audit_log SET connection_name = ? WHERE id = ?').run('renamed', second.id)
+    raw.close()
+    const result = store.verify()
+    expect(result.valid).toBe(false)
+    expect(result.firstBrokenId).toBe(second.id)
+  })
+
   it('filters by source and connection', () => {
     store.record(entry())
     store.record(entry({ source: 'mcp', connectionId: 'c2' }))
@@ -129,5 +140,21 @@ describe.skipIf(!sqliteAvailable)('AuditStorage', () => {
     const csv = readFileSync(csvPath, 'utf-8')
     expect(csv.split('\n')[0]).toContain('ts,source,connectionId')
     expect(csv).toContain('"SELECT ""quoted"", comma"')
+  })
+
+  it('escapes CSV formula injection with a leading apostrophe', () => {
+    store.record(entry({ sql: "=CMD('x')" }))
+    const csvPath = join(dir, 'out.csv')
+    store.exportTo('csv', csvPath)
+    const csv = readFileSync(csvPath, 'utf-8')
+    expect(csv).toMatch(/'=CMD\('x'\)/)
+  })
+
+  it('quotes CSV fields containing a bare carriage return', () => {
+    store.record(entry({ sql: 'line1\rline2' }))
+    const csvPath = join(dir, 'out.csv')
+    store.exportTo('csv', csvPath)
+    const csv = readFileSync(csvPath, 'utf-8')
+    expect(csv).toContain('"line1\rline2"')
   })
 })

--- a/apps/desktop/src/main/__tests__/audit-storage.test.ts
+++ b/apps/desktop/src/main/__tests__/audit-storage.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, rmSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import Database from 'better-sqlite3'
+import type { AuditEntryInput } from '@shared/index'
+
+vi.mock('electron-log/main', () => ({
+  default: {
+    initialize: vi.fn(),
+    transports: {
+      console: { level: 'debug' },
+      file: { level: 'debug', maxSize: 0, format: '' }
+    },
+    scope: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn()
+    })
+  }
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: false
+  }
+}))
+
+import { AuditStorage } from '../audit-storage'
+
+// better-sqlite3 is compiled for Electron's ABI; under plain node the whole
+// suite skips (mirrors the vitest.config.ts exclusion of notebook-storage).
+// Run for real via: ELECTRON_RUN_AS_NODE=1 electron node_modules/vitest/vitest.mjs run <file>
+const sqliteAvailable = (() => {
+  try {
+    new Database(':memory:').close()
+    return true
+  } catch {
+    return false
+  }
+})()
+
+const ZERO = '0'.repeat(64)
+
+function entry(overrides: Partial<AuditEntryInput> = {}): AuditEntryInput {
+  return {
+    source: 'editor',
+    connectionId: 'c1',
+    connectionName: 'local',
+    dbType: 'postgresql',
+    sql: 'SELECT 1',
+    rowCount: 1,
+    success: true,
+    ...overrides
+  }
+}
+
+describe.skipIf(!sqliteAvailable)('AuditStorage', () => {
+  let dir: string
+  let store: AuditStorage
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'audit-test-'))
+    store = new AuditStorage(join(dir, 'audit.db'))
+  })
+
+  afterEach(() => {
+    store.close()
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('records entries and chains hashes from the zero anchor', () => {
+    store.record(entry())
+    store.record(entry({ sql: 'SELECT 2' }))
+    const rows = store.list({ limit: 10, offset: 0 })
+    expect(rows).toHaveLength(2)
+    expect(rows[0].prevHash).toBe(ZERO)
+    expect(rows[1].prevHash).toBe(rows[0].hash)
+    expect(rows[0].hash).toMatch(/^[0-9a-f]{64}$/)
+  })
+
+  it('verify passes on an intact chain and an empty log', () => {
+    expect(store.verify()).toEqual({ valid: true, entries: 0 })
+    for (let i = 0; i < 5; i++) store.record(entry({ sql: `SELECT ${i}` }))
+    expect(store.verify()).toEqual({ valid: true, entries: 5 })
+  })
+
+  it('verify detects tampering and reports the first broken entry', () => {
+    for (let i = 0; i < 3; i++) store.record(entry({ sql: `SELECT ${i}` }))
+    const second = store.list({ limit: 10, offset: 0 })[1]
+    const raw = new Database(join(dir, 'audit.db'))
+    raw.prepare('UPDATE audit_log SET sql = ? WHERE id = ?').run('DROP TABLE users', second.id)
+    raw.close()
+    const result = store.verify()
+    expect(result.valid).toBe(false)
+    expect(result.firstBrokenId).toBe(second.id)
+  })
+
+  it('filters by source and connection', () => {
+    store.record(entry())
+    store.record(entry({ source: 'mcp', connectionId: 'c2' }))
+    expect(store.list({ limit: 10, offset: 0, source: 'mcp' })).toHaveLength(1)
+    expect(store.count({ connectionId: 'c2' })).toBe(1)
+  })
+
+  it('prune removes old entries and re-anchors so verify still passes', () => {
+    for (let i = 0; i < 4; i++) store.record(entry({ sql: `SELECT ${i}` }))
+    const all = store.list({ limit: 10, offset: 0 })
+    const raw = new Database(join(dir, 'audit.db'))
+    // Age the first two entries to 100 days old
+    const old = new Date(Date.now() - 100 * 24 * 3600 * 1000).toISOString()
+    raw.prepare('UPDATE audit_log SET ts = ? WHERE id <= ?').run(old, all[1].id)
+    raw.close()
+    const removed = store.prune(90)
+    expect(removed).toBe(2)
+    expect(store.count({})).toBe(2)
+    expect(store.verify()).toEqual({ valid: true, entries: 2 })
+  })
+
+  it('exports JSON and CSV with correct shapes', () => {
+    store.record(entry({ sql: 'SELECT "quoted", comma' }))
+    const jsonPath = join(dir, 'out.json')
+    const csvPath = join(dir, 'out.csv')
+    expect(store.exportTo('json', jsonPath).entries).toBe(1)
+    expect(store.exportTo('csv', csvPath).entries).toBe(1)
+    const parsed = JSON.parse(readFileSync(jsonPath, 'utf-8'))
+    expect(parsed[0].sql).toBe('SELECT "quoted", comma')
+    const csv = readFileSync(csvPath, 'utf-8')
+    expect(csv.split('\n')[0]).toContain('ts,source,connectionId')
+    expect(csv).toContain('"SELECT ""quoted"", comma"')
+  })
+})

--- a/apps/desktop/src/main/__tests__/notebook-storage.test.ts
+++ b/apps/desktop/src/main/__tests__/notebook-storage.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import * as fs from 'fs'
 import * as path from 'path'
 import * as os from 'os'
+import Database from 'better-sqlite3'
 
 vi.mock('electron-log/main', () => ({
   default: {
@@ -27,7 +28,19 @@ vi.mock('electron', () => ({
 
 import { NotebookStorage } from '../notebook-storage'
 
-describe('NotebookStorage', () => {
+// better-sqlite3 is compiled for Electron's ABI; under plain node the whole
+// suite skips (mirrors the vitest.config.ts exclusion of sqlite-adapter).
+// Run for real via: pnpm test:electron
+const sqliteAvailable = (() => {
+  try {
+    new Database(':memory:').close()
+    return true
+  } catch {
+    return false
+  }
+})()
+
+describe.skipIf(!sqliteAvailable)('NotebookStorage', () => {
   let storage: NotebookStorage
   let tmpDir: string
 

--- a/apps/desktop/src/main/audit-service.ts
+++ b/apps/desktop/src/main/audit-service.ts
@@ -17,19 +17,31 @@ type AuditStore = PersistentStore<{ auditSettings: AuditSettings }>
 let store: AuditStore | null = null
 let storage: AuditStorage | null = null
 const warnedClasses = new Set<string>()
+const DAY_MS = 24 * 60 * 60 * 1000
+let pruneInterval: ReturnType<typeof setInterval> | null = null
+
+function pruneNow(): void {
+  if (!storage) return
+  const s = settings()
+  if (!s.enabled) return
+  try {
+    const removed = storage.prune(s.retentionDays)
+    if (removed > 0) log.debug(`Pruned ${removed} audit entries older than retention`)
+  } catch (err) {
+    log.warn('Audit prune failed:', err)
+  }
+}
 
 export function initAuditService(s: AuditStore, st: AuditStorage | null): void {
   store = s
   storage = st
-  const settings = s.get('auditSettings', AUDIT_SETTINGS_DEFAULTS)
-  if (st && settings.enabled) {
-    try {
-      const removed = st.prune(settings.retentionDays)
-      if (removed > 0) log.debug(`Pruned ${removed} audit entries older than retention`)
-    } catch (err) {
-      log.warn('Audit prune failed:', err)
-    }
+  if (pruneInterval) {
+    clearInterval(pruneInterval)
+    pruneInterval = null
   }
+  pruneNow()
+  pruneInterval = setInterval(pruneNow, DAY_MS)
+  pruneInterval.unref()
 }
 
 function settings(): AuditSettings {

--- a/apps/desktop/src/main/audit-service.ts
+++ b/apps/desktop/src/main/audit-service.ts
@@ -1,0 +1,92 @@
+import type { AuditEntryInput, AuditStatus } from '@shared/index'
+import type { PersistentStore } from './storage'
+import type { AuditStorage } from './audit-storage'
+import { createLogger } from './lib/logger'
+
+const log = createLogger('audit-service')
+
+export interface AuditSettings {
+  enabled: boolean
+  retentionDays: number
+}
+
+export const AUDIT_SETTINGS_DEFAULTS: AuditSettings = { enabled: false, retentionDays: 90 }
+
+type AuditStore = PersistentStore<{ auditSettings: AuditSettings }>
+
+let store: AuditStore | null = null
+let storage: AuditStorage | null = null
+const warnedClasses = new Set<string>()
+
+export function initAuditService(s: AuditStore, st: AuditStorage | null): void {
+  store = s
+  storage = st
+  const settings = s.get('auditSettings', AUDIT_SETTINGS_DEFAULTS)
+  if (st && settings.enabled) {
+    try {
+      const removed = st.prune(settings.retentionDays)
+      if (removed > 0) log.debug(`Pruned ${removed} audit entries older than retention`)
+    } catch (err) {
+      log.warn('Audit prune failed:', err)
+    }
+  }
+}
+
+function settings(): AuditSettings {
+  return store?.get('auditSettings', AUDIT_SETTINGS_DEFAULTS) ?? AUDIT_SETTINGS_DEFAULTS
+}
+
+export function recordAudit(entry: AuditEntryInput): void {
+  if (!storage || !settings().enabled) return
+  try {
+    storage.record(entry)
+  } catch (err) {
+    const cls = err instanceof Error ? err.message.slice(0, 60) : String(err)
+    if (!warnedClasses.has(cls)) {
+      warnedClasses.add(cls)
+      log.warn('Audit record failed (suppressing repeats):', cls)
+    }
+  }
+}
+
+export function getAuditStatus(): AuditStatus {
+  const s = settings()
+  let entryCount = 0
+  try {
+    entryCount = storage?.count({}) ?? 0
+  } catch {
+    // count failure should not break status
+  }
+  return {
+    available: storage !== null,
+    enabled: s.enabled,
+    retentionDays: s.retentionDays,
+    entryCount
+  }
+}
+
+export function setAuditEnabled(enabled: boolean): AuditStatus {
+  if (!store) throw new Error('Audit service not initialised')
+  store.set('auditSettings', { ...settings(), enabled })
+  return getAuditStatus()
+}
+
+export function setAuditRetention(days: number): AuditStatus {
+  if (!store) throw new Error('Audit service not initialised')
+  if (!Number.isInteger(days) || days < 7 || days > 3650) {
+    throw new Error('Retention must be between 7 and 3650 days')
+  }
+  store.set('auditSettings', { ...settings(), retentionDays: days })
+  if (storage && settings().enabled) {
+    try {
+      storage.prune(days)
+    } catch (err) {
+      log.warn('Audit prune failed:', err)
+    }
+  }
+  return getAuditStatus()
+}
+
+export function getAuditStorage(): AuditStorage | null {
+  return storage
+}

--- a/apps/desktop/src/main/audit-storage.ts
+++ b/apps/desktop/src/main/audit-storage.ts
@@ -13,6 +13,7 @@ function entryHash(prevHash: string, e: AuditEntryInput & { ts: string }): strin
     e.ts,
     e.source,
     e.connectionId,
+    e.connectionName,
     e.dbType,
     e.sql,
     e.rowCount,
@@ -81,8 +82,9 @@ function whereClause(f: AuditFilters): { sql: string; params: unknown[] } {
 
 function csvField(value: unknown): string {
   if (value === null || value === undefined) return ''
-  const s = String(value)
-  return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s
+  let s = String(value)
+  if (/^[=+\-@\t]/.test(s)) s = `'${s}`
+  return /[",\n\r]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s
 }
 
 export class AuditStorage {

--- a/apps/desktop/src/main/audit-storage.ts
+++ b/apps/desktop/src/main/audit-storage.ts
@@ -1,0 +1,247 @@
+import Database from 'better-sqlite3'
+import { createHash } from 'crypto'
+import { writeFileSync } from 'fs'
+import type { AuditEntry, AuditEntryInput, AuditFilters, AuditVerifyResult } from '@shared/index'
+import { createLogger } from './lib/logger'
+
+const log = createLogger('audit-storage')
+
+const ZERO_HASH = '0'.repeat(64)
+
+function entryHash(prevHash: string, e: AuditEntryInput & { ts: string }): string {
+  const canonical = JSON.stringify([
+    e.ts,
+    e.source,
+    e.connectionId,
+    e.dbType,
+    e.sql,
+    e.rowCount,
+    e.success,
+    e.error ?? null,
+    e.durationMs ?? null
+  ])
+  return createHash('sha256').update(`${prevHash}\n${canonical}`).digest('hex')
+}
+
+interface Row {
+  id: number
+  ts: string
+  source: string
+  connection_id: string
+  connection_name: string
+  db_type: string
+  sql: string
+  row_count: number | null
+  success: number
+  error: string | null
+  duration_ms: number | null
+  prev_hash: string
+  hash: string
+}
+
+function toEntry(r: Row): AuditEntry {
+  return {
+    id: r.id,
+    ts: r.ts,
+    source: r.source as AuditEntry['source'],
+    connectionId: r.connection_id,
+    connectionName: r.connection_name,
+    dbType: r.db_type,
+    sql: r.sql,
+    rowCount: r.row_count,
+    success: r.success === 1,
+    error: r.error ?? undefined,
+    durationMs: r.duration_ms ?? undefined,
+    prevHash: r.prev_hash,
+    hash: r.hash
+  }
+}
+
+function whereClause(f: AuditFilters): { sql: string; params: unknown[] } {
+  const conds: string[] = []
+  const params: unknown[] = []
+  if (f.source) {
+    conds.push('source = ?')
+    params.push(f.source)
+  }
+  if (f.connectionId) {
+    conds.push('connection_id = ?')
+    params.push(f.connectionId)
+  }
+  if (f.from) {
+    conds.push('ts >= ?')
+    params.push(f.from)
+  }
+  if (f.to) {
+    conds.push('ts <= ?')
+    params.push(f.to)
+  }
+  return { sql: conds.length ? `WHERE ${conds.join(' AND ')}` : '', params }
+}
+
+function csvField(value: unknown): string {
+  if (value === null || value === undefined) return ''
+  const s = String(value)
+  return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s
+}
+
+export class AuditStorage {
+  private db: Database.Database
+
+  constructor(dbPath: string) {
+    this.db = new Database(dbPath)
+    this.db.pragma('journal_mode = WAL')
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS audit_log (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        ts TEXT NOT NULL,
+        source TEXT NOT NULL,
+        connection_id TEXT NOT NULL,
+        connection_name TEXT NOT NULL,
+        db_type TEXT NOT NULL,
+        sql TEXT NOT NULL,
+        row_count INTEGER,
+        success INTEGER NOT NULL,
+        error TEXT,
+        duration_ms INTEGER,
+        prev_hash TEXT NOT NULL,
+        hash TEXT NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_audit_ts ON audit_log (ts);
+      CREATE TABLE IF NOT EXISTS audit_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+    `)
+  }
+
+  private get anchor(): string {
+    const row = this.db.prepare("SELECT value FROM audit_meta WHERE key = 'chainAnchor'").get() as
+      { value: string } | undefined
+    return row?.value ?? ZERO_HASH
+  }
+
+  private lastHash(): string {
+    const row = this.db.prepare('SELECT hash FROM audit_log ORDER BY id DESC LIMIT 1').get() as
+      { hash: string } | undefined
+    return row?.hash ?? this.anchor
+  }
+
+  record(entry: AuditEntryInput): void {
+    const ts = new Date().toISOString()
+    const prevHash = this.lastHash()
+    const hash = entryHash(prevHash, { ...entry, ts })
+    this.db
+      .prepare(
+        `INSERT INTO audit_log
+         (ts, source, connection_id, connection_name, db_type, sql, row_count, success, error, duration_ms, prev_hash, hash)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .run(
+        ts,
+        entry.source,
+        entry.connectionId,
+        entry.connectionName,
+        entry.dbType,
+        entry.sql,
+        entry.rowCount,
+        entry.success ? 1 : 0,
+        entry.error ?? null,
+        entry.durationMs ?? null,
+        prevHash,
+        hash
+      )
+  }
+
+  list(opts: AuditFilters & { limit: number; offset: number }): AuditEntry[] {
+    const { sql, params } = whereClause(opts)
+    const rows = this.db
+      .prepare(`SELECT * FROM audit_log ${sql} ORDER BY id ASC LIMIT ? OFFSET ?`)
+      .all(...params, opts.limit, opts.offset) as Row[]
+    return rows.map(toEntry)
+  }
+
+  count(filters: AuditFilters): number {
+    const { sql, params } = whereClause(filters)
+    const row = this.db.prepare(`SELECT count(*) AS n FROM audit_log ${sql}`).get(...params) as {
+      n: number
+    }
+    return row.n
+  }
+
+  verify(): AuditVerifyResult {
+    const rows = this.db.prepare('SELECT * FROM audit_log ORDER BY id ASC').all() as Row[]
+    let prev = this.anchor
+    for (const r of rows) {
+      const expected = entryHash(prev, {
+        ts: r.ts,
+        source: r.source as AuditEntryInput['source'],
+        connectionId: r.connection_id,
+        connectionName: r.connection_name,
+        dbType: r.db_type,
+        sql: r.sql,
+        rowCount: r.row_count,
+        success: r.success === 1,
+        error: r.error ?? undefined,
+        durationMs: r.duration_ms ?? undefined
+      })
+      if (r.prev_hash !== prev || r.hash !== expected) {
+        return { valid: false, entries: rows.length, firstBrokenId: r.id }
+      }
+      prev = r.hash
+    }
+    return { valid: true, entries: rows.length }
+  }
+
+  exportTo(
+    format: 'csv' | 'json',
+    filePath: string,
+    filters: AuditFilters = {}
+  ): { entries: number } {
+    const entries = this.list({ ...filters, limit: Number.MAX_SAFE_INTEGER, offset: 0 })
+    if (format === 'json') {
+      writeFileSync(filePath, JSON.stringify(entries, null, 2))
+    } else {
+      const header =
+        'ts,source,connectionId,connectionName,dbType,sql,rowCount,success,error,durationMs,prevHash,hash'
+      const lines = entries.map((e) =>
+        [
+          e.ts,
+          e.source,
+          e.connectionId,
+          e.connectionName,
+          e.dbType,
+          e.sql,
+          e.rowCount,
+          e.success,
+          e.error,
+          e.durationMs,
+          e.prevHash,
+          e.hash
+        ]
+          .map(csvField)
+          .join(',')
+      )
+      writeFileSync(filePath, [header, ...lines].join('\n'))
+    }
+    log.debug(`Exported ${entries.length} audit entries to ${filePath}`)
+    return { entries: entries.length }
+  }
+
+  prune(maxAgeDays: number): number {
+    const cutoff = new Date(Date.now() - maxAgeDays * 24 * 3600 * 1000).toISOString()
+    const last = this.db
+      .prepare('SELECT hash FROM audit_log WHERE ts < ? ORDER BY id DESC LIMIT 1')
+      .get(cutoff) as { hash: string } | undefined
+    if (!last) return 0
+    const result = this.db.prepare('DELETE FROM audit_log WHERE ts < ?').run(cutoff)
+    this.db
+      .prepare(
+        "INSERT INTO audit_meta (key, value) VALUES ('chainAnchor', ?) " +
+          'ON CONFLICT(key) DO UPDATE SET value = excluded.value'
+      )
+      .run(last.hash)
+    return result.changes
+  }
+
+  close(): void {
+    this.db.close()
+  }
+}

--- a/apps/desktop/src/main/audit-storage.ts
+++ b/apps/desktop/src/main/audit-storage.ts
@@ -83,7 +83,7 @@ function whereClause(f: AuditFilters): { sql: string; params: unknown[] } {
 function csvField(value: unknown): string {
   if (value === null || value === undefined) return ''
   let s = String(value)
-  if (/^[=+\-@\t]/.test(s)) s = `'${s}`
+  if (/^[=+\-@\t]/.test(s.trimStart()) || /^[\r\n]/.test(s)) s = `'${s}`
   return /[",\n\r]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s
 }
 
@@ -229,18 +229,21 @@ export class AuditStorage {
 
   prune(maxAgeDays: number): number {
     const cutoff = new Date(Date.now() - maxAgeDays * 24 * 3600 * 1000).toISOString()
-    const last = this.db
-      .prepare('SELECT hash FROM audit_log WHERE ts < ? ORDER BY id DESC LIMIT 1')
-      .get(cutoff) as { hash: string } | undefined
-    if (!last) return 0
-    const result = this.db.prepare('DELETE FROM audit_log WHERE ts < ?').run(cutoff)
-    this.db
-      .prepare(
-        "INSERT INTO audit_meta (key, value) VALUES ('chainAnchor', ?) " +
-          'ON CONFLICT(key) DO UPDATE SET value = excluded.value'
-      )
-      .run(last.hash)
-    return result.changes
+    const runPrune = this.db.transaction((cutoffTs: string) => {
+      const last = this.db
+        .prepare('SELECT hash FROM audit_log WHERE ts < ? ORDER BY id DESC LIMIT 1')
+        .get(cutoffTs) as { hash: string } | undefined
+      if (!last) return 0
+      const result = this.db.prepare('DELETE FROM audit_log WHERE ts < ?').run(cutoffTs)
+      this.db
+        .prepare(
+          "INSERT INTO audit_meta (key, value) VALUES ('chainAnchor', ?) " +
+            'ON CONFLICT(key) DO UPDATE SET value = excluded.value'
+        )
+        .run(last.hash)
+      return result.changes
+    })
+    return runPrune(cutoff)
   }
 
   close(): void {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -29,6 +29,9 @@ import {
   type McpSettings
 } from './ipc'
 import type { McpServiceWithApproval } from './ipc/mcp-handlers'
+import { AuditStorage } from './audit-storage'
+import { initAuditService, AUDIT_SETTINGS_DEFAULTS, type AuditSettings } from './audit-service'
+import { registerAuditHandlers } from './ipc/audit-handlers'
 import { setForceQuit } from './app-state'
 import { windowManager } from './window-manager'
 import { initSchedulerService, stopAllSchedules } from './scheduler-service'
@@ -50,6 +53,8 @@ let queryHistoryStore: DpStorage<{ queryHistory: QueryHistoryEntry[] }>
 let timeMachineStorage: TimeMachineStorage | null = null
 let mcpStore: PersistentStore<{ mcpSettings: McpSettings }>
 let mcpService: McpServiceWithApproval
+let auditStore: PersistentStore<{ auditSettings: AuditSettings }>
+let auditStorage: AuditStorage | null = null
 
 const stepSessionRegistry = new StepSessionRegistry()
 
@@ -169,6 +174,17 @@ async function initStores(): Promise<void> {
 
   mcpStore = await createMcpSettingsStore()
   mcpService = createMcpService(() => store.get('connections', []))
+
+  auditStore = await DpStorage.create<{ auditSettings: AuditSettings }>({
+    name: 'data-peek-audit',
+    defaults: { auditSettings: AUDIT_SETTINGS_DEFAULTS }
+  })
+  try {
+    auditStorage = new AuditStorage(join(app.getPath('userData'), 'audit.db'))
+  } catch (error) {
+    log.warn('AuditStorage unavailable; audit logging disabled:', error)
+  }
+  initAuditService(auditStore, auditStorage)
 }
 
 // Set app name for macOS dock and Mission Control
@@ -284,6 +300,7 @@ app.whenReady().then(async () => {
 
   registerMcpHandlers(mcpStore, mcpService)
   void startMcpIfEnabled(mcpStore, mcpService)
+  registerAuditHandlers()
 
   // Create initial window
   await windowManager.createWindow()
@@ -345,6 +362,11 @@ app.on('before-quit', (event) => {
         timeMachineStorage?.close()
       } catch (err) {
         log.warn('TimeMachineStorage close failed during quit:', err)
+      }
+      try {
+        auditStorage?.close()
+      } catch (err) {
+        log.warn('AuditStorage close failed during quit:', err)
       }
       app.quit()
     })

--- a/apps/desktop/src/main/ipc/audit-handlers.ts
+++ b/apps/desktop/src/main/ipc/audit-handlers.ts
@@ -1,0 +1,68 @@
+import { ipcMain, dialog } from 'electron'
+import type { AuditFilters, AuditSource } from '@shared/index'
+import { wrapHandler } from './types'
+import {
+  getAuditStatus,
+  setAuditEnabled,
+  setAuditRetention,
+  getAuditStorage
+} from '../audit-service'
+
+function requireStorage(): NonNullable<ReturnType<typeof getAuditStorage>> {
+  const storage = getAuditStorage()
+  if (!storage) throw new Error('Audit storage is unavailable on this system')
+  return storage
+}
+
+export function registerAuditHandlers(): void {
+  ipcMain.handle(
+    'audit:status',
+    wrapHandler(async () => getAuditStatus())
+  )
+
+  ipcMain.handle(
+    'audit:setEnabled',
+    wrapHandler(async (_e, { enabled }: { enabled: boolean }) => setAuditEnabled(enabled))
+  )
+
+  ipcMain.handle(
+    'audit:setRetention',
+    wrapHandler(async (_e, { days }: { days: number }) => setAuditRetention(days))
+  )
+
+  ipcMain.handle(
+    'audit:list',
+    wrapHandler(
+      async (_e, args: AuditFilters & { limit: number; offset: number; source?: AuditSource }) => {
+        const storage = requireStorage()
+        const limit = Math.min(Math.max(1, args.limit ?? 100), 1000)
+        return {
+          entries: storage.list({ ...args, limit, offset: Math.max(0, args.offset ?? 0) }),
+          total: storage.count(args)
+        }
+      }
+    )
+  )
+
+  ipcMain.handle(
+    'audit:verify',
+    wrapHandler(async () => requireStorage().verify())
+  )
+
+  ipcMain.handle(
+    'audit:export',
+    wrapHandler(
+      async (_e, { format, filters }: { format: 'csv' | 'json'; filters?: AuditFilters }) => {
+        const storage = requireStorage()
+        const stamp = new Date().toISOString().slice(0, 10).replace(/-/g, '')
+        const { canceled, filePath } = await dialog.showSaveDialog({
+          defaultPath: `data-peek-audit-${stamp}.${format}`,
+          filters: [{ name: format.toUpperCase(), extensions: [format] }]
+        })
+        if (canceled || !filePath) return null
+        const result = storage.exportTo(format, filePath, filters)
+        return { path: filePath, entries: result.entries }
+      }
+    )
+  )
+}

--- a/apps/desktop/src/main/ipc/audit-handlers.ts
+++ b/apps/desktop/src/main/ipc/audit-handlers.ts
@@ -56,7 +56,7 @@ export function registerAuditHandlers(): void {
         const storage = requireStorage()
         const stamp = new Date().toISOString().slice(0, 10).replace(/-/g, '')
         const { canceled, filePath } = await dialog.showSaveDialog({
-          defaultPath: `data-peek-audit-${stamp}.${format}`,
+          defaultPath: `${stamp}-data-peek-audit.${format}`,
           filters: [{ name: format.toUpperCase(), extensions: [format] }]
         })
         if (canceled || !filePath) return null

--- a/apps/desktop/src/main/ipc/ddl-handlers.ts
+++ b/apps/desktop/src/main/ipc/ddl-handlers.ts
@@ -10,6 +10,7 @@ import {
 } from '../ddl-builder'
 import { invalidateSchemaCache } from '../schema-cache'
 import { createLogger } from '../lib/logger'
+import { recordAudit } from '../audit-service'
 
 const log = createLogger('ddl-handlers')
 
@@ -64,10 +65,30 @@ export function registerDDLHandlers(): void {
         // Drop cached schemas so callers see the new table on the next read.
         invalidateSchemaCache(config)
 
+        recordAudit({
+          source: 'ddl',
+          connectionId: config.id ?? 'unsaved',
+          connectionName: config.name ?? config.database,
+          dbType,
+          sql: result.executedSql.join('\n'),
+          rowCount: null,
+          success: true
+        })
+
         return { success: true, data: result }
       } catch (error: unknown) {
         log.error('Create table error:', error)
         const errorMessage = error instanceof Error ? error.message : String(error)
+        recordAudit({
+          source: 'ddl',
+          connectionId: config.id ?? 'unsaved',
+          connectionName: config.name ?? config.database,
+          dbType,
+          sql: result.executedSql.join('\n'),
+          rowCount: null,
+          success: false,
+          error: errorMessage
+        })
         return { success: false, error: errorMessage }
       }
     }
@@ -100,12 +121,32 @@ export function registerDDLHandlers(): void {
         // Cached column sets / FK metadata are now stale; force the next read.
         invalidateSchemaCache(config)
 
+        recordAudit({
+          source: 'ddl',
+          connectionId: config.id ?? 'unsaved',
+          connectionName: config.name ?? config.database,
+          dbType,
+          sql: result.executedSql.join('\n'),
+          rowCount: null,
+          success: true
+        })
+
         return { success: true, data: result }
       } catch (error: unknown) {
         log.error('Alter table error:', error)
         const errorMessage = error instanceof Error ? error.message : String(error)
         result.errors!.push(errorMessage)
         result.success = false
+        recordAudit({
+          source: 'ddl',
+          connectionId: config.id ?? 'unsaved',
+          connectionName: config.name ?? config.database,
+          dbType,
+          sql: result.executedSql.join('\n'),
+          rowCount: null,
+          success: false,
+          error: errorMessage
+        })
         return { success: true, data: result }
       }
     }
@@ -127,15 +168,26 @@ export function registerDDLHandlers(): void {
 
       const adapter = getAdapter(config)
       const dbType = config.dbType || 'postgresql'
+      let sql = ''
 
       try {
-        const { sql } = buildDropTable(schema, table, cascade, dbType)
+        ;({ sql } = buildDropTable(schema, table, cascade, dbType))
         log.debug('Executing SQL:', sql)
 
         await adapter.executeTransaction(config, [{ sql, params: [] }])
 
         // Drop cached schemas so the dropped table disappears from the next read.
         invalidateSchemaCache(config)
+
+        recordAudit({
+          source: 'ddl',
+          connectionId: config.id ?? 'unsaved',
+          connectionName: config.name ?? config.database,
+          dbType,
+          sql,
+          rowCount: null,
+          success: true
+        })
 
         return {
           success: true,
@@ -144,6 +196,16 @@ export function registerDDLHandlers(): void {
       } catch (error: unknown) {
         log.error('Drop table error:', error)
         const errorMessage = error instanceof Error ? error.message : String(error)
+        recordAudit({
+          source: 'ddl',
+          connectionId: config.id ?? 'unsaved',
+          connectionName: config.name ?? config.database,
+          dbType,
+          sql,
+          rowCount: null,
+          success: false,
+          error: errorMessage
+        })
         return { success: false, error: errorMessage }
       }
     }

--- a/apps/desktop/src/main/ipc/query-handlers.ts
+++ b/apps/desktop/src/main/ipc/query-handlers.ts
@@ -22,6 +22,7 @@ import { createLogger } from '../lib/logger'
 import { annotateSslError } from '../lib/ssl-error'
 import { telemetryCollector } from '../telemetry-collector'
 import { analyzeQueryPerformance } from '../performance-analyzer'
+import { recordAudit } from '../audit-service'
 
 const log = createLogger('query-handlers')
 
@@ -81,6 +82,22 @@ export function registerQueryHandlers(): void {
         log.debug('Query completed in', multiResult.totalDurationMs, 'ms')
         log.debug('Statement count:', multiResult.results.length)
 
+        const legacyRowCount =
+          multiResult.results.find((r) => r.isDataReturning)?.rowCount ??
+          multiResult.results[0]?.rowCount ??
+          0
+
+        recordAudit({
+          source: 'editor',
+          connectionId: config.id ?? 'unsaved',
+          connectionName: config.name ?? config.database,
+          dbType: config.dbType || 'postgresql',
+          sql: query,
+          rowCount: legacyRowCount,
+          success: true,
+          durationMs: multiResult.totalDurationMs
+        })
+
         return {
           success: true,
           data: {
@@ -98,16 +115,23 @@ export function registerQueryHandlers(): void {
               multiResult.results.find((r) => r.isDataReturning)?.fields ||
               multiResult.results[0]?.fields ||
               [],
-            rowCount:
-              multiResult.results.find((r) => r.isDataReturning)?.rowCount ??
-              multiResult.results[0]?.rowCount ??
-              0,
+            rowCount: legacyRowCount,
             durationMs: multiResult.totalDurationMs
           }
         }
       } catch (error: unknown) {
         log.error('Query error:', error)
         const errorMessage = error instanceof Error ? error.message : String(error)
+        recordAudit({
+          source: 'editor',
+          connectionId: config.id ?? 'unsaved',
+          connectionName: config.name ?? config.database,
+          dbType: config.dbType || 'postgresql',
+          sql: query,
+          rowCount: null,
+          success: false,
+          error: errorMessage
+        })
         return { success: false, error: errorMessage }
       }
     }
@@ -280,10 +304,30 @@ export function registerQueryHandlers(): void {
               )
               result.rowsAffected += res.rowCount ?? 0
               result.executedSql.push(op.preview)
+              recordAudit({
+                source: 'inline-edit',
+                connectionId: config.id ?? 'unsaved',
+                connectionName: config.name ?? config.database,
+                dbType,
+                sql: op.sql,
+                rowCount: res.rowCount ?? 0,
+                success: true
+              })
             } catch (error) {
+              const errorMessage = error instanceof Error ? error.message : String(error)
               result.errors!.push({
                 operationId: op.opId,
-                message: error instanceof Error ? error.message : String(error)
+                message: errorMessage
+              })
+              recordAudit({
+                source: 'inline-edit',
+                connectionId: config.id ?? 'unsaved',
+                connectionName: config.name ?? config.database,
+                dbType,
+                sql: op.sql,
+                rowCount: null,
+                success: false,
+                error: errorMessage
               })
               break // Stop executing further ops in this transaction
             }
@@ -298,6 +342,18 @@ export function registerQueryHandlers(): void {
         result.rowsAffected = txResult.rowsAffected
         result.executedSql = validOperations.map((op) => op.preview)
 
+        for (const op of validOperations) {
+          recordAudit({
+            source: 'inline-edit',
+            connectionId: config.id ?? 'unsaved',
+            connectionName: config.name ?? config.database,
+            dbType,
+            sql: op.sql,
+            rowCount: null,
+            success: true
+          })
+        }
+
         return { success: true, data: result }
       } catch (error: unknown) {
         log.error('Execute batch error:', error)
@@ -307,6 +363,16 @@ export function registerQueryHandlers(): void {
           result.errors!.push({
             operationId: op.opId,
             message: errorMessage
+          })
+          recordAudit({
+            source: 'inline-edit',
+            connectionId: config.id ?? 'unsaved',
+            connectionName: config.name ?? config.database,
+            dbType,
+            sql: op.sql,
+            rowCount: null,
+            success: false,
+            error: errorMessage
           })
         }
         result.success = false

--- a/apps/desktop/src/main/mcp/tools.ts
+++ b/apps/desktop/src/main/mcp/tools.ts
@@ -6,6 +6,7 @@ import { getCachedSchema, isCacheValid, getOrFetchCachedSchema } from '../schema
 import { runReadOnlyQuery, assertSingleReadStatement, MCP_MAX_ROWS } from './read-guard'
 import type { ApprovalManager } from './approval'
 import { parseStatementsWithLines } from '../lib/parse-statements'
+import { recordAudit } from '../audit-service'
 
 export interface McpToolDeps {
   getConnections: () => ConnectionConfig[]
@@ -97,8 +98,34 @@ export function registerMcpTools(server: McpServer, deps: McpToolDeps): void {
     async ({ connectionId, sql, maxRows }) =>
       withToolErrors(async () => {
         const conn = findConnection(deps, connectionId)
-        const result = await runReadOnlyQuery(conn, sql, maxRows)
-        return ok({ rows: result.rows, rowCount: result.rowCount })
+        const started = Date.now()
+        try {
+          const result = await runReadOnlyQuery(conn, sql, maxRows)
+          recordAudit({
+            source: 'mcp',
+            connectionId: conn.id ?? 'unsaved',
+            connectionName: conn.name ?? conn.database,
+            dbType: conn.dbType || 'postgresql',
+            sql,
+            rowCount: result.rowCount,
+            success: true,
+            durationMs: Date.now() - started
+          })
+          return ok({ rows: result.rows, rowCount: result.rowCount })
+        } catch (err) {
+          recordAudit({
+            source: 'mcp',
+            connectionId: conn.id ?? 'unsaved',
+            connectionName: conn.name ?? conn.database,
+            dbType: conn.dbType || 'postgresql',
+            sql,
+            rowCount: null,
+            success: false,
+            error: err instanceof Error ? err.message : String(err),
+            durationMs: Date.now() - started
+          })
+          throw err
+        }
       })
   )
 
@@ -136,8 +163,34 @@ export function registerMcpTools(server: McpServer, deps: McpToolDeps): void {
         const stmt = statements[0].sql.trim()
         const approved = await deps.approval.request(conn.name, stmt)
         if (!approved) return fail('User rejected the statement')
-        const result = await getAdapter(conn).execute(conn, stmt, [])
-        return ok({ rowCount: result.rowCount })
+        const started = Date.now()
+        try {
+          const result = await getAdapter(conn).execute(conn, stmt, [])
+          recordAudit({
+            source: 'mcp',
+            connectionId: conn.id ?? 'unsaved',
+            connectionName: conn.name ?? conn.database,
+            dbType: conn.dbType || 'postgresql',
+            sql: stmt,
+            rowCount: result.rowCount,
+            success: true,
+            durationMs: Date.now() - started
+          })
+          return ok({ rowCount: result.rowCount })
+        } catch (err) {
+          recordAudit({
+            source: 'mcp',
+            connectionId: conn.id ?? 'unsaved',
+            connectionName: conn.name ?? conn.database,
+            dbType: conn.dbType || 'postgresql',
+            sql: stmt,
+            rowCount: null,
+            success: false,
+            error: err instanceof Error ? err.message : String(err),
+            durationMs: Date.now() - started
+          })
+          throw err
+        }
       })
   )
 }

--- a/apps/desktop/src/main/scheduler-service.ts
+++ b/apps/desktop/src/main/scheduler-service.ts
@@ -13,6 +13,7 @@ import { SCHEDULE_PRESETS } from '@shared/index'
 import { DpStorage, type PersistentStore } from './storage'
 import { getAdapter } from './db-adapter'
 import { createLogger } from './lib/logger'
+import { recordAudit } from './audit-service'
 
 const log = createLogger('scheduler')
 
@@ -185,11 +186,10 @@ async function executeScheduledQuery(queryId: string): Promise<void> {
     success: false
   }
 
-  try {
-    // Get the connection
-    const connections = connectionsStore.get('connections', [])
-    const connection = connections.find((c) => c.id === query.connectionId)
+  const connections = connectionsStore.get('connections', [])
+  const connection = connections.find((c) => c.id === query.connectionId)
 
+  try {
     if (!connection) {
       throw new Error(`Connection not found: ${query.connectionId}`)
     }
@@ -215,6 +215,17 @@ async function executeScheduledQuery(queryId: string): Promise<void> {
 
     log.debug(`Scheduled query "${query.name}" completed in ${run.durationMs}ms`)
 
+    recordAudit({
+      source: 'scheduled',
+      connectionId: connection.id ?? 'unsaved',
+      connectionName: connection.name ?? connection.database,
+      dbType: connection.dbType || 'postgresql',
+      sql: query.query,
+      rowCount: run.rowCount ?? null,
+      success: true,
+      durationMs: run.durationMs
+    })
+
     // Update query with last run time
     updateScheduledQueryInternal(query.id, {
       lastRunAt: run.completedAt,
@@ -237,6 +248,17 @@ async function executeScheduledQuery(queryId: string): Promise<void> {
     run.error = errorMessage
 
     log.error(`Scheduled query "${query.name}" failed:`, errorMessage)
+
+    recordAudit({
+      source: 'scheduled',
+      connectionId: connection?.id ?? 'unsaved',
+      connectionName: connection?.name ?? connection?.database ?? 'unknown',
+      dbType: connection?.dbType || 'postgresql',
+      sql: query.query,
+      rowCount: null,
+      success: false,
+      error: errorMessage
+    })
 
     // Update query with error status
     updateScheduledQueryInternal(query.id, {

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -78,7 +78,9 @@ import type {
   TimeMachineListResult,
   TimeMachineStats,
   McpServerStatus,
-  McpApprovalRequest
+  McpApprovalRequest,
+  AuditStatus,
+  AuditVerifyResult
 } from '@shared/index'
 
 // AI Types
@@ -543,6 +545,15 @@ interface DataPeekApi {
     respondToApproval: (id: string, approved: boolean) => Promise<IpcResponse<void>>
     onApprovalRequest: (callback: (req: McpApprovalRequest) => void) => () => void
     onApprovalResolved: (callback: (payload: { id: string }) => void) => () => void
+  }
+  audit: {
+    status: () => Promise<IpcResponse<AuditStatus>>
+    setEnabled: (enabled: boolean) => Promise<IpcResponse<AuditStatus>>
+    setRetention: (days: number) => Promise<IpcResponse<AuditStatus>>
+    verify: () => Promise<IpcResponse<AuditVerifyResult>>
+    export: (
+      format: 'csv' | 'json'
+    ) => Promise<IpcResponse<{ path: string; entries: number } | null>>
   }
 }
 

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -86,7 +86,9 @@ import type {
   TimeMachineListResult,
   TimeMachineStats,
   McpServerStatus,
-  McpApprovalRequest
+  McpApprovalRequest,
+  AuditStatus,
+  AuditVerifyResult
 } from '@shared/index'
 
 // Re-export AI types for renderer consumers
@@ -725,6 +727,18 @@ const api = {
       ipcRenderer.on('mcp:approval:resolved', listener)
       return () => ipcRenderer.removeListener('mcp:approval:resolved', listener)
     }
+  },
+  audit: {
+    status: (): Promise<IpcResponse<AuditStatus>> => ipcRenderer.invoke('audit:status'),
+    setEnabled: (enabled: boolean): Promise<IpcResponse<AuditStatus>> =>
+      ipcRenderer.invoke('audit:setEnabled', { enabled }),
+    setRetention: (days: number): Promise<IpcResponse<AuditStatus>> =>
+      ipcRenderer.invoke('audit:setRetention', { days }),
+    verify: (): Promise<IpcResponse<AuditVerifyResult>> => ipcRenderer.invoke('audit:verify'),
+    export: (
+      format: 'csv' | 'json'
+    ): Promise<IpcResponse<{ path: string; entries: number } | null>> =>
+      ipcRenderer.invoke('audit:export', { format })
   }
 }
 

--- a/apps/desktop/src/renderer/src/components/audit-settings-section.tsx
+++ b/apps/desktop/src/renderer/src/components/audit-settings-section.tsx
@@ -70,8 +70,10 @@ export function AuditSettingsSection() {
         Audit Log
       </h3>
       <p className="text-xs text-muted-foreground">
-        Records every SQL statement data-peek executes, in a local file on this machine. SQL text
-        can contain data values. Off by default; prunable and deletable.
+        Records SQL statements data-peek executes — editor, edits, DDL, scheduled, and agent (MCP)
+        — in a local file on this machine. Not recorded: the explain panel, schema reads, and
+        agent writes you reject. SQL text can contain data values. Off by default; prunable and
+        deletable.
       </p>
 
       <div className="flex items-center justify-between">

--- a/apps/desktop/src/renderer/src/components/audit-settings-section.tsx
+++ b/apps/desktop/src/renderer/src/components/audit-settings-section.tsx
@@ -31,6 +31,8 @@ export function AuditSettingsSection() {
   }, [])
 
   const applyResult = (response: IpcResponse<AuditStatus>) => {
+    setVerifyResult(null)
+    setExportResult(null)
     if (response.success && response.data) {
       setStatus(response.data)
       setRetentionDraft(String(response.data.retentionDays))
@@ -125,7 +127,9 @@ export function AuditSettingsSection() {
           variant="outline"
           size="sm"
           className="h-7 text-xs"
-          onClick={() =>
+          onClick={() => {
+            setExportResult(null)
+            setError(null)
             window.api.audit.verify().then((response) => {
               if (response.success && response.data) {
                 setVerifyResult(
@@ -137,7 +141,7 @@ export function AuditSettingsSection() {
                 setError(response.error ?? 'Unknown error')
               }
             })
-          }
+          }}
         >
           Verify integrity
         </Button>
@@ -155,7 +159,9 @@ export function AuditSettingsSection() {
             variant="outline"
             size="sm"
             className="h-7 text-xs"
-            onClick={() =>
+            onClick={() => {
+              setVerifyResult(null)
+              setError(null)
               window.api.audit.export('csv').then((response) => {
                 if (response.success) {
                   if (response.data) {
@@ -165,7 +171,7 @@ export function AuditSettingsSection() {
                   setError(response.error ?? 'Unknown error')
                 }
               })
-            }
+            }}
           >
             Export CSV
           </Button>
@@ -173,7 +179,9 @@ export function AuditSettingsSection() {
             variant="outline"
             size="sm"
             className="h-7 text-xs"
-            onClick={() =>
+            onClick={() => {
+              setVerifyResult(null)
+              setError(null)
               window.api.audit.export('json').then((response) => {
                 if (response.success) {
                   if (response.data) {
@@ -183,7 +191,7 @@ export function AuditSettingsSection() {
                   setError(response.error ?? 'Unknown error')
                 }
               })
-            }
+            }}
           >
             Export JSON
           </Button>

--- a/apps/desktop/src/renderer/src/components/audit-settings-section.tsx
+++ b/apps/desktop/src/renderer/src/components/audit-settings-section.tsx
@@ -1,0 +1,194 @@
+import { useEffect, useState } from 'react'
+import { Button, Input, Label, Switch } from '@data-peek/ui'
+import type { AuditStatus, IpcResponse } from '@shared/index'
+
+export function AuditSettingsSection() {
+  const [status, setStatus] = useState<AuditStatus | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [verifyResult, setVerifyResult] = useState<string | null>(null)
+  const [exportResult, setExportResult] = useState<string | null>(null)
+  const [retentionDraft, setRetentionDraft] = useState('')
+
+  useEffect(() => {
+    let cancelled = false
+    window.api.audit
+      .status()
+      .then((response) => {
+        if (cancelled) return
+        if (response.success && response.data) {
+          setStatus(response.data)
+          setRetentionDraft(String(response.data.retentionDays))
+        } else {
+          setError(response.error ?? 'Unknown error')
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setError('Failed to load audit status')
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const applyResult = (response: IpcResponse<AuditStatus>) => {
+    if (response.success && response.data) {
+      setStatus(response.data)
+      setRetentionDraft(String(response.data.retentionDays))
+      setError(null)
+    } else {
+      setError(response.error ?? 'Unknown error')
+    }
+  }
+
+  if (!status && !error) {
+    return (
+      <div className="space-y-4">
+        <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">
+          Audit Log
+        </h3>
+        <p className="text-xs text-muted-foreground">Loading...</p>
+      </div>
+    )
+  }
+
+  if (!status) {
+    return (
+      <div className="space-y-4">
+        <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">
+          Audit Log
+        </h3>
+        <p className="text-xs text-destructive">{error}</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">
+        Audit Log
+      </h3>
+      <p className="text-xs text-muted-foreground">
+        Records every SQL statement data-peek executes, in a local file on this machine. SQL text
+        can contain data values. Off by default; prunable and deletable.
+      </p>
+
+      <div className="flex items-center justify-between">
+        <div className="space-y-0.5">
+          <Label htmlFor="audit-enabled">Enable audit log</Label>
+          {!status.available && (
+            <p className="text-xs text-muted-foreground">
+              Audit storage unavailable on this system
+            </p>
+          )}
+        </div>
+        <Switch
+          id="audit-enabled"
+          checked={status.enabled}
+          disabled={!status.available}
+          onCheckedChange={(enabled) => window.api.audit.setEnabled(enabled).then(applyResult)}
+        />
+      </div>
+
+      {error && <p className="text-xs text-destructive">{error}</p>}
+
+      <div className="flex items-center justify-between">
+        <div className="space-y-0.5">
+          <Label htmlFor="audit-retention">Retention (days)</Label>
+          <p className="text-xs text-muted-foreground">Entries older than this are pruned</p>
+        </div>
+        <Input
+          id="audit-retention"
+          type="number"
+          className="w-24 font-mono"
+          value={retentionDraft}
+          onChange={(e) => setRetentionDraft(e.target.value)}
+          onBlur={() => {
+            const days = Number.parseInt(retentionDraft, 10)
+            if (Number.isInteger(days) && days > 0 && days !== status.retentionDays) {
+              window.api.audit.setRetention(days).then(applyResult)
+            } else {
+              setRetentionDraft(String(status.retentionDays))
+            }
+          }}
+        />
+      </div>
+
+      <div className="flex items-center justify-between">
+        <div className="space-y-0.5">
+          <Label>Integrity</Label>
+          <p className="text-xs text-muted-foreground">
+            {status.entryCount} entries recorded
+            {verifyResult ? ` — ${verifyResult}` : ''}
+          </p>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-7 text-xs"
+          onClick={() =>
+            window.api.audit.verify().then((response) => {
+              if (response.success && response.data) {
+                setVerifyResult(
+                  response.data.valid
+                    ? `Chain intact — ${response.data.entries} entries`
+                    : `Chain broken at entry #${response.data.firstBrokenId}`
+                )
+              } else {
+                setError(response.error ?? 'Unknown error')
+              }
+            })
+          }
+        >
+          Verify integrity
+        </Button>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <div className="space-y-0.5">
+          <Label>Export</Label>
+          <p className="text-xs text-muted-foreground">
+            {exportResult ?? 'Export the audit log to a local file'}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 text-xs"
+            onClick={() =>
+              window.api.audit.export('csv').then((response) => {
+                if (response.success) {
+                  if (response.data) {
+                    setExportResult(`Exported ${response.data.entries} entries`)
+                  }
+                } else {
+                  setError(response.error ?? 'Unknown error')
+                }
+              })
+            }
+          >
+            Export CSV
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 text-xs"
+            onClick={() =>
+              window.api.audit.export('json').then((response) => {
+                if (response.success) {
+                  if (response.data) {
+                    setExportResult(`Exported ${response.data.entries} entries`)
+                  }
+                } else {
+                  setError(response.error ?? 'Unknown error')
+                }
+              })
+            }
+          >
+            Export JSON
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/src/components/audit-settings-section.tsx
+++ b/apps/desktop/src/renderer/src/components/audit-settings-section.tsx
@@ -70,10 +70,9 @@ export function AuditSettingsSection() {
         Audit Log
       </h3>
       <p className="text-xs text-muted-foreground">
-        Records SQL statements data-peek executes — editor, edits, DDL, scheduled, and agent (MCP)
-        — in a local file on this machine. Not recorded: the explain panel, schema reads, and
-        agent writes you reject. SQL text can contain data values. Off by default; prunable and
-        deletable.
+        Records SQL statements data-peek executes — editor, edits, DDL, scheduled, and agent (MCP) —
+        in a local file on this machine. Not recorded: the explain panel, schema reads, and agent
+        writes you reject. SQL text can contain data values. Off by default; prunable and deletable.
       </p>
 
       <div className="flex items-center justify-between">
@@ -103,12 +102,19 @@ export function AuditSettingsSection() {
         <Input
           id="audit-retention"
           type="number"
+          min={7}
+          max={3650}
           className="w-24 font-mono"
           value={retentionDraft}
           onChange={(e) => setRetentionDraft(e.target.value)}
           onBlur={() => {
             const days = Number.parseInt(retentionDraft, 10)
-            if (Number.isInteger(days) && days > 0 && days !== status.retentionDays) {
+            if (
+              Number.isInteger(days) &&
+              days >= 7 &&
+              days <= 3650 &&
+              days !== status.retentionDays
+            ) {
               window.api.audit.setRetention(days).then(applyResult)
             } else {
               setRetentionDraft(String(status.retentionDays))

--- a/apps/desktop/src/renderer/src/components/settings-modal.tsx
+++ b/apps/desktop/src/renderer/src/components/settings-modal.tsx
@@ -15,6 +15,7 @@ import type { TimeMachineStats } from '@data-peek/shared'
 
 import { useSettingsStore } from '@/stores/settings-store'
 import { McpSettingsSection } from '@/components/mcp-settings-section'
+import { AuditSettingsSection } from '@/components/audit-settings-section'
 
 interface SettingsModalProps {
   open: boolean
@@ -225,6 +226,8 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
           </div>
 
           <McpSettingsSection />
+
+          <AuditSettingsSection />
 
           {/* Time Machine Section */}
           <div className="space-y-4">

--- a/apps/desktop/vitest.config.ts
+++ b/apps/desktop/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['src/**/__tests__/**/*.test.ts'],
-    exclude: ['**/node_modules/**', '**/sqlite-adapter.test.ts', '**/notebook-storage.test.ts'],
+    exclude: ['**/node_modules/**', '**/sqlite-adapter.test.ts'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],

--- a/apps/docs/content/docs/features/audit-log.mdx
+++ b/apps/docs/content/docs/features/audit-log.mdx
@@ -25,15 +25,21 @@ Each entry stores the timestamp, source, connection, database type, SQL text, ro
 
 ## What is NOT recorded
 
-- `EXPLAIN` / query plan requests
+- The explain panel (and the MCP `explain_query` tool)
 - Schema reads (listing tables, columns, schemas)
 - Writes rejected in the MCP approval dialog
+
+An `EXPLAIN` statement you type and run in the editor is recorded like any other executed statement.
 
 ## Hash chain and integrity
 
 Every entry is hashed together with the hash of the entry before it, forming a chain anchored to a fixed starting value. Any edit, deletion, or reordering of a past entry breaks the chain from that point forward.
 
 Click **Verify integrity** in Settings to walk the chain. It reports either that the chain is intact, or the ID of the first broken entry.
+
+### Integrity limitations
+
+The hash chain detects edits and deletions inside the recorded history. It cannot detect truncation from the tail (or deletion of the whole file) by someone with write access to the log file — a limitation of any local-only integrity scheme. For stronger guarantees, export regularly and store the export elsewhere.
 
 ## Retention and pruning
 
@@ -45,4 +51,4 @@ Export the log to CSV or JSON from Settings. The default filename is `YYYYMMDD-d
 
 ## Privacy
 
-Records every SQL statement data-peek executes, in a local file on this machine. SQL text can contain data values. Off by default; prunable and deletable.
+Records SQL statements data-peek executes — editor, edits, DDL, scheduled, and agent (MCP) — in a local file on this machine. Not recorded: the explain panel, schema reads, and agent writes you reject. SQL text can contain data values. Off by default; prunable and deletable.

--- a/apps/docs/content/docs/features/audit-log.mdx
+++ b/apps/docs/content/docs/features/audit-log.mdx
@@ -1,0 +1,48 @@
+---
+title: Audit Log
+description: A tamper-evident, hash-chained local record of every SQL statement data-peek executes
+---
+
+# Audit Log
+
+The audit log keeps a tamper-evident record of every SQL statement data-peek executes, so you can answer "what ran, when, and from where" after the fact. It's off by default.
+
+Enable it in **Settings → Audit Log**.
+
+## What is recorded
+
+Every recorded entry is tagged with the source that triggered it:
+
+| Source        | What triggers it                                     |
+| ------------- | ----------------------------------------------------- |
+| `editor`      | Queries run from the SQL editor                       |
+| `inline-edit` | INSERT/UPDATE/DELETE from inline data editing          |
+| `ddl`         | CREATE/ALTER/DROP statements from the Table Designer   |
+| `scheduled`   | Statements run by Scheduled Queries                    |
+| `mcp`         | Statements run by an AI agent through the MCP server   |
+
+Each entry stores the timestamp, source, connection, database type, SQL text, row count, success/error, and duration.
+
+## What is NOT recorded
+
+- `EXPLAIN` / query plan requests
+- Schema reads (listing tables, columns, schemas)
+- Writes rejected in the MCP approval dialog
+
+## Hash chain and integrity
+
+Every entry is hashed together with the hash of the entry before it, forming a chain anchored to a fixed starting value. Any edit, deletion, or reordering of a past entry breaks the chain from that point forward.
+
+Click **Verify integrity** in Settings to walk the chain. It reports either that the chain is intact, or the ID of the first broken entry.
+
+## Retention and pruning
+
+Retention is configurable from 7 to 3650 days (default 90). Entries older than the retention window are pruned automatically. Pruning preserves the chain: the anchor is advanced to the hash of the last pruned entry, so **Verify integrity** continues to validate correctly across prune boundaries.
+
+## Export
+
+Export the log to CSV or JSON from Settings. The default filename is `YYYYMMDD-data-peek-audit.csv` (or `.json`).
+
+## Privacy
+
+Records every SQL statement data-peek executes, in a local file on this machine. SQL text can contain data values. Off by default; prunable and deletable.

--- a/apps/docs/content/docs/features/meta.json
+++ b/apps/docs/content/docs/features/meta.json
@@ -36,6 +36,7 @@
     "health-monitor",
     "pg-notifications",
     "data-masking",
+    "audit-log",
     "ssh-tunnels",
     "export",
     "share-as-image",

--- a/apps/web/src/components/marketing/features.tsx
+++ b/apps/web/src/components/marketing/features.tsx
@@ -87,6 +87,10 @@ const categories: { id: string; label: string; items: Feature[] }[] = [
         title: "MCP server",
         body: "Read-only queries run free. Writes are gated behind an in-app approval before they touch the database.",
       },
+      {
+        title: "Audit log",
+        body: "Hash-chained record of every statement executed, from any source. Local, off by default, exportable to CSV or JSON.",
+      },
     ],
   },
   {

--- a/docs/features.md
+++ b/docs/features.md
@@ -173,6 +173,13 @@ For power users and teams:
 | **execute_statement (writes)** | Every write pops an Approve/Reject dialog in data-peek; a 60s timeout auto-rejects |
 | **Copyable Setup Snippet** | Settings → MCP server generates the `claude mcp add` command with your token pre-filled |
 
+### Audit Log
+
+| Feature | Description |
+|---------|-------------|
+| **Audit log** | Tamper-evident (hash-chained) local record of every executed statement, with CSV/JSON export and integrity verification. Off by default. |
+| **Privacy** | Stored locally, never uploaded; SQL text can contain data values. |
+
 ### Column Statistics
 
 | Feature | Description |

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -2592,3 +2592,44 @@ export interface McpServerStatus {
   url: string;
   error?: string;
 }
+
+export type AuditSource = "editor" | "inline-edit" | "ddl" | "scheduled" | "mcp";
+
+export interface AuditEntryInput {
+  source: AuditSource;
+  connectionId: string;
+  connectionName: string;
+  dbType: string;
+  sql: string;
+  rowCount: number | null;
+  success: boolean;
+  error?: string;
+  durationMs?: number;
+}
+
+export interface AuditEntry extends AuditEntryInput {
+  id: number;
+  ts: string;
+  prevHash: string;
+  hash: string;
+}
+
+export interface AuditFilters {
+  source?: AuditSource;
+  connectionId?: string;
+  from?: string;
+  to?: string;
+}
+
+export interface AuditVerifyResult {
+  valid: boolean;
+  entries: number;
+  firstBrokenId?: number;
+}
+
+export interface AuditStatus {
+  available: boolean;
+  enabled: boolean;
+  retentionDays: number;
+  entryCount: number;
+}


### PR DESCRIPTION
## Summary

Local, tamper-evident audit trail of every SQL statement data-peek executes — addressing the "no audit logging" gap for privacy-conscious teams. Off by default; nothing leaves the machine.

- **Storage** (`audit-storage.ts`): dedicated SQLite db, SHA-256 hash-chained append-only log (each entry hashes the previous), `verify()` walks the chain and reports the first broken entry, retention pruning re-anchors the chain so verification survives it, CSV/JSON export (CSV hardened against formula injection).
- **Capture** at five main-process execution sites, each tagged: editor queries, inline edits (per operation), table-designer DDL, scheduled queries, MCP agent statements (post-approval only). Never logged: EXPLAIN, schema reads, rejected MCP writes. `recordAudit` is fire-and-forget and can never fail or slow a query.
- **Service**: off-by-default gate, retention 7–3650 days (default 90) enforced on init and daily.
- **UI**: Settings section with toggle, retention, "Verify integrity", and export buttons; explicit privacy copy (SQL text can contain data values; local file, prunable, deletable).
- **CI**: `test:electron` now runs the Electron-ABI storage suites (audit, notebook, time-machine) in CI — the notebook suite previously never executed anywhere.
- Docs updated in all four locations (README, docs/features.md, docs site page, marketing entry).

## Review

Built with per-task spec+quality reviews plus a final whole-branch review (verdict: ready to merge). The final review caught and fixed a real hole: `connectionName` was excluded from the hash chain, so tampering with attribution passed verification — now hashed, with a regression test. Also fixed there: daily prune (spec required, was init-only) and CSV formula-injection hardening.

Follow-ups filed in the session ledger (none blocking): prune-by-id for clock-skew edge, direct tests for editor/inline-edit capture sites, unused `audit:list` IPC surface, tail-truncation limitation note.

## Testing

- 1032 vitest tests pass; the 55 Electron-ABI storage tests (including hash-chain tamper, prune re-anchor, CSV injection) execute via `pnpm test:electron` — now also in CI
- `pnpm typecheck` clean; docs and web builds green

https://claude.ai/code/session_01Khhdnw9aShE87ALovgMqax

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a tamper-evident **Audit Log** (off by default) that records executed SQL in a local hash-chained log with status, durations, row counts, and errors.
  * Added **Audit Log** settings for enabling/disabling, retention, integrity verification, and CSV/JSON export (including exports from the renderer UI).
* **Documentation**
  * Added Audit Log documentation and updated the feature list to describe privacy and verification/retention behavior.
* **Tests**
  * Expanded Electron-based audit/storage test coverage and improved skipping when SQLite isn’t available; adjusted test exclusions.
* **Chores**
  * CI now runs an additional desktop test pass targeting the Electron ABI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->