### PR TITLE
fix(pg): don't permanently poison the pool manager after shutdown cleanup

### DIFF
--- a/apps/desktop/src/main/__tests__/pg-pool-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/pg-pool-manager.test.ts
@@ -144,4 +144,13 @@ describe('closeAllPgPools', () => {
     await expect(withPgClient(makeConfig(), async () => 'ok')).resolves.toBe('ok')
     expect(PoolCtor.mock.calls.length).toBe(beforeClose + 1)
   })
+
+  it('coalesces concurrent teardown calls without wedging the guard', async () => {
+    await withPgClient(makeConfig(), async () => {})
+
+    // Two overlapping teardowns must not leave shuttingDown latched.
+    await Promise.all([closeAllPgPools(), closeAllPgPools()])
+
+    await expect(withPgClient(makeConfig(), async () => 'ok')).resolves.toBe('ok')
+  })
 })

--- a/apps/desktop/src/main/__tests__/pg-pool-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/pg-pool-manager.test.ts
@@ -21,7 +21,7 @@ vi.mock('../lib/logger', () => ({
   createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
 }))
 
-import { withPgClient, withPgTransaction } from '../adapters/pg-pool-manager'
+import { withPgClient, withPgTransaction, closeAllPgPools } from '../adapters/pg-pool-manager'
 
 let counter = 0
 function makeConfig(overrides: Partial<ConnectionConfig> = {}): ConnectionConfig {
@@ -127,5 +127,21 @@ describe('withPgTransaction', () => {
     ).rejects.toBe(original)
 
     expect(mockClient.release).toHaveBeenCalledWith(true)
+  })
+})
+
+describe('closeAllPgPools', () => {
+  it('leaves the manager reusable after teardown (does not permanently poison it)', async () => {
+    // A pool is created and in use.
+    await withPgClient(makeConfig(), async () => {})
+    const beforeClose = PoolCtor.mock.calls.length
+
+    // The app runs shutdown cleanup — but on macOS the process can outlive it
+    // (windows hide instead of quitting; an aborted/raced quit can leave it alive).
+    await closeAllPgPools()
+
+    // Subsequent work must still succeed — not throw "Pool manager is shutting down".
+    await expect(withPgClient(makeConfig(), async () => 'ok')).resolves.toBe('ok')
+    expect(PoolCtor.mock.calls.length).toBe(beforeClose + 1)
   })
 })

--- a/apps/desktop/src/main/adapters/pg-pool-manager.ts
+++ b/apps/desktop/src/main/adapters/pg-pool-manager.ts
@@ -29,6 +29,7 @@ const pools = new Map<string, PoolEntry>()
 const pendingPools = new Map<string, Promise<PoolEntry>>()
 
 let shuttingDown = false
