### PR TITLE
fix(ci): make Homebrew cask arm64-only to match mac build

### DIFF
--- a/.github/workflows/update-homebrew-cask.yml
+++ b/.github/workflows/update-homebrew-cask.yml
@@ -13,30 +13,24 @@ jobs:
         id: version
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
-      - name: Download macOS DMGs and compute SHA256
+      - name: Download macOS DMG and compute SHA256
         id: sha
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
 
+          # mac builds are arm64-only (see apps/desktop/electron-builder.yml) — the
+          # cask is Apple Silicon only, so there is no x64 DMG to fetch.
           echo "Downloading arm64 DMG..."
           gh release download "$GITHUB_REF_NAME" \
             --repo Rohithgilla12/data-peek \
             --pattern "data-peek-${VERSION}-arm64.dmg" \
             --dir /tmp/release
 
-          echo "Downloading x64 DMG..."
-          gh release download "$GITHUB_REF_NAME" \
-            --repo Rohithgilla12/data-peek \
-            --pattern "data-peek-${VERSION}-x64.dmg" \
-            --dir /tmp/release
-
           ARM64_SHA=$(sha256sum "/tmp/release/data-peek-${VERSION}-arm64.dmg" | cut -d' ' -f1)
-          X64_SHA=$(sha256sum "/tmp/release/data-peek-${VERSION}-x64.dmg" | cut -d' ' -f1)
 
           echo "arm64_sha=${ARM64_SHA}" >> "$GITHUB_OUTPUT"
-          echo "x64_sha=${X64_SHA}" >> "$GITHUB_OUTPUT"
 
       - name: Update tap repo
         env:
@@ -44,26 +38,16 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           ARM64_SHA="${{ steps.sha.outputs.arm64_sha }}"
-          X64_SHA="${{ steps.sha.outputs.x64_sha }}"
 
           git clone https://x-access-token:${TAP_TOKEN}@github.com/Rohithgilla12/homebrew-tap.git /tmp/tap
           cd /tmp/tap
 
           cat > Casks/data-peek.rb << CASK_EOF
           cask "data-peek" do
-            arch arm: "arm64", intel: "x64"
-
             version "${VERSION}"
+            sha256 "${ARM64_SHA}"
 
-            on_arm do
-              sha256 "${ARM64_SHA}"
-            end
-
-            on_intel do
-              sha256 "${X64_SHA}"
-            end
-
-            url "https://github.com/Rohithgilla12/data-peek/releases/download/v#{version}/data-peek-#{version}-#{arch}.dmg",
+            url "https://github.com/Rohithgilla12/data-peek/releases/download/v#{version}/data-peek-#{version}-arm64.dmg",
                 verified: "github.com/Rohithgilla12/data-peek/"
             name "Data Peek"
             desc "Minimal, fast SQL client desktop application"
@@ -74,6 +58,7 @@ jobs:
               strategy :github_latest
             end
 
+            depends_on arch: :arm64
             depends_on macos: ">= :catalina"
 
             app "data-peek.app"

--- a/.github/workflows/update-homebrew-cask.yml
+++ b/.github/workflows/update-homebrew-cask.yml
@@ -3,15 +3,22 @@ name: Update Homebrew Cask
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to sync the cask to (e.g. v0.26.0)"
+        required: true
 
 jobs:
   update-cask:
     runs-on: ubuntu-latest
-    if: "!github.event.release.prerelease"
+    if: "github.event_name == 'workflow_dispatch' || !github.event.release.prerelease"
+    env:
+      RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
     steps:
       - name: Get release version
         id: version
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        run: echo "version=${RELEASE_TAG#v}" >> "$GITHUB_OUTPUT"
 
       - name: Download macOS DMG and compute SHA256
         id: sha
@@ -23,7 +30,7 @@ jobs:
           # mac builds are arm64-only (see apps/desktop/electron-builder.yml) — the
           # cask is Apple Silicon only, so there is no x64 DMG to fetch.
           echo "Downloading arm64 DMG..."
-          gh release download "$GITHUB_REF_NAME" \
+          gh release download "$RELEASE_TAG" \
             --repo Rohithgilla12/data-peek \
             --pattern "data-peek-${VERSION}-arm64.dmg" \
             --dir /tmp/release


### PR DESCRIPTION
## Why

The **Update Homebrew Cask** job failed on the v0.26.0 release ([run](https://github.com/Rohithgilla12/data-peek/actions/runs/29626724981/job/88032509068)):

```
Downloading arm64 DMG...   ✓
Downloading x64 DMG...      ✗  no assets match the file pattern
```

The job downloaded both an arm64 **and** an x64 mac DMG to compute cask SHA256s, but `apps/desktop/electron-builder.yml` builds mac **arm64-only** on purpose (x64 can't cross-build correct native `.node` files — ssh2's sshcrypto etc.). No `x64.dmg` has ever been published, so `gh release download --pattern "…-x64.dmg"` exits 1.

This has been red on every release since arm64-only was adopted (v0.25.0 shipped arm64-only too). It runs *after* the release publishes and doesn't touch the binaries, so it went unnoticed — but it left the Homebrew tap stale, and the generated cask's `on_intel` branch pointed at a non-existent x64 download URL.

## Fix

1. **Match the cask to reality — Apple Silicon only:** drop the x64 DMG download + `X64_SHA`; ship a single-arch cask (`sha256 "<arm64>"`, arm64 URL, `depends_on arch: :arm64`).
2. **Add `workflow_dispatch`** with a `tag` input so the tap can be re-synced to any release manually — the release-only trigger gave no recovery path when a run failed. Version resolves from the dispatch input or the release ref.

## After merge — catch the tap up to v0.26.0

The original run failed before touching the tap, so it's stuck on an older version. Re-sync:

```
gh workflow run "Update Homebrew Cask" --ref main -f tag=v0.26.0
```

Workflow-only change; YAML validated both commits, resulting cask is valid Homebrew Ruby.

https://claude.ai/code/session_01Khhdnw9aShE87ALovgMqax

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added manual triggering for Homebrew cask updates, with an optional release tag.
  * Homebrew cask generation now targets Apple Silicon (arm64) installations.

* **Bug Fixes**
  * Improved version selection for manually triggered and release-based updates.
  * Simplified architecture handling and SHA256 verification for more reliable cask updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->