### PR TITLE
harden: audit transaction boundaries + MCP read-guard (deferred findings B & C)

### DIFF
--- a/apps/desktop/src/main/__tests__/mcp-read-guard.test.ts
+++ b/apps/desktop/src/main/__tests__/mcp-read-guard.test.ts
@@ -97,10 +97,11 @@ describe('runReadOnlyQuery', () => {
     mockAdapter.rollbackTransaction.mockResolvedValue(undefined)
   })
 
-  it('runs postgres queries in a read-only transaction and rolls back', async () => {
+  it('runs postgres queries read-only, bounds them with a statement timeout, and rolls back', async () => {
     mockAdapter.queryInTransaction
-      .mockResolvedValueOnce({ rows: [], fields: [], rowCount: null })
-      .mockResolvedValueOnce({ rows: [{ n: 1 }], fields: [], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [], fields: [], rowCount: null }) // SET TRANSACTION READ ONLY
+      .mockResolvedValueOnce({ rows: [], fields: [], rowCount: null }) // SET LOCAL statement_timeout
+      .mockResolvedValueOnce({ rows: [{ n: 1 }], fields: [], rowCount: 1 }) // the query
 
     const result = await runReadOnlyQuery(pgConfig, 'SELECT 1')
 
@@ -111,13 +112,20 @@ describe('runReadOnlyQuery', () => {
       expect.any(String),
       'SET TRANSACTION READ ONLY'
     )
+    expect(mockAdapter.queryInTransaction).toHaveBeenNthCalledWith(
+      2,
+      pgConfig,
+      expect.any(String),
+      expect.stringContaining('statement_timeout')
+    )
     expect(mockAdapter.rollbackTransaction).toHaveBeenCalledOnce()
     expect(result.rows).toEqual([{ n: 1 }])
   })
 
   it('rolls back even when the query throws', async () => {
     mockAdapter.queryInTransaction
-      .mockResolvedValueOnce({ rows: [], fields: [], rowCount: null })
+      .mockResolvedValueOnce({ rows: [], fields: [], rowCount: null }) // SET TRANSACTION READ ONLY
+      .mockResolvedValueOnce({ rows: [], fields: [], rowCount: null }) // SET LOCAL statement_timeout
       .mockRejectedValueOnce(new Error('syntax error'))
 
     await expect(runReadOnlyQuery(pgConfig, 'SELECT oops')).rejects.toThrow('syntax error')
@@ -127,7 +135,8 @@ describe('runReadOnlyQuery', () => {
   it('caps returned rows at maxRows', async () => {
     const rows = Array.from({ length: 600 }, (_, i) => ({ i }))
     mockAdapter.queryInTransaction
-      .mockResolvedValueOnce({ rows: [], fields: [], rowCount: null })
+      .mockResolvedValueOnce({ rows: [], fields: [], rowCount: null }) // SET TRANSACTION READ ONLY
+      .mockResolvedValueOnce({ rows: [], fields: [], rowCount: null }) // SET LOCAL statement_timeout
       .mockResolvedValueOnce({ rows, fields: [], rowCount: 600 })
 
     const result = await runReadOnlyQuery(pgConfig, 'SELECT * FROM big')

--- a/apps/desktop/src/main/__tests__/transaction-audit.test.ts
+++ b/apps/desktop/src/main/__tests__/transaction-audit.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { ConnectionConfig } from '@shared/index'
+
+type Handler = (event: unknown, ...args: unknown[]) => unknown
+
+const { handlers, adapter, recordAudit } = vi.hoisted(() => ({
+  handlers: new Map<string, Handler>(),
+  adapter: {
+    beginTransaction: vi.fn(),
+    commitTransaction: vi.fn(),
+    rollbackTransaction: vi.fn()
+  },
+  recordAudit: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: (channel: string, handler: Handler) => handlers.set(channel, handler) }
+}))
+vi.mock('../db-adapter', () => ({ getAdapter: () => adapter }))
+vi.mock('../schema-cache', () => ({
+  getCachedSchema: vi.fn(),
+  isCacheValid: vi.fn(),
+  getOrFetchCachedSchema: vi.fn(),
+  invalidateSchemaCache: vi.fn()
+}))
+vi.mock('../lib/ssl-error', () => ({ annotateSslError: (e: Error) => e }))
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}))
+vi.mock('../audit-service', () => ({ recordAudit }))
+
+import { registerQueryHandlers } from '../ipc/query-handlers'
+
+const config = {
+  id: 'c1',
+  name: 'local',
+  database: 'app',
+  dbType: 'postgresql'
+} as unknown as ConnectionConfig
+
+const invoke = (channel: string): Promise<unknown> =>
+  handlers.get(channel)!(null, { config, sessionId: 's1' }) as Promise<unknown>
+
+beforeEach(() => {
+  handlers.clear()
+  adapter.beginTransaction.mockReset().mockResolvedValue(undefined)
+  adapter.commitTransaction.mockReset().mockResolvedValue(undefined)
+  adapter.rollbackTransaction.mockReset().mockResolvedValue(undefined)
+  recordAudit.mockReset()
+  registerQueryHandlers()
+})
+
+describe('manual transaction audit boundaries', () => {
+  it('records BEGIN when a manual transaction starts', async () => {
+    await invoke('db:begin-transaction')
+    expect(recordAudit).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'editor', sql: 'BEGIN', success: true })
+    )
+  })
+
+  it('records COMMIT when a manual transaction commits', async () => {
+    await invoke('db:commit-transaction')
+    expect(recordAudit).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'editor', sql: 'COMMIT', success: true })
+    )
+  })
+
+  it('records ROLLBACK so a rolled-back write is visible in the trail', async () => {
+    await invoke('db:rollback-transaction')
+    expect(recordAudit).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'editor', sql: 'ROLLBACK', success: true })
+    )
+  })
+
+  it('records a failed commit as unsuccessful with the error', async () => {
+    adapter.commitTransaction.mockRejectedValue(new Error('commit failed'))
+    await invoke('db:commit-transaction')
+    expect(recordAudit).toHaveBeenCalledWith(
+      expect.objectContaining({ sql: 'COMMIT', success: false, error: 'commit failed' })
+    )
+  })
+})

--- a/apps/desktop/src/main/ipc/query-handlers.ts
+++ b/apps/desktop/src/main/ipc/query-handlers.ts
@@ -26,6 +26,28 @@ import { recordAudit } from '../audit-service'
 
 const log = createLogger('query-handlers')
 
+// Record a manual-transaction boundary (BEGIN/COMMIT/ROLLBACK) in the audit log.
+// Without this a rolled-back write is indistinguishable in the trail from a
+// committed one — the per-statement entries look identical either way, so the
+// outcome events are what make the tamper-evident log forensically complete.
+function recordTxBoundary(
+  config: ConnectionConfig,
+  boundary: 'BEGIN' | 'COMMIT' | 'ROLLBACK',
+  success: boolean,
+  error?: string
+): void {
+  recordAudit({
+    source: 'editor',
+    connectionId: config.id ?? 'unsaved',
+    connectionName: config.name ?? config.database,
+    dbType: config.dbType || 'postgresql',
+    sql: boundary,
+    rowCount: null,
+    success,
+    ...(error ? { error } : {})
+  })
+}
+
 /**
  * Register database query and schema handlers
  */
@@ -615,12 +637,15 @@ export function registerQueryHandlers(): void {
         const adapter = getAdapter(config)
         if (adapter.beginTransaction) {
           await adapter.beginTransaction(config, sessionId)
+          recordTxBoundary(config, 'BEGIN', true)
           return { success: true }
         } else {
           return { success: false, error: 'Transactions not supported for this database type.' }
         }
       } catch (error: unknown) {
-        return { success: false, error: error instanceof Error ? error.message : String(error) }
+        const errorMessage = error instanceof Error ? error.message : String(error)
+        recordTxBoundary(config, 'BEGIN', false, errorMessage)
+        return { success: false, error: errorMessage }
       }
     }
   )
@@ -632,11 +657,14 @@ export function registerQueryHandlers(): void {
         const adapter = getAdapter(config)
         if (adapter.commitTransaction) {
           await adapter.commitTransaction(config, sessionId)
+          recordTxBoundary(config, 'COMMIT', true)
           return { success: true }
         }
         return { success: false, error: 'Transactions not supported.' }
       } catch (error: unknown) {
-        return { success: false, error: error instanceof Error ? error.message : String(error) }
+        const errorMessage = error instanceof Error ? error.message : String(error)
+        recordTxBoundary(config, 'COMMIT', false, errorMessage)
+        return { success: false, error: errorMessage }
       }
     }
   )
@@ -648,11 +676,14 @@ export function registerQueryHandlers(): void {
         const adapter = getAdapter(config)
         if (adapter.rollbackTransaction) {
           await adapter.rollbackTransaction(config, sessionId)
+          recordTxBoundary(config, 'ROLLBACK', true)
           return { success: true }
         }
         return { success: false, error: 'Transactions not supported.' }
       } catch (error: unknown) {
-        return { success: false, error: error instanceof Error ? error.message : String(error) }
+        const errorMessage = error instanceof Error ? error.message : String(error)
+        recordTxBoundary(config, 'ROLLBACK', false, errorMessage)
+        return { success: false, error: errorMessage }
       }
     }
   )

--- a/apps/desktop/src/main/mcp/read-guard.ts
+++ b/apps/desktop/src/main/mcp/read-guard.ts
@@ -4,6 +4,12 @@ import { getAdapter, type AdapterQueryResult } from '../db-adapter'
 import { parseStatementsWithLines } from '../lib/parse-statements'
 
 export const MCP_MAX_ROWS = 500
+// Bound how long a single MCP read may run on PostgreSQL. The read-only keyword
+// guard can't catch side-effecting or slow functions inside a SELECT (e.g.
+// pg_sleep), and the row cap is applied after the full result is fetched — a
+// statement timeout puts a hard ceiling on both a runaway query and a
+// SELECT pg_sleep(600) DoS through a tool advertised as safe.
+export const MCP_READ_TIMEOUT_MS = 30_000
 
 const READ_FIRST_KEYWORDS = new Set([
   'select',
@@ -48,6 +54,12 @@ export async function runReadOnlyQuery(
     try {
       if (dbType === 'postgresql') {
         await adapter.queryInTransaction(config, sessionId, 'SET TRANSACTION READ ONLY')
+        // SET LOCAL is scoped to this transaction, which is always rolled back.
+        await adapter.queryInTransaction(
+          config,
+          sessionId,
+          `SET LOCAL statement_timeout = ${MCP_READ_TIMEOUT_MS}`
+        )
       }
       const result = await adapter.queryInTransaction(config, sessionId, stmt)
       return { ...result, rows: result.rows.slice(0, cap) }

--- a/apps/desktop/src/main/mcp/tools.ts
+++ b/apps/desktop/src/main/mcp/tools.ts
@@ -88,7 +88,7 @@ export function registerMcpTools(server: McpServer, deps: McpToolDeps): void {
   server.registerTool(
     'run_query',
     {
-      description: `Run a single read-only SQL statement. Executes inside a transaction that is always rolled back; PostgreSQL additionally enforces READ ONLY at the database level. Rows are capped at ${MCP_MAX_ROWS}. Use execute_statement for writes/DDL.`,
+      description: `Run a single read-only SQL statement. On PostgreSQL it runs inside a READ ONLY transaction that is always rolled back and bounded by a statement timeout; on MySQL/SQL Server it is checked by a read-only statement guard (best-effort — a side-effecting function inside a SELECT can still run). Rows are capped at ${MCP_MAX_ROWS}. Use execute_statement for writes/DDL.`,
       inputSchema: {
         connectionId: z.string(),
         sql: z.string(),


### PR DESCRIPTION
## Hardening pass — deferred bug-hunt findings B & C

The two audit/MCP findings I'd flagged as "needs a call" — addressed with the **objective, additive** fix in each case, leaving the genuinely subjective parts (removing existing entries, implementing MySQL/MSSQL transaction wrappers, marketing wording) out. Base `main`; independent of #227/#228.

### B — audit trail for manual transactions (`fix(audit)`)
With auto-commit off, each statement in an open transaction was recorded `success:true` the moment it executed, but **commit/rollback wrote nothing** — so a `DELETE` that was later rolled back appeared in the tamper-evident trail as a completed delete with no compensating entry.

Fix: record the transaction **boundary** events — `BEGIN` / `COMMIT` / `ROLLBACK`, including failed commits — so the outcome is always visible. The per-statement entries are unchanged (the statement *did* execute); the trail is just now complete and unambiguous. This is additive — it doesn't touch or remove anything already recorded, so it doesn't foreclose a future "defer recording until commit" design if you'd prefer that.

### C — MCP read guard: bound reads + honest description (`harden(mcp)`)
The read-only guard is a keyword blacklist, so a slow or side-effecting function inside a `SELECT` (e.g. `pg_sleep(600)`, or a runaway full scan) slips through, and the 500-row cap is applied only *after* the full result is fetched.

- **Statement timeout:** add `SET LOCAL statement_timeout = 30000` to the PostgreSQL read-only transaction (scoped to the always-rolled-back tx). Puts a hard ceiling on runaway/DoS reads. *Partial* mitigation — it bounds slowness, not instant side-effects like `pg_terminate_backend()`; fully closing that needs a semantic allow-list, which is a bigger design call.
- **Honest `run_query` description:** it claimed reads are "always rolled back", but only PostgreSQL gets the rolled-back transaction — MySQL/SQL Server fall back to the best-effort keyword guard with **no** transaction. The description now says so (developer/agent-facing accuracy, not marketing).

### Still deferred (genuinely need your decision)
- Implementing real rolled-back-transaction wrapping for the MySQL/MSSQL adapters (so all three dbs get the same guarantee), vs. keeping the honest "best-effort" wording.
- A semantic read allow-list to close the side-effecting-function hole entirely.

### Tests
`transaction-audit.test.ts` (new, 4 cases): BEGIN/COMMIT/ROLLBACK recorded, failed commit recorded as unsuccessful. `mcp-read-guard.test.ts` updated: asserts the statement timeout is applied in the read-only transaction. Full main suite green, `typecheck:node` clean, lint clean on all changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Read-only PostgreSQL queries now automatically enforce a 30-second execution limit.
  * PostgreSQL read queries remain isolated and are rolled back after execution.

* **Improvements**
  * Transaction activity now records successful and failed begin, commit, and rollback operations for improved audit visibility.
  * Query guidance now clearly explains read-only safeguards, execution limits, row limits, and when to use write operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->