+let teardownInFlight: Promise<void> | null = null
 
 function getPoolKey(config: ConnectionConfig): string {
   if (config.id) return `pg:${config.id}`
@@ -233,21 +234,34 @@ export async function closePgPool(config: ConnectionConfig): Promise<void> {
  * fail with "Pool manager is shutting down" until relaunch.
  */
 export async function closeAllPgPools(): Promise<void> {
+  // Coalesce concurrent calls onto one teardown, so a second call's `finally`
+  // can't flip `shuttingDown` back to false while the first is still tearing down.
+  if (teardownInFlight) return teardownInFlight
   shuttingDown = true
-  try {
-    const entries = Array.from(pools.values())
-    pools.clear()
-    await Promise.all(
-      entries.map(async (entry) => {
-        try {
-          await entry.pool.end()
-        } catch (err) {
-          log.warn('error ending pool:', (err as Error).message)
-        }
-        closeTunnel(entry.tunnel)
-      })
-    )
-  } finally {
-    shuttingDown = false
-  }
+  teardownInFlight = (async () => {
+    try {
+      // Let in-flight pool creations settle first. Each resolves through
+      // getOrCreatePool's post-create check, which ends the pool and closes its
+      // tunnel while `shuttingDown` is true — so awaiting them here tears them
+      // down too instead of leaking a half-created pool + tunnel. New creations
+      // can't start during teardown (the guard above rejects them).
+      await Promise.allSettled(Array.from(pendingPools.values()))
+      const entries = Array.from(pools.values())
+      pools.clear()
+      await Promise.all(
+        entries.map(async (entry) => {
+          try {
+            await entry.pool.end()
+          } catch (err) {
+            log.warn('error ending pool:', (err as Error).message)
+          }
+          closeTunnel(entry.tunnel)
+        })
+      )
+    } finally {
+      shuttingDown = false
+      teardownInFlight = null
+    }
+  })()
+  return teardownInFlight
 }

--- a/apps/desktop/src/main/adapters/pg-pool-manager.ts
+++ b/apps/desktop/src/main/adapters/pg-pool-manager.ts
@@ -222,19 +222,32 @@ export async function closePgPool(config: ConnectionConfig): Promise<void> {
 
 /**
  * Close every pool. Call on app shutdown.
+ *
+ * `shuttingDown` is a *transient* guard, not a permanent latch: it blocks new
+ * pool creation only while teardown is in flight (so a pool created mid-teardown
+ * can't be orphaned by the snapshot below), then clears. This matters on macOS,
+ * where the process routinely outlives a cleanup pass — the last window hides
+ * instead of quitting, and a raced/aborted quit (e.g. an auto-update
+ * `quitAndInstall` whose quit is preventDefault-ed) can run this without the
+ * process dying. If the flag stayed latched, every later pool acquisition would
+ * fail with "Pool manager is shutting down" until relaunch.
  */
 export async function closeAllPgPools(): Promise<void> {
   shuttingDown = true
-  const entries = Array.from(pools.values())
-  pools.clear()
-  await Promise.all(
-    entries.map(async (entry) => {
-      try {
-        await entry.pool.end()
-      } catch (err) {
-        log.warn('error ending pool:', (err as Error).message)
-      }
-      closeTunnel(entry.tunnel)
-    })
-  )
+  try {
+    const entries = Array.from(pools.values())
+    pools.clear()
+    await Promise.all(
+      entries.map(async (entry) => {
+        try {
+          await entry.pool.end()
+        } catch (err) {
+          log.warn('error ending pool:', (err as Error).message)
+        }
+        closeTunnel(entry.tunnel)
+      })
+    )
+  } finally {
+    shuttingDown = false
+  }
 }


### PR DESCRIPTION
## Symptom

A live PostgreSQL connection shows **"Pool manager is shutting down"** in the schema sidebar during normal use — the connection looks connected (green dot) but nothing can query it. Seen in prod.

## Root cause

`shuttingDown` in `pg-pool-manager.ts` was a **one-way latch**: set `true` in `closeAllPgPools()` and never reset. `getOrCreatePool()` throws whenever it's set.

`closeAllPgPools()` has exactly one caller — the `before-quit` cleanup in `index.ts`. So hitting this state means **the app ran shutdown cleanup but the process kept running**. On macOS that's routine, not exotic:

- The last window **hides instead of quitting** (`window.on('close')` → `preventDefault()` + `hide()`), so the process is long-lived.
- The `before-quit` handler `preventDefault()`s the quit, runs cleanup, then re-quits. A raced or aborted quit — e.g. an auto-update `quitAndInstall` whose quit is caught by that same generic `before-quit` handler — can run cleanup **without the process terminating**.

Once latched, every subsequent pool acquisition fails, so all Postgres work is dead until the app is fully relaunched.

## Fix

Make `shuttingDown` **transient**: reset it in a `finally` after teardown completes. It still blocks pool creation *while* teardown is in flight (so a pool created mid-teardown can't be orphaned by the snapshot `closeAllPgPools` takes), but the manager is reusable once teardown finishes. On a genuine quit the process exits moments later, so the reset is harmless.

## Test

Added a regression test that reproduces the exact failure: create a pool → `closeAllPgPools()` → `withPgClient` must create a fresh pool rather than throwing "Pool manager is shutting down". Fails before the fix, passes after.

- Full main-process suite: 466 passed, 0 failed. Typecheck clean.

## Note

Separate, rarer edge (not this bug): if `pool.end()` on a prod pool/SSH tunnel *hangs*, `shuttingDown` stays true until it resolves. Bounding teardown with a timeout would harden that further — happy to follow up if you want it.

https://claude.ai/code/session_01Khhdnw9aShE87ALovgMqax

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pool shutdown behavior so the pool manager isn’t left in a permanently “shutting down” state after closing all pools.
  * Improved teardown to coordinate concurrent shutdown calls, wait for in-flight pool creation to settle, and reliably clear pools and close any associated tunnels.
* **Tests**
  * Added coverage to verify `closeAllPgPools()` does not block future pool usage and remains stable under concurrent invocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->