### PR TITLE
docs(site): expand seven more thin feature pages for indexability

### DIFF
--- a/apps/docs/content/docs/configuration/themes.mdx
+++ b/apps/docs/content/docs/configuration/themes.mdx
@@ -7,9 +7,11 @@ description: Switch between dark and light themes
 
 data-peek supports both dark and light themes.
 
+A SQL client is something you stare at for hours, so the theme isn't cosmetic — it's about eye comfort across very different environments. Dark mode is the default for low-light, long sessions; light mode is there for bright rooms, projectors, and screenshots where a dark UI washes out. Whichever you pick, the accent blue and the editor syntax colors stay consistent, so the app feels like one coherent tool in either mode.
+
 ## Switching Themes
 
-Click the **theme toggle** button in the sidebar header (sun/moon icon) to switch between themes.
+Click the **theme toggle** button in the sidebar header (sun/moon icon) to switch between themes. The change applies instantly across every open tab and window.
 
 ## Dark Theme
 
@@ -45,4 +47,14 @@ Your theme preference is saved and persists across app restarts.
 
 ## Editor Theme
 
-The Monaco editor automatically adjusts to match the selected theme, with appropriate syntax highlighting colors for each mode.
+The Monaco editor automatically adjusts to match the selected theme, with appropriate syntax highlighting colors for each mode — you never configure the editor theme separately.
+
+## When to use which
+
+- **Dark** — night work, dim rooms, or if bright screens tire your eyes. It's the default.
+- **Light** — presenting on a projector, pairing in a bright room, or capturing screenshots for docs where a light background reads better. For demo screenshots you also want [Data Masking](/docs/features/data-masking) to blur sensitive values.
+
+## Related
+
+- [Settings](/docs/configuration/settings) — the rest of data-peek's preferences
+- [Share as Image](/docs/features/share-as-image) — export queries/results with their own light or dark code theme

--- a/apps/docs/content/docs/features/pg-notifications.mdx
+++ b/apps/docs/content/docs/features/pg-notifications.mdx
@@ -7,6 +7,8 @@ description: Subscribe to PostgreSQL notification channels in real time
 
 Monitor PostgreSQL pub/sub channels directly in data-peek with a live event stream.
 
+`LISTEN`/`NOTIFY` is PostgreSQL's built-in pub/sub: a trigger or an app fires `NOTIFY channel, 'payload'`, and anyone listening gets it instantly. It's great for cache invalidation, real-time UI updates, and job queues — but debugging it usually means writing a throwaway listener script. This panel is that listener, built in: subscribe to a channel and watch events stream in live, or fire test notifications to check your consumers react.
+
 ## Opening the Panel
 
 Open the **Notifications** panel from the sidebar. It opens as a dedicated tab.
@@ -38,10 +40,27 @@ This is useful for testing notification consumers.
 
 ## Actions
 
-- **Copy** - Copy a notification payload to clipboard
-- **Clear All** - Remove all received events from the display
+- **Copy** — copy a notification payload to clipboard
+- **Clear All** — remove all received events from the display
+
+## Example: watching a trigger fire
+
+Subscribe to a channel — say `orders_changed` — then, from a [Query Editor](/docs/features/query-editor) tab (or the panel's **Send**), fire:
+
+```sql
+NOTIFY orders_changed, '{"id": 4821, "status": "paid"}';
+```
+
+The event shows up in the stream instantly, timestamped, with the JSON payload pretty-printed. Wire the same `NOTIFY` into an `AFTER INSERT` [trigger](/docs/features/triggers) and you can watch your database emit events in real time as data changes — the fastest way to confirm a trigger actually fires and carries the payload you expect.
 
 <Callout type="info">
-  This feature is PostgreSQL-only, as LISTEN/NOTIFY is a PostgreSQL-specific
-  feature.
+  This feature is PostgreSQL-only, as `LISTEN`/`NOTIFY` is a PostgreSQL-specific
+  feature. Payloads are capped at 8000 bytes by Postgres itself — send an id and
+  look the row up, rather than stuffing the whole record into the payload.
 </Callout>
+
+## Related
+
+- [Triggers](/docs/features/triggers) — fire `NOTIFY` automatically on data changes
+- [Query Editor](/docs/features/query-editor) — run `NOTIFY` / set up `LISTEN` manually
+- [Watch Mode](/docs/features/watch-mode) — poll a query on a cadence when pub/sub isn't a fit

--- a/apps/docs/content/docs/features/query-benchmarking.mdx
+++ b/apps/docs/content/docs/features/query-benchmarking.mdx
@@ -7,6 +7,8 @@ description: Benchmark queries by running them multiple times and collecting tim
 
 Run a query multiple times to collect accurate performance statistics, eliminating variance from single-run measurements.
 
+A single run tells you almost nothing: a cold cache, a background checkpoint, or a noisy neighbor can make the same query look 10× slower than it really is. Benchmarking runs it many times and reports the distribution, so "is this actually faster?" gets a trustworthy answer instead of a coin flip. It's the tool you reach for when deciding whether an index or a rewrite really helped — not just whether it happened to be quick once.
+
 ## Running a Benchmark
 
 1. Write your query in the editor
@@ -26,13 +28,24 @@ Run a query multiple times to collect accurate performance statistics, eliminati
 
 After completion, you see:
 
-- **Average** - Mean execution time
-- **P90** - 90th percentile (90% of runs were faster than this)
-- **P95** - 95th percentile
-- **P99** - 99th percentile
+- **Average** — mean execution time
+- **P90** — 90th percentile (90% of runs were faster than this)
+- **P95** — 95th percentile
+- **P99** — 99th percentile
+
+## Example: proving an index helped
+
+You suspect a filter on `organizations.plan` needs an index. Benchmark the query at **100 iterations** and note the numbers (say avg 42 ms, P99 110 ms). Add the index in the [Table Designer](/docs/features/table-designer), benchmark again, and compare — if the average drops to 3 ms and P99 to 6 ms, the win is real and consistent, not a fluke of one lucky run. Watch the **P99** especially: an index that fixes the average but leaves a fat tail is often a caching artifact, not a genuine improvement.
 
 <Callout type="tip">
-  Use benchmarking to compare query performance before and after adding an index
-  or rewriting a query. The percentile values help you understand worst-case
-  behavior, not just average.
+  Percentiles describe worst-case behavior, not just the average — a query with
+  a great average but a bad P99 will still feel janky under load. Pair this with
+  [Query Plans](/docs/features/query-plans) to see *why* a query is slow before
+  you benchmark the fix.
 </Callout>
+
+## Related
+
+- [Query Plans](/docs/features/query-plans) — `EXPLAIN` the query to find the bottleneck
+- [Query Telemetry](/docs/features/query-telemetry) — timing breakdown of a single execution
+- [Performance Analysis](/docs/features/performance-analysis) — detect missing indexes and slow patterns

--- a/apps/docs/content/docs/features/quick-query.mdx
+++ b/apps/docs/content/docs/features/quick-query.mdx
@@ -1,11 +1,13 @@
 ---
 title: Quick Query
-description: Run ad-hoc queries from the sidebar without opening a tab
+description: Run ad-hoc SQL from the sidebar without opening a full editor tab
 ---
 
 # Quick Query
 
 A mini SQL editor embedded in the sidebar for running quick, one-off queries without opening a full tab.
+
+It exists for the queries you don't want to think about: a `COUNT(*)` to sanity-check a table, a fast lookup of one row, a `SHOW` to confirm a setting. Opening a full [editor tab](/docs/features/query-editor) for those is overkill and clutters your workspace — Quick Query keeps them out of the way while you're really working on something else in the main tabs.
 
 ## Using Quick Query
 
@@ -16,13 +18,31 @@ A mini SQL editor embedded in the sidebar for running quick, one-off queries wit
 
 ## Recent Queries
 
-The panel shows your 3 most recent successful queries as clickable chips. Tap one to re-run it instantly.
+The panel shows your 3 most recent successful queries as clickable chips. Tap one to re-run it instantly — handy when you're repeatedly checking the same count as you work.
 
 ## Hiding Quick Query
 
-If you prefer a cleaner sidebar, go to **Settings** and enable **Hide quick query panel**.
+If you prefer a cleaner sidebar, go to [Settings](/docs/configuration/settings) and enable **Hide quick query panel**.
+
+## Example: a throwaway sanity check
+
+Mid-way through building a bigger query in a main tab, you want to confirm a table isn't empty. Instead of switching tabs, drop into the sidebar panel:
+
+```sql
+SELECT count(*) FROM organizations;
+```
+
+`Cmd+Enter`, read the number inline, and carry on — your real editor tab is untouched, and the query lands in the recent-chips list if you need it again.
 
 <Callout type="tip">
   Quick Query is perfect for `SELECT COUNT(*)`, checking a value, or running a
-  quick `SHOW` command without cluttering your tab bar.
+  quick `SHOW` command. For anything you'll iterate on — multi-statement scripts,
+  saved work, results you want to chart — use a full [Query Editor](/docs/features/query-editor)
+  tab instead.
 </Callout>
+
+## Related
+
+- [Query Editor](/docs/features/query-editor) — the full multi-tab SQL editor
+- [Command Palette](/docs/features/command-palette) — jump to any action with `Cmd+K`
+- [Saved Queries](/docs/features/saved-queries) — bookmark a query you keep re-running

--- a/apps/docs/content/docs/features/share-as-image.mdx
+++ b/apps/docs/content/docs/features/share-as-image.mdx
@@ -7,6 +7,8 @@ description: Export queries and data as styled PNG images
 
 Export your queries or data as beautiful, styled PNG images for sharing in Slack, documentation, or presentations.
 
+Pasting raw SQL or a wall of query output into Slack looks rough and loses its formatting. Share as Image renders it as a clean, syntax-highlighted card — the same idea as the popular "screenshot your code" tools, but built in and pointed at your queries and results, so a teammate instantly gets readable context instead of a mangled monospace blob.
+
 ## Sharing a Query
 
 1. Right-click in the query editor or use the command palette
@@ -43,10 +45,21 @@ Optionally include or hide the data-peek watermark.
 
 ## Export Options
 
-- **Copy to clipboard** - Paste directly into Slack, Notion, or any app
-- **Download as PNG** - Save to disk
+- **Copy to clipboard** — paste directly into Slack, Notion, or any app
+- **Download as PNG** — save to disk
+
+## Example: dropping a query into Slack
+
+You want to ask a teammate about a query. Right-click it → **Share as Image**, pick the **Brand Blue** background and a **dark** code theme, hide the watermark for an internal share, and hit **Copy to clipboard**. Paste straight into the Slack thread — they see clean, highlighted SQL with zero formatting loss, and you never left the app.
 
 <Callout type="tip">
-  Health Monitor panels also support Share as Image via the share button on each
-  card.
+  [Health Monitor](/docs/features/health-monitor) panels also support Share as
+  Image via the share button on each card — handy for pasting a locks or
+  table-sizes snapshot into an incident channel.
 </Callout>
+
+## Related
+
+- [Health Monitor](/docs/features/health-monitor) — share live health panels as images
+- [Results Viewer](/docs/features/results-viewer) — the grid you export from
+- [Export](/docs/features/export) — export the underlying data as CSV/JSON/Excel instead of an image

--- a/apps/docs/content/docs/features/sidebar-omnibar.mdx
+++ b/apps/docs/content/docs/features/sidebar-omnibar.mdx
@@ -7,6 +7,8 @@ description: Search across tables, columns, functions, saved queries, and histor
 
 The omnibar is a universal search bar at the top of the sidebar that searches across everything in your workspace.
 
+On a database with hundreds of tables and columns, scrolling the schema tree is slow. The omnibar is the "just type what you're looking for" answer — one input that spans your schema, your saved work, and your history, so getting to a table, a column, or that query you ran yesterday is a few keystrokes instead of a hunt. Think of it as find-as-you-type for the whole workspace, not just the tree.
+
 ## What It Searches
 
 | Source                   | Example                      |
@@ -24,6 +26,20 @@ The omnibar is a universal search bar at the top of the sidebar that searches ac
 2. Type your search term
 3. Results are grouped by type
 4. Click a result to take action:
-   - **Table/view** - Opens a preview tab
-   - **Saved query/snippet** - Inserts into the active editor
-   - **History item** - Opens in a new tab
+   - **Table/view** — opens a preview tab
+   - **Saved query/snippet** — inserts into the active editor
+   - **History item** — opens in a new tab
+
+## Example: jumping to a column you half-remember
+
+You know there's an `email` column somewhere but not which table. Type `email` in the omnibar and it lists every table that has one, grouped under Columns — click through to the right table's preview without expanding a single tree node. The same search surfaces the `calculate_total()` function and last week's query touching email, so one term covers "where is it" and "what did I run against it."
+
+## Omnibar vs Command Palette
+
+The omnibar searches your **data and workspace** (tables, columns, functions, saved queries, history). The [Command Palette](/docs/features/command-palette) (`Cmd+K`) runs **actions** (new tab, format SQL, toggle settings). Reach for the omnibar to *find something*, the palette to *do something*.
+
+## Related
+
+- [Command Palette](/docs/features/command-palette) — run actions with `Cmd+K`
+- [Schema Explorer](/docs/features/schema-explorer) — browse the full schema tree
+- [Saved Queries](/docs/features/saved-queries) and [Snippets](/docs/features/snippets) — both searchable here

--- a/apps/docs/content/docs/features/smart-filters.mdx
+++ b/apps/docs/content/docs/features/smart-filters.mdx
@@ -1,11 +1,13 @@
 ---
 title: Smart Filters
-description: Filter query results client-side with a visual filter builder
+description: Filter query results client-side with a visual filter builder — no re-running SQL
 ---
 
 # Smart Filters
 
 Smart Filters let you narrow down query results without rewriting SQL. Filters run client-side on already-fetched data.
+
+That's the whole point: once you've pulled a result set, you can slice it a dozen different ways instantly — no round trip to the database, no editing your `WHERE` clause, no losing your place. It turns a static grid into something you can interrogate the way you'd filter a spreadsheet, which is perfect for exploring unfamiliar data or hunting down the handful of rows that look wrong.
 
 ## Adding a Filter
 
@@ -67,7 +69,19 @@ Add multiple filter chips to narrow results further. All filters are combined wi
 
 Click the **X** on any filter chip to remove it, or click **Clear All** to remove all filters.
 
+## Example: isolating a suspicious subset
+
+You ran `SELECT * FROM users` and something's off with free-plan signups. Instead of editing the query, add two chips: `plan` **equals** `free`, then `email` **contains** `test`. The grid narrows immediately to the rows that match both (filters stack with AND), and [Column Statistics](/docs/features/column-statistics) on the filtered view tells you how many you're dealing with. Clear the chips and the full result is back — the underlying query never re-ran.
+
 <Callout type="tip">
-  Smart Filters are great for exploring a large result set without re-running
-  queries. For server-side filtering, add a WHERE clause to your SQL instead.
+  Smart Filters work on the rows already fetched, so they're instant but bounded
+  by your result set — if a query has a `LIMIT`, you're filtering only those
+  rows. When you need to filter the whole table, add a `WHERE` clause in the
+  [Query Editor](/docs/features/query-editor) instead.
 </Callout>
+
+## Related
+
+- [Results Viewer](/docs/features/results-viewer) — the grid these filters run on
+- [Column Statistics](/docs/features/column-statistics) — profile the rows a filter surfaced
+- [Query Editor](/docs/features/query-editor) — push a filter server-side with `WHERE`


### PR DESCRIPTION
## What

Second batch from the thin-page audit. Each page gains a **why/when intro, a worked example, and cross-links** (additive — no stated facts changed).

| Page | Before → After (prose words) |
|---|---|
| smart-filters | 133 → 251 (+ large operator tables) |
| quick-query | 118 → 305 |
| pg-notifications | 140 → 357 |
| share-as-image | 134 → 310 |
| themes | 118 → 287 |
| sidebar-omnibar | 119 → 344 |
| query-benchmarking | 123 → 341 |

Examples use the acme_saas demo schema; links point only to existing pages. Docs site builds clean.

## ⚠️ Deliberately excluded: `features/settings.mdx`

It **near-duplicates `configuration/settings.mdx`** (both titled "Settings", same content, 117 vs 295 words). Expanding it would create two competing Settings pages and *worsen* the duplicate-content signal — the opposite of the goal. Recommend consolidating instead:
- Keep `configuration/settings.mdx` as canonical (it's fuller), and
- either remove `features/settings.mdx` from the nav, or slim it to a pointer/redirect to the config page.

Happy to do that as a follow-up once you pick a direction.

https://claude.ai/code/session_01Khhdnw9aShE87ALovgMqax

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded theme guidance, including editor synchronization, accessibility considerations, and dark/light usage recommendations.
  * Added PostgreSQL notification examples, payload limits, and related links.
  * Improved query benchmarking guidance around repeated runs, percentiles, and query plans.
  * Clarified Quick Query workflows, recent queries, keyboard shortcuts, and settings.
  * Enhanced Share as Image instructions, sharing examples, and export alternatives.
  * Expanded Sidebar Omnibar navigation guidance and comparisons with Command Palette.
  * Added Smart Filters usage guidance, limitations, and related feature links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->