### PR TITLE
docs(site): expand six thin feature pages for indexability

### DIFF
--- a/apps/docs/content/docs/features/column-statistics.mdx
+++ b/apps/docs/content/docs/features/column-statistics.mdx
@@ -1,11 +1,13 @@
 ---
 title: Column Statistics
-description: View distribution and statistics for any result column
+description: Instant data profiling for any result column — nulls, distincts, distribution, and top values
 ---
 
 # Column Statistics
 
 Get instant statistical insights on any column in your query results without writing aggregate queries.
+
+It's the quickest way to *profile* data before you trust it: how many nulls are really in that column, how skewed the distribution is, whether a "unique" field actually is. Instead of writing four `COUNT(DISTINCT ...)` / `MIN` / `MAX` queries by hand, you click a column and read it off.
 
 ## Opening the Stats Panel
 
@@ -15,10 +17,10 @@ Click on any column header in the results table and select **Column Statistics**
 
 ### General
 
-- **Row count** - Total rows in the result
-- **Distinct count** - Number of unique values
-- **Null count** - Number of NULL values
-- **Null percentage** - Proportion of NULLs
+- **Row count** — total rows in the result
+- **Distinct count** — number of unique values
+- **Null count** — number of NULL values
+- **Null percentage** — proportion of NULLs
 
 ### Numeric Columns
 
@@ -37,7 +39,18 @@ A histogram shows the distribution of values across the column, giving you a vis
 
 A frequency chart displays the most common values with relative proportion bars, helping you spot dominant patterns at a glance.
 
+## Example: profiling a column before a migration
+
+About to add `NOT NULL` to `users.phone`? Run `SELECT phone FROM users`, open Column Statistics on the column, and read the **Null percentage**. If it's above 0%, the constraint will fail — now you know to backfill first. The **Most Common Values** chart also exposes junk defaults (a suspicious spike of `''` or `'N/A'`) that a plain null check would miss.
+
 <Callout type="info">
-  Statistics are computed client-side on the fetched result set. For full-table
-  statistics, ensure your query fetches all rows.
+  Statistics are computed client-side on the fetched result set, so they reflect
+  the rows you pulled — a query with a `LIMIT` profiles only those rows. For
+  full-table statistics, make sure your query fetches every row.
 </Callout>
+
+## Related
+
+- [Results Viewer](/docs/features/results-viewer) — the grid these stats are computed from
+- [Smart Filters](/docs/features/smart-filters) — filter to the rows a stat surfaced
+- [Data Masking](/docs/features/data-masking) — hide sensitive column values for demos and screenshots

--- a/apps/docs/content/docs/features/csv-import.mdx
+++ b/apps/docs/content/docs/features/csv-import.mdx
@@ -1,26 +1,28 @@
 ---
 title: CSV Import
-description: Import CSV files into database tables
+description: Import CSV files into database tables with column mapping, type inference, and conflict handling
 ---
 
 # CSV Import
 
-Import data from CSV files directly into your database tables.
+Import data from CSV files directly into your database tables — no `COPY` command, no scripting, no leaving the app.
+
+CSV import is the fastest way to get a spreadsheet, an export from another tool, or a colleague's data dump into a real table you can query. It's handy for seeding a dev database, loading a lookup table, or reconciling an external file against data you already have.
 
 ## Starting an Import
 
-1. Open the CSV Import dialog from the sidebar or command palette
+1. Open the CSV Import dialog from the sidebar or [command palette](/docs/features/command-palette)
 2. Drag and drop a `.csv` file, or click to browse
 
 ## Configuration
 
 ### Column Mapping
 
-data-peek auto-detects CSV headers and attempts to match them to existing table columns. You can:
+data-peek reads the CSV header row, infers a type for each column, and attempts to match each one to a column in your target table. From there you can:
 
-- Map CSV columns to different table columns
+- Map CSV columns to differently-named table columns
 - Skip columns you don't want to import
-- Create a new table from the CSV structure
+- Create a brand-new table from the CSV structure (types are inferred from the data)
 
 ### Import Options
 
@@ -33,8 +35,39 @@ data-peek auto-detects CSV headers and attempts to match them to existing table 
 
 ## Import Progress
 
-A progress bar shows the import status. Large files are imported in batches to avoid timeouts.
+A progress bar shows the import status. Large files are streamed and inserted in batches, so a single huge transaction never blocks the connection or times out.
+
+## Example: loading a users file into a new table
+
+Say you have `users.csv`:
+
+```csv
+email,full_name,plan
+ada@acme.test,Ada Lovelace,pro
+grace@acme.test,Grace Hopper,free
+```
+
+Drop it in, choose **Create new table** named `users_import`, keep the inferred types, and import. You now have a queryable table:
+
+```sql
+SELECT plan, count(*) FROM users_import GROUP BY plan;
+```
+
+Re-running the same file with **Conflict handling → Update on primary key** lets you use the CSV as a repeatable upsert source instead of creating duplicates.
 
 ## Supported Databases
 
 CSV import works with PostgreSQL and MySQL connections.
+
+<Callout type="tip">
+  Type inference is a best guess from the sampled rows — a column of `007` or
+  leading-zero IDs may come in as an integer. If exact types matter, create the
+  table first in the [Table Designer](/docs/features/table-designer), then import
+  into it.
+</Callout>
+
+## Related
+
+- [SQL Dump Import](/docs/features/pg-import) — for `.sql` dump files rather than CSV
+- [Data Generator](/docs/features/data-generator) — synthesize test data instead of importing it
+- [Inline Editing](/docs/features/inline-editing) — fix up individual rows after an import

--- a/apps/docs/content/docs/features/data-generator.mdx
+++ b/apps/docs/content/docs/features/data-generator.mdx
@@ -1,15 +1,17 @@
 ---
 title: Data Generator
-description: Generate realistic test data for any table
+description: Generate realistic, FK-aware test data for any table — for development, testing, and demos
 ---
 
 # Data Generator
 
-Generate realistic test data for your tables without leaving data-peek. Useful for development, testing, and demos.
+Generate realistic test data for your tables without leaving data-peek — no seed scripts, no Faker boilerplate, no hand-writing a thousand `INSERT`s.
+
+It's the fastest way to fill an empty dev database, stress-test a query against realistic volume, or build a believable demo dataset. Because it's **foreign-key aware**, you can populate a whole related schema (organizations → users → invoices) and the rows actually join up.
 
 ## Opening the Generator
 
-Right-click a table in the sidebar and select **Generate Data**, or open it from the command palette. It opens as a dedicated tab.
+Right-click a table in the sidebar and select **Generate Data**, or open it from the [command palette](/docs/features/command-palette). It opens as a dedicated tab.
 
 ## Configuring Columns
 
@@ -34,8 +36,8 @@ For each column, choose a generator:
 
 ## Generation Options
 
-- **Row count** - Generate 1 to 10,000 rows
-- **Seed** - Set a seed for reproducible output
+- **Row count** — generate 1 to 10,000 rows
+- **Seed** — set a seed for reproducible output
 
 ## Preview Mode
 
@@ -45,7 +47,30 @@ Click **Preview** to generate sample rows without inserting them. Review the dat
 
 A progress indicator shows generation status. You can cancel at any time.
 
+## Example: seeding a related schema
+
+To fill `organizations` then `users` so every user belongs to a real org:
+
+1. On `organizations`, set `name` → **Faker: name**, `plan` → **Random enum** (`free`, `pro`, `enterprise`), generate 20 rows.
+2. On `users`, set `email` → **Faker: email**, `organization_id` → **FK reference** (`organizations.id`), generate 500 rows.
+
+Now the join works out of the box:
+
+```sql
+SELECT o.plan, count(u.id) AS users
+FROM organizations o JOIN users u ON u.organization_id = o.id
+GROUP BY o.plan;
+```
+
 <Callout type="tip">
-  Use the FK reference generator to maintain referential integrity. It pulls
-  real foreign key values from the parent table.
+  Use the FK reference generator to maintain referential integrity — it pulls
+  real values from the parent table, so **generate parents before children**.
+  Set a **seed** when you need the same dataset every run (handy for
+  reproducible tests or screenshots).
 </Callout>
+
+## Related
+
+- [CSV Import](/docs/features/csv-import) — load real data from a file instead of generating it
+- [Inline Editing](/docs/features/inline-editing) — tweak individual generated rows
+- [Table Designer](/docs/features/table-designer) — create the table first, then fill it

--- a/apps/docs/content/docs/features/health-monitor.mdx
+++ b/apps/docs/content/docs/features/health-monitor.mdx
@@ -1,11 +1,13 @@
 ---
 title: Health Monitor
-description: Monitor database health with active queries, table sizes, cache ratios, and locks
+description: Live view of database health — active queries, table sizes, cache hit ratios, and blocking locks
 ---
 
 # Health Monitor
 
 The Health Monitor gives you a live view of your database's operational health without leaving data-peek.
+
+It's the panel you open when something feels off: a query that won't return, a dashboard that's suddenly slow, or a table that's ballooning on disk. Instead of remembering the `pg_stat_activity` and `pg_locks` incantations, you get the four things you actually reach for during an incident — what's running, what's blocking, what's cached, and what's big — in one auto-refreshing tab.
 
 ## Opening the Monitor
 
@@ -36,7 +38,7 @@ Sort by any column to find your largest tables or most indexed tables.
 
 ### Cache Hit Ratios
 
-Displays the cache hit ratio for your database, indicating how effectively PostgreSQL is using shared buffers.
+Displays the cache hit ratio for your database, indicating how effectively PostgreSQL is using shared buffers. A healthy OLTP database usually sits well above 99% — a sustained dip often means a working set that no longer fits in memory.
 
 ### Locks
 
@@ -54,11 +56,21 @@ Configure automatic polling:
 | 30s      | Low-frequency checks  |
 | Off      | Manual refresh only   |
 
+## Example: finding and clearing a blocker
+
+A write is hanging. Open the Health Monitor, drop the refresh to **2s**, and check the **Locks** panel — it surfaces the blocking query and what it's holding. Cross-reference it in **Active Queries** (sort by duration to find the long-running culprit), confirm it's safe to stop, and hit **Terminate** (graceful) or **Kill** (force). The blocked write clears immediately.
+
 ## Share as Image
 
-Each panel has a **Share** button that exports the data as a styled PNG image with your choice of background theme, perfect for sharing in Slack or documentation.
+Each panel has a **Share** button that exports the data as a styled PNG image with your choice of background theme, perfect for sharing in Slack or documentation. See [Share as Image](/docs/features/share-as-image).
 
 <Callout type="info">
   The Health Monitor currently supports PostgreSQL. MySQL and MSSQL support is
   planned.
 </Callout>
+
+## Related
+
+- [Query Plans](/docs/features/query-plans) — `EXPLAIN` the slow query you just found
+- [Query Telemetry](/docs/features/query-telemetry) — timing breakdown for a single execution
+- [Transactions](/docs/features/transactions) — manage the open transactions that cause locks

--- a/apps/docs/content/docs/features/pg-import.mdx
+++ b/apps/docs/content/docs/features/pg-import.mdx
@@ -1,30 +1,54 @@
 ---
 title: SQL Dump Import
-description: Import PostgreSQL SQL dump files
+description: Import PostgreSQL .sql dump files statement-by-statement, with progress and error handling
 ---
 
 # SQL Dump Import
 
 Import `.sql` dump files into your PostgreSQL database directly from data-peek.
 
+Reach for this when you have a `pg_dump` plain-text export, a schema file from a repo, or a seed script you want to load into a connection — and you'd rather watch it run with a progress bar and an error report than paste it into a terminal and hope. It's the companion to [CSV Import](/docs/features/csv-import): CSV for tabular data, SQL dump for full schema + data + statements.
+
 ## Starting an Import
 
-1. Open the import dialog from the sidebar or command palette
+1. Open the import dialog from the sidebar or [command palette](/docs/features/command-palette)
 2. Select a `.sql` dump file
 
 ## Import Process
 
 data-peek streams the dump file and executes SQL statements one at a time:
 
-- **Progress** - Shows statements executed vs. total
-- **Error handling** - Choose between stopping on first error or continuing past failures
-- **Report** - After completion, see a summary of successful, skipped, and failed statements
+- **Progress** — shows statements executed vs. total
+- **Error handling** — choose between stopping on the first error or continuing past failures
+- **Report** — after completion, see a summary of successful, skipped, and failed statements
+
+Because statements run individually rather than as one giant transaction, a large dump won't hold a single lock for the whole run, and the report tells you exactly which statement failed if one does.
+
+## Example: loading a schema + seed file
+
+Point it at a plain-text dump like:
+
+```sql
+CREATE TABLE organizations (id serial PRIMARY KEY, name text, plan text);
+INSERT INTO organizations (name, plan) VALUES ('Acme', 'pro'), ('Globex', 'free');
+```
+
+Run it with **continue past failures** on, and if (say) the `CREATE TABLE` fails because the table already exists, the `INSERT` statements still run and the report flags the one skipped statement — no need to hand-edit the file first.
 
 <Callout type="warning">
   Large dump files may take time to import. The progress indicator helps you
-  track the process.
+  track the process. For dumps that are pure tabular data, [CSV Import](/docs/features/csv-import)
+  is usually faster.
 </Callout>
 
 <Callout type="info">
-  SQL dump import is currently available for PostgreSQL connections only.
+  SQL dump import is currently available for PostgreSQL connections only. It
+  expects plain-text (`--format=plain`) dumps, not custom/compressed archive
+  formats.
 </Callout>
+
+## Related
+
+- [CSV Import](/docs/features/csv-import) — import tabular data from a `.csv` file
+- [Connection Management](/docs/features/connection-management) — pick which database the dump loads into
+- [Export](/docs/features/export) — export results back out to CSV, JSON, or Excel

--- a/apps/docs/content/docs/features/scheduled-queries.mdx
+++ b/apps/docs/content/docs/features/scheduled-queries.mdx
@@ -1,21 +1,23 @@
 ---
 title: Scheduled Queries
-description: Run SQL queries automatically on a cron schedule
+description: Run SQL queries automatically on a cron schedule, with run history and desktop notifications
 ---
 
 # Scheduled Queries
 
 Schedule queries to run automatically at recurring intervals. Useful for monitoring, periodic data checks, or generating recurring reports.
 
+Where [Watch Mode](/docs/features/watch-mode) re-runs a query while you're looking at it, Scheduled Queries keep running on their own cadence in the background — so you can leave a "how many signups today?" or "any rows stuck in `pending`?" check ticking over and get a desktop ping when it completes, without babysitting a tab.
+
 ## Creating a Schedule
 
 1. Open the **Scheduled Queries** dialog from the sidebar
 2. Click **New Schedule**
 3. Configure the schedule:
-   - **Name** - A descriptive label
-   - **Connection** - Which database to run against
-   - **SQL** - The query to execute
-   - **Schedule** - Choose a preset or enter a custom cron expression
+   - **Name** — a descriptive label
+   - **Connection** — which database to run against
+   - **SQL** — the query to execute
+   - **Schedule** — choose a preset or enter a custom cron expression
 
 ### Schedule Presets
 
@@ -50,7 +52,24 @@ Click a schedule to see all past runs with:
 
 When a scheduled query completes, data-peek sends a desktop notification with the result summary.
 
+## Example: an hourly backlog check
+
+Create a schedule named **Pending invoices**, pick your connection, set the cron to `0 * * * *` (every hour), and use:
+
+```sql
+SELECT count(*) AS pending FROM invoices WHERE status = 'pending';
+```
+
+Each hour you get a notification with the count, and the run history keeps a timestamped record you can scan for the moment the number started climbing. Need a custom cadence like every 15 minutes? Use `*/15 * * * *`.
+
 <Callout type="warning">
   Scheduled queries only run while data-peek is open. They do not run in the
-  background after quitting the app.
+  background after quitting the app — for always-on jobs use a server-side
+  scheduler (cron, pg_cron, etc.).
 </Callout>
+
+## Related
+
+- [Watch Mode](/docs/features/watch-mode) — live-refresh a query while you watch it
+- [Query Telemetry](/docs/features/query-telemetry) — see where a slow scheduled query spends its time
+- [Health Monitor](/docs/features/health-monitor) — live view of active queries, locks, and table sizes


### PR DESCRIPTION
## Why

From the GSC audit: most "not indexed" pages are **"crawled – currently not indexed"** — Google's signal that a page is technically fine but too thin/templated to be worth an index slot on a young domain. Six high-search-intent feature pages were 107–199 words each, all following the same *one-liner → steps → callout* template.

## What

Expanded each to ~330–385 words with the recipe from the audit — **a why/when intro, a worked example, a tips/gotchas note, and cross-links** to related features. No stated facts changed; this is additive.

| Page | Before | After |
|---|---|---|
| csv-import | 145 | 372 |
| pg-import (SQL dump) | 107 | 328 |
| data-generator | 199 | 380 |
| scheduled-queries | 177 | 348 |
| health-monitor | 195 | 384 |
| column-statistics | 156 | 333 |

Examples use the acme_saas demo schema; cross-links point only to existing pages. Docs site builds clean.

Note: this fixes the part in our control — domain authority (backlinks/traffic from the launch) is still the bigger lever for indexing.

https://claude.ai/code/session_01Khhdnw9aShE87ALovgMqax

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded guidance for Column Statistics, including migration examples and `LIMIT`-related behavior.
  * Added comprehensive CSV import instructions covering mapping, type inference, progress, batching, and conflict handling.
  * Expanded Data Generator documentation with foreign-key-aware seeding examples.
  * Improved Health Monitor guidance with cache ratios and blocker resolution walkthroughs.
  * Clarified SQL Dump Import capabilities, progress handling, errors, and supported formats.
  * Enhanced Scheduled Queries setup, notifications, run history, cron examples, and limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->