### PR TITLE
fix: post-release correctness pass (audit chain, MCP audit, pg teardown, DDL contract)

### DIFF
--- a/apps/desktop/src/main/__tests__/audit-capture.test.ts
+++ b/apps/desktop/src/main/__tests__/audit-capture.test.ts
@@ -8,7 +8,8 @@ vi.mock('../lib/logger', () => ({
 
 const mockAdapter = vi.hoisted(() => ({
   execute: vi.fn(),
-  queryMultiple: vi.fn()
+  queryMultiple: vi.fn(),
+  explain: vi.fn().mockResolvedValue({ plan: { cost: 1 }, durationMs: 2 })
 }))
 vi.mock('../db-adapter', () => ({ getAdapter: vi.fn(() => mockAdapter) }))
 vi.mock('../mcp/read-guard', async (importOriginal) => ({
@@ -54,6 +55,17 @@ describe('audit capture', () => {
     await client.callTool({ name: 'run_query', arguments: { connectionId: 'c1', sql: 'SELECT 1' } })
     expect(recordAudit).toHaveBeenCalledWith(
       expect.objectContaining({ source: 'mcp', sql: 'SELECT 1', success: true, rowCount: 1 })
+    )
+  })
+
+  it('mcp explain_query records an mcp entry on success', async () => {
+    const client = await connectedClient(new ApprovalManager(() => undefined))
+    await client.callTool({
+      name: 'explain_query',
+      arguments: { connectionId: 'c1', sql: 'SELECT 1' }
+    })
+    expect(recordAudit).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'mcp', sql: 'SELECT 1', success: true })
     )
   })
 

--- a/apps/desktop/src/main/__tests__/audit-storage.test.ts
+++ b/apps/desktop/src/main/__tests__/audit-storage.test.ts
@@ -129,6 +129,31 @@ describe.skipIf(!sqliteAvailable)('AuditStorage', () => {
     expect(store.verify()).toEqual({ valid: true, entries: 2 })
   })
 
+  it('prune keeps the chain valid when a backward clock change makes ts order differ from insertion order', () => {
+    vi.useFakeTimers()
+    try {
+      const recordAt = (iso: string): void => {
+        vi.setSystemTime(new Date(iso))
+        store.record(entry({ sql: iso }))
+      }
+      recordAt('2020-01-01T00:00:00.000Z') // id 1
+      recordAt('2020-01-02T00:00:00.000Z') // id 2
+      recordAt('2020-01-10T00:00:00.000Z') // id 3
+      recordAt('2020-01-05T00:00:00.000Z') // id 4 — clock jumped back, ts earlier than id 3
+      recordAt('2020-01-20T00:00:00.000Z') // id 5
+      expect(store.verify().valid).toBe(true)
+
+      // cutoff = now - 25d = 2020-01-07. `ts < cutoff` matches id 1, 2, 4 but not id 3,
+      // so a ts-keyed delete would leave id 3 as a hole below the re-anchor point and
+      // orphan the survivors from the chain anchor — verify() must still pass.
+      vi.setSystemTime(new Date('2020-02-01T00:00:00.000Z'))
+      store.prune(25)
+      expect(store.verify().valid).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('exports JSON and CSV with correct shapes', () => {
     store.record(entry({ sql: 'SELECT "quoted", comma' }))
     const jsonPath = join(dir, 'out.json')

--- a/apps/desktop/src/main/__tests__/ddl-handlers.test.ts
+++ b/apps/desktop/src/main/__tests__/ddl-handlers.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { ConnectionConfig } from '@shared/index'
+
+type Handler = (event: unknown, ...args: unknown[]) => unknown
+
+const { handlers, adapter, invalidateSchemaCache, recordAudit } = vi.hoisted(() => ({
+  handlers: new Map<string, Handler>(),
+  adapter: { executeTransaction: vi.fn() },
+  invalidateSchemaCache: vi.fn(),
+  recordAudit: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: vi.fn((channel: string, handler: Handler) => handlers.set(channel, handler)) }
+}))
+vi.mock('../db-adapter', () => ({ getAdapter: () => adapter }))
+vi.mock('../schema-cache', () => ({ invalidateSchemaCache }))
+vi.mock('../audit-service', () => ({ recordAudit }))
+vi.mock('../ddl-builder', () => ({
+  buildCreateTable: () => ({ sql: 'CREATE TABLE t ()' }),
+  buildAlterTable: () => [{ sql: 'ALTER TABLE t ADD COLUMN c int' }],
+  buildDropTable: () => ({ sql: 'DROP TABLE t' }),
+  buildPreviewDDL: () => ({ sql: '' }),
+  validateTableDefinition: () => ({ valid: true, errors: [] })
+}))
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}))
+
+import { registerDDLHandlers } from '../ipc/ddl-handlers'
+
+const config = {
+  id: 'c1',
+  name: 'db',
+  dbType: 'postgresql',
+  host: 'h',
+  port: 5432,
+  database: 'd',
+  dstPort: 5432
+} as unknown as ConnectionConfig
+
+const invoke = (channel: string, args: unknown): Promise<{ success: boolean; error?: string }> =>
+  handlers.get(channel)!({}, args) as Promise<{ success: boolean; error?: string }>
+
+beforeEach(() => {
+  handlers.clear()
+  adapter.executeTransaction.mockReset()
+  recordAudit.mockReset()
+  registerDDLHandlers()
+})
+
+describe('DDL handler error contract', () => {
+  // A failed DDL statement must surface as success:false on the IPC envelope — the
+  // renderer keys off response.success, so returning success:true on failure would
+  // report a failed CREATE/ALTER/DROP as if it had worked.
+  it('create-table returns success:false when the transaction throws', async () => {
+    adapter.executeTransaction.mockRejectedValue(new Error('create boom'))
+    const res = await invoke('db:create-table', {
+      config,
+      definition: { schema: 'public', name: 't', columns: [] }
+    })
+    expect(res.success).toBe(false)
+    expect(res.error).toContain('create boom')
+  })
+
+  it('alter-table returns success:false when the transaction throws', async () => {
+    adapter.executeTransaction.mockRejectedValue(new Error('alter boom'))
+    const res = await invoke('db:alter-table', {
+      config,
+      batch: { schema: 'public', table: 't', operations: [] }
+    })
+    expect(res.success).toBe(false)
+    expect(res.error).toContain('alter boom')
+  })
+
+  it('drop-table returns success:false when the transaction throws', async () => {
+    adapter.executeTransaction.mockRejectedValue(new Error('drop boom'))
+    const res = await invoke('db:drop-table', { config, schema: 'public', table: 't' })
+    expect(res.success).toBe(false)
+    expect(res.error).toContain('drop boom')
+  })
+})

--- a/apps/desktop/src/main/__tests__/pg-pool-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/pg-pool-manager.test.ts
@@ -145,6 +145,25 @@ describe('closeAllPgPools', () => {
     expect(PoolCtor.mock.calls.length).toBe(beforeClose + 1)
   })
 
+  it('does not wedge when a pool.end() hangs (bounded teardown)', async () => {
+    vi.useFakeTimers()
+    try {
+      await withPgClient(makeConfig(), async () => {})
+      // A client stuck on a server-side lock keeps pool.end() pending forever.
+      mockPool.end.mockReturnValueOnce(new Promise<void>(() => {}))
+
+      const closed = closeAllPgPools()
+      await vi.advanceTimersByTimeAsync(2_500)
+      await expect(closed).resolves.toBeUndefined()
+
+      // The manager must be reusable, not latched on the hung teardown.
+      mockPool.end.mockResolvedValue(undefined)
+      await expect(withPgClient(makeConfig(), async () => 'ok')).resolves.toBe('ok')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('coalesces concurrent teardown calls without wedging the guard', async () => {
     await withPgClient(makeConfig(), async () => {})
 

--- a/apps/desktop/src/main/adapters/pg-pool-manager.ts
+++ b/apps/desktop/src/main/adapters/pg-pool-manager.ts
@@ -23,6 +23,11 @@ interface PoolEntry {
 const POOL_MAX = 5
 const IDLE_TIMEOUT_MS = 30_000
 const CONNECT_TIMEOUT_MS = 15_000
+// pool.end() blocks until every checked-out client is released, so an ad-hoc query
+// stuck on a server-side lock (or a dead socket) would otherwise hang teardown
+// indefinitely — leaving `shuttingDown` latched and every later acquisition failing
+// with "Pool manager is shutting down". Bound each end() so teardown always completes.
+const POOL_END_TIMEOUT_MS = 2_500
 
 const pools = new Map<string, PoolEntry>()
 // Tracks in-flight pool creation so concurrent first-use callers share one tunnel/pool.
@@ -233,6 +238,24 @@ export async function closePgPool(config: ConnectionConfig): Promise<void> {
  * process dying. If the flag stayed latched, every later pool acquisition would
  * fail with "Pool manager is shutting down" until relaunch.
  */
+// Await pool.end() but never longer than POOL_END_TIMEOUT_MS. A stuck client keeps
+// end() pending forever; letting teardown move on unblocks the manager's state reset
+// (the pg socket handle is the OS's to clean up on exit).
+async function endPoolBounded(pool: Pool): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  try {
+    await Promise.race([
+      pool.end(),
+      new Promise<void>((resolve) => {
+        timer = setTimeout(resolve, POOL_END_TIMEOUT_MS)
+        timer.unref?.()
+      })
+    ])
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+}
+
 export async function closeAllPgPools(): Promise<void> {
   // Coalesce concurrent calls onto one teardown, so a second call's `finally`
   // can't flip `shuttingDown` back to false while the first is still tearing down.
@@ -251,7 +274,7 @@ export async function closeAllPgPools(): Promise<void> {
       await Promise.all(
         entries.map(async (entry) => {
           try {
-            await entry.pool.end()
+            await endPoolBounded(entry.pool)
           } catch (err) {
             log.warn('error ending pool:', (err as Error).message)
           }

--- a/apps/desktop/src/main/audit-storage.ts
+++ b/apps/desktop/src/main/audit-storage.ts
@@ -230,17 +230,23 @@ export class AuditStorage {
   prune(maxAgeDays: number): number {
     const cutoff = new Date(Date.now() - maxAgeDays * 24 * 3600 * 1000).toISOString()
     const runPrune = this.db.transaction((cutoffTs: string) => {
-      const last = this.db
-        .prepare('SELECT hash FROM audit_log WHERE ts < ? ORDER BY id DESC LIMIT 1')
-        .get(cutoffTs) as { hash: string } | undefined
-      if (!last) return 0
-      const result = this.db.prepare('DELETE FROM audit_log WHERE ts < ?').run(cutoffTs)
+      // The hash chain is ordered by id, so pruning must remove a contiguous id-prefix
+      // and re-anchor to the last removed row's hash. Deleting `WHERE ts < cutoff`
+      // directly would leave a hole if a backward clock change made an earlier-inserted
+      // row's ts newer than a later one — the survivors would be orphaned from the anchor
+      // and verify() would fail permanently. So pick the boundary as the highest id whose
+      // ts is older than the cutoff, then delete by id up to (and including) that boundary.
+      const boundary = this.db
+        .prepare('SELECT id, hash FROM audit_log WHERE ts < ? ORDER BY id DESC LIMIT 1')
+        .get(cutoffTs) as { id: number; hash: string } | undefined
+      if (!boundary) return 0
+      const result = this.db.prepare('DELETE FROM audit_log WHERE id <= ?').run(boundary.id)
       this.db
         .prepare(
           "INSERT INTO audit_meta (key, value) VALUES ('chainAnchor', ?) " +
             'ON CONFLICT(key) DO UPDATE SET value = excluded.value'
         )
-        .run(last.hash)
+        .run(boundary.hash)
       return result.changes
     })
     return runPrune(cutoff)

--- a/apps/desktop/src/main/ipc/ddl-handlers.ts
+++ b/apps/desktop/src/main/ipc/ddl-handlers.ts
@@ -135,8 +135,6 @@ export function registerDDLHandlers(): void {
       } catch (error: unknown) {
         log.error('Alter table error:', error)
         const errorMessage = error instanceof Error ? error.message : String(error)
-        result.errors!.push(errorMessage)
-        result.success = false
         recordAudit({
           source: 'ddl',
           connectionId: config.id ?? 'unsaved',
@@ -147,7 +145,9 @@ export function registerDDLHandlers(): void {
           success: false,
           error: errorMessage
         })
-        return { success: true, data: result }
+        // Surface failure on the envelope like create-table/drop-table — the renderer
+        // keys off response.success, so returning success:true here would hide a failed ALTER.
+        return { success: false, error: errorMessage }
       }
     }
   )

--- a/apps/desktop/src/main/mcp/tools.ts
+++ b/apps/desktop/src/main/mcp/tools.ts
@@ -139,8 +139,34 @@ export function registerMcpTools(server: McpServer, deps: McpToolDeps): void {
       withToolErrors(async () => {
         const conn = findConnection(deps, connectionId)
         const stmt = assertSingleReadStatement(sql, conn.dbType || 'postgresql')
-        const result = await getAdapter(conn).explain(conn, stmt, false)
-        return ok(result.plan)
+        const started = Date.now()
+        try {
+          const result = await getAdapter(conn).explain(conn, stmt, false)
+          recordAudit({
+            source: 'mcp',
+            connectionId: conn.id ?? 'unsaved',
+            connectionName: conn.name ?? conn.database,
+            dbType: conn.dbType || 'postgresql',
+            sql,
+            rowCount: null,
+            success: true,
+            durationMs: Date.now() - started
+          })
+          return ok(result.plan)
+        } catch (err) {
+          recordAudit({
+            source: 'mcp',
+            connectionId: conn.id ?? 'unsaved',
+            connectionName: conn.name ?? conn.database,
+            dbType: conn.dbType || 'postgresql',
+            sql,
+            rowCount: null,
+            success: false,
+            error: err instanceof Error ? err.message : String(err),
+            durationMs: Date.now() - started
+          })
+          throw err
+        }
       })
   )
 


### PR DESCRIPTION
## Post-release correctness pass

A bug-hunt over the code shipped in v0.26 (MCP server, tamper-evident audit log, pg pool manager) surfaced four independent latent bugs. Each fix here is small, self-contained, and lands with a regression test that fails without it. **Not merging on your say-so** — opening for review.

### Fixes (one commit each)

1. **`fix(ddl)` — alter-table failure reported as success.**
   `db:alter-table`'s catch block returned `{ success: true, data: result }` on failure, unlike `db:create-table`/`db:drop-table` which correctly return `{ success: false, error }`. The renderer keys off `response.success`, so a failed `ALTER` would read as a success. Currently *latent* — see finding **A** below, `alterTable` is never called from the renderer — but the contract inconsistency is real and this handler should behave like its siblings before anything wires it up.

2. **`fix(audit)` — clock skew could permanently corrupt the hash chain.**
   `prune()` selected its re-anchor row and deleted rows both keyed on `ts`, but the chain verifies by `id`. A backward clock change (NTP correction after sleep/wake, manual clock edit) can make an earlier-inserted row's `ts` newer than a later row's, so a `ts`-keyed `DELETE` leaves a hole below the new anchor and orphans the survivors — `verify()` then fails **permanently on an untampered log**. Now prunes a contiguous `id`-prefix and anchors to the boundary row.

3. **`fix(mcp)` — `explain_query` wrote nothing to the audit log.**
   `run_query` and `execute_statement` both record every call; `explain_query` (which runs a real `EXPLAIN` against the DB) recorded nothing, leaving a gap in the "tamper-evident" trail for anything routed through that tool. Records success and failure the same way `run_query` does.

4. **`fix(pg)` — a stuck `pool.end()` could wedge the pool manager.**
   `closeAllPgPools()` awaited `pool.end()` with no timeout. `end()` blocks until every checked-out client is released, so an ad-hoc query stuck on a server-side lock or a dead socket hung teardown indefinitely — leaving the module-global `shuttingDown` latched in practice, so every later acquisition failed with **"Pool manager is shutting down"** (same class as the prod incident fixed transiently in #222). Each `end()` now races a bounded timer so teardown always completes and the manager resets.

### Test coverage
- `ddl-handlers.test.ts` (new): all three DDL handlers return `success:false` when the transaction throws.
- `audit-storage.test.ts`: clock-skew prune keeps `verify()` valid (runs under Electron ABI).
- `audit-capture.test.ts`: `explain_query` records an mcp audit entry.
- `pg-pool-manager.test.ts`: a hung `pool.end()` doesn't wedge teardown; manager stays reusable.

Full main-process suite: **472 passed**, no regressions. `typecheck:node` clean. Desktop lint clean.

### Deferred — bigger findings needing your call (not in this PR)
These came out of the same hunt but are judgment calls (product/design or larger scope), written up separately rather than fixed autonomously:

- **A. Table Designer "Edit Table" never issues `ALTER` — it always issues `CREATE TABLE`.** `handleSave` unconditionally calls `createTable`, even in edit mode (right-click table → "Edit Table" → "Save Changes"). Best case a hard "relation already exists" error; worse, a renamed-then-saved table silently creates a *new* table and leaves the original untouched while the UI reports success. The correct fix is an ALTER-diff engine (old vs edited definition → add/drop/alter/rename ops) with rename-detection and per-dialect handling, run against live tables — that wants your design input and real DB integration tests.
- **B. Manual-transaction writes are audited `success:true` before commit; rollback logs nothing.** With auto-commit off, a `DELETE` is recorded as successful the moment it runs inside the open transaction; a later rollback (or tab close, or failed commit) leaves the audit log asserting a delete that never persisted. This is an audit-semantics decision (defer recording to commit? log rollback events?).
- **C. MCP read-guard is a keyword blacklist.** `SELECT pg_terminate_backend(...)` / `pg_sleep(...)` pass the guard and run for real inside the "read-only" transaction; and MySQL/MSSQL have no rollback wrapper at all (only Postgres implements the transaction methods), while the tool description promises "always rolled back". Mitigations (statement_timeout, honest per-dialect wording) are worth discussing.

Full write-up in the session; happy to open follow-up PRs for any of these once you've weighed in.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added audit tracking for successful and failed MCP query explanations, including execution timing.

* **Bug Fixes**
  * Database table alterations now correctly report failures instead of appearing successful.
  * Database shutdown remains responsive when connection pool cleanup hangs.
  * Audit history pruning now preserves hash-chain integrity, including after system clock changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->