### PR TITLE
feat: Table Designer edit mode issues ALTER instead of CREATE

### DIFF
--- a/apps/desktop/src/main/__tests__/diff-table.test.ts
+++ b/apps/desktop/src/main/__tests__/diff-table.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from 'vitest'
+import { diffTableDefinitions } from '@shared/index'
+import type { ColumnDefinition, TableDefinition, AlterColumnOperation } from '@shared/index'
+
+function col(overrides: Partial<ColumnDefinition> = {}): ColumnDefinition {
+  return {
+    id: 'col-0',
+    name: 'id',
+    dataType: 'integer',
+    isNullable: false,
+    isPrimaryKey: false,
+    isUnique: false,
+    ...overrides
+  }
+}
+
+function table(overrides: Partial<TableDefinition> = {}): TableDefinition {
+  return {
+    schema: 'public',
+    name: 'users',
+    columns: [col()],
+    constraints: [],
+    indexes: [],
+    ...overrides
+  }
+}
+
+// Clone so the "edited" definition is a distinct object graph, like the store's
+// structuredClone of the loaded definition.
+const clone = (t: TableDefinition): TableDefinition => structuredClone(t)
+
+function ops(result: ReturnType<typeof diffTableDefinitions>): AlterColumnOperation[] {
+  if (result.kind !== 'batch') throw new Error(`expected batch, got ${result.kind}`)
+  return result.batch.columnOperations
+}
+
+describe('diffTableDefinitions', () => {
+  it('returns noop when nothing changed', () => {
+    const original = table()
+    expect(diffTableDefinitions(original, clone(original)).kind).toBe('noop')
+  })
+
+  it('detects an added column', () => {
+    const original = table()
+    const edited = clone(original)
+    edited.columns.push(col({ id: 'col-new', name: 'email', dataType: 'text', isNullable: true }))
+    expect(ops(diffTableDefinitions(original, edited))).toEqual([
+      { type: 'add', column: expect.objectContaining({ name: 'email' }) }
+    ])
+  })
+
+  it('detects a dropped column by its stable id', () => {
+    const original = table({
+      columns: [col(), col({ id: 'col-1', name: 'email', dataType: 'text' })]
+    })
+    const edited = clone(original)
+    edited.columns = edited.columns.filter((c) => c.id !== 'col-1')
+    expect(ops(diffTableDefinitions(original, edited))).toEqual([
+      { type: 'drop', columnName: 'email' }
+    ])
+  })
+
+  it('detects a rename (matched by id, not name heuristics)', () => {
+    const original = table({ columns: [col({ id: 'col-0', name: 'name' })] })
+    const edited = clone(original)
+    edited.columns[0].name = 'full_name'
+    expect(ops(diffTableDefinitions(original, edited))).toEqual([
+      { type: 'rename', oldName: 'name', newName: 'full_name' }
+    ])
+  })
+
+  it('emits rename before set_type and set_type uses the new name', () => {
+    const original = table({ columns: [col({ id: 'col-0', name: 'amount', dataType: 'integer' })] })
+    const edited = clone(original)
+    edited.columns[0].name = 'total'
+    edited.columns[0].dataType = 'numeric'
+    edited.columns[0].precision = 10
+    edited.columns[0].scale = 2
+    expect(ops(diffTableDefinitions(original, edited))).toEqual([
+      { type: 'rename', oldName: 'amount', newName: 'total' },
+      { type: 'set_type', columnName: 'total', newType: 'numeric(10,2)' }
+    ])
+  })
+
+  it('detects a nullability change', () => {
+    const original = table({ columns: [col({ id: 'col-0', name: 'name', isNullable: false })] })
+    const edited = clone(original)
+    edited.columns[0].isNullable = true
+    expect(ops(diffTableDefinitions(original, edited))).toEqual([
+      { type: 'set_nullable', columnName: 'name', nullable: true }
+    ])
+  })
+
+  it('sets and drops a default value', () => {
+    const original = table({ columns: [col({ id: 'col-0', name: 'status', dataType: 'text' })] })
+    const setEdited = clone(original)
+    setEdited.columns[0].defaultValue = "'active'"
+    setEdited.columns[0].defaultType = 'value'
+    expect(ops(diffTableDefinitions(original, setEdited))).toEqual([
+      { type: 'set_default', columnName: 'status', defaultValue: "'active'" }
+    ])
+
+    const withDefault = clone(setEdited)
+    const dropEdited = clone(original) // back to no default
+    expect(ops(diffTableDefinitions(withDefault, dropEdited))).toEqual([
+      { type: 'set_default', columnName: 'status', defaultValue: null }
+    ])
+  })
+
+  it('renders a sequence default as nextval()', () => {
+    const original = table({ columns: [col({ id: 'col-0', name: 'id' })] })
+    const edited = clone(original)
+    edited.columns[0].defaultType = 'sequence'
+    edited.columns[0].sequenceName = 'users_id_seq'
+    edited.columns[0].defaultValue = 'users_id_seq'
+    expect(ops(diffTableDefinitions(original, edited))).toEqual([
+      { type: 'set_default', columnName: 'id', defaultValue: "nextval('users_id_seq')" }
+    ])
+  })
+
+  it('detects a column comment change', () => {
+    const original = table({ columns: [col({ id: 'col-0', name: 'email', dataType: 'text' })] })
+    const edited = clone(original)
+    edited.columns[0].comment = 'primary email'
+    expect(ops(diffTableDefinitions(original, edited))).toEqual([
+      { type: 'set_comment', columnName: 'email', comment: 'primary email' }
+    ])
+  })
+
+  it('detects a table comment change', () => {
+    const original = table()
+    const edited = clone(original)
+    edited.comment = 'the users table'
+    const result = diffTableDefinitions(original, edited)
+    if (result.kind !== 'batch') throw new Error('expected batch')
+    expect(result.batch.comment).toBe('the users table')
+    expect(result.batch.columnOperations).toEqual([])
+  })
+
+  it('treats a bare column reorder as a noop (Postgres cannot reorder columns)', () => {
+    const original = table({
+      columns: [col({ id: 'col-0', name: 'a' }), col({ id: 'col-1', name: 'b', dataType: 'text' })]
+    })
+    const edited = clone(original)
+    edited.columns.reverse()
+    expect(diffTableDefinitions(original, edited).kind).toBe('noop')
+  })
+
+  it.each([
+    ['table rename', (t: TableDefinition) => (t.name = 'renamed')],
+    ['schema move', (t: TableDefinition) => (t.schema = 'archive')],
+    ['unlogged toggle', (t: TableDefinition) => (t.unlogged = true)],
+    ['primary key toggle', (t: TableDefinition) => (t.columns[0].isPrimaryKey = true)],
+    ['unique toggle', (t: TableDefinition) => (t.columns[0].isUnique = true)],
+    ['collation change', (t: TableDefinition) => (t.columns[0].collation = 'C')],
+    ['check change', (t: TableDefinition) => (t.columns[0].checkConstraint = 'id > 0')],
+    [
+      'constraint edit',
+      (t: TableDefinition) => t.constraints.push({ id: 'c1', type: 'unique', columns: ['id'] })
+    ],
+    [
+      'index edit',
+      (t: TableDefinition) =>
+        t.indexes.push({ id: 'i1', columns: [{ name: 'id' }], isUnique: false })
+    ]
+  ])('refuses %s as unsupported (never silently mis-applies)', (_label, mutate) => {
+    const original = table()
+    const edited = clone(original)
+    mutate(edited)
+    const result = diffTableDefinitions(original, edited)
+    expect(result.kind).toBe('unsupported')
+    if (result.kind === 'unsupported') expect(result.reason).toMatch(/SQL query/)
+  })
+})

--- a/apps/desktop/src/main/ddl-builder.ts
+++ b/apps/desktop/src/main/ddl-builder.ts
@@ -15,6 +15,7 @@ import type {
   ParameterizedQuery,
   DatabaseType
 } from '@data-peek/shared'
+import { formatColumnType } from '@data-peek/shared'
 import { quoteIdentifier as quoteIdentifierUtil } from './sql-utils'
 
 /**
@@ -88,34 +89,6 @@ function buildTableRef(schema: string, table: string, dialect: DdlDialect): stri
 }
 
 /**
- * Build column data type with modifiers
- */
-function buildDataType(column: ColumnDefinition): string {
-  let dataType = column.dataType
-
-  // Handle length for varchar/char
-  if ((dataType === 'varchar' || dataType === 'char') && column.length !== undefined) {
-    dataType = `${dataType}(${column.length})`
-  }
-
-  // Handle precision/scale for numeric
-  if (dataType === 'numeric' && column.precision !== undefined) {
-    if (column.scale !== undefined) {
-      dataType = `numeric(${column.precision},${column.scale})`
-    } else {
-      dataType = `numeric(${column.precision})`
-    }
-  }
-
-  // Handle array types
-  if (column.isArray) {
-    dataType = `${dataType}[]`
-  }
-
-  return dataType
-}
-
-/**
  * Build column definition for CREATE TABLE
  */
 function buildColumnDef(column: ColumnDefinition, dialect: DdlDialect): string {
@@ -123,7 +96,7 @@ function buildColumnDef(column: ColumnDefinition, dialect: DdlDialect): string {
 
   // Column name and type
   parts.push(quoteIdentifier(column.name, dialect))
-  parts.push(buildDataType(column))
+  parts.push(formatColumnType(column))
 
   // Collation
   if (column.collation) {

--- a/apps/desktop/src/renderer/src/components/table-designer.tsx
+++ b/apps/desktop/src/renderer/src/components/table-designer.tsx
@@ -38,6 +38,7 @@ import { useTabStore, useConnectionStore } from '@/stores'
 import { useDDLStore, type ValidationError } from '@/stores/ddl-store'
 import type { TableDesignerTab } from '@/stores/tab-store'
 import type { ColumnDefinition, PostgresDataType, ConstraintType } from '@data-peek/shared'
+import { diffTableDefinitions } from '@data-peek/shared'
 import { ConstraintEditor } from '@/components/constraint-editor'
 import { IndexEditor } from '@/components/index-editor'
 
@@ -225,6 +226,45 @@ export function TableDesigner({ tabId }: TableDesignerProps) {
       return
     }
 
+    // In edit mode, diff against the loaded definition and issue an ALTER —
+    // issuing CREATE TABLE for an existing table would error or, worse, silently
+    // create a second table under a new name. The diff refuses changes it can't
+    // safely express (see diffTableDefinitions) rather than mis-applying them.
+    if (state?.mode === 'edit') {
+      const original = state.originalDefinition
+      if (!original) {
+        setError(tabId, 'Original table definition not loaded yet — reopen the table and try again')
+        return
+      }
+
+      const diff = diffTableDefinitions(original, definition)
+      if (diff.kind === 'unsupported') {
+        setError(tabId, diff.reason)
+        return
+      }
+      if (diff.kind === 'noop') {
+        setError(tabId, null)
+        return
+      }
+
+      setSaving(tabId, true)
+      setError(tabId, null)
+      try {
+        const response = await window.api.ddl.alterTable(tabConnection, diff.batch)
+        if (response.success) {
+          await fetchSchemas(tabConnection.id)
+          setError(tabId, null)
+        } else {
+          setError(tabId, response.error ?? 'Failed to alter table')
+        }
+      } catch (err) {
+        setError(tabId, err instanceof Error ? err.message : String(err))
+      } finally {
+        setSaving(tabId, false)
+      }
+      return
+    }
+
     setSaving(tabId, true)
     setError(tabId, null)
 
@@ -244,7 +284,7 @@ export function TableDesigner({ tabId }: TableDesignerProps) {
     } finally {
       setSaving(tabId, false)
     }
-  }, [definition, tabConnection, tabId, validate, setSaving, setError, fetchSchemas])
+  }, [definition, tabConnection, tabId, state, validate, setSaving, setError, fetchSchemas])
 
   // Get available schema names
   const availableSchemas = schemas.map((s) => s.name)

--- a/apps/desktop/src/renderer/src/components/table-designer.tsx
+++ b/apps/desktop/src/renderer/src/components/table-designer.tsx
@@ -253,6 +253,17 @@ export function TableDesigner({ tabId }: TableDesignerProps) {
         const response = await window.api.ddl.alterTable(tabConnection, diff.batch)
         if (response.success) {
           await fetchSchemas(tabConnection.id)
+          // Re-sync the editor with the now-altered table so a subsequent save in
+          // this tab diffs against current DB state instead of re-applying ops that
+          // already landed (e.g. renaming a column that was already renamed).
+          const reloaded = await window.api.ddl.getTableDDL(
+            tabConnection,
+            definition.schema,
+            definition.name
+          )
+          if (reloaded.success && reloaded.data) {
+            loadTableDefinition(tabId, reloaded.data)
+          }
           setError(tabId, null)
         } else {
           setError(tabId, response.error ?? 'Failed to alter table')
@@ -284,7 +295,17 @@ export function TableDesigner({ tabId }: TableDesignerProps) {
     } finally {
       setSaving(tabId, false)
     }
-  }, [definition, tabConnection, tabId, state, validate, setSaving, setError, fetchSchemas])
+  }, [
+    definition,
+    tabConnection,
+    tabId,
+    state,
+    validate,
+    setSaving,
+    setError,
+    fetchSchemas,
+    loadTableDefinition
+  ])
 
   // Get available schema names
   const availableSchemas = schemas.map((s) => s.name)

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1182,6 +1182,214 @@ export interface AlterTableBatch {
 }
 
 /**
+ * Format a column's SQL data type with length / precision / scale / array
+ * modifiers. Shared by CREATE (ddl-builder) and the ALTER diff below so both
+ * agree on exactly what a column's type string looks like.
+ */
+export function formatColumnType(column: ColumnDefinition): string {
+  let dataType = column.dataType;
+  if (
+    (dataType === "varchar" || dataType === "char") &&
+    column.length !== undefined
+  ) {
+    dataType = `${dataType}(${column.length})`;
+  }
+  if (dataType === "numeric" && column.precision !== undefined) {
+    dataType =
+      column.scale !== undefined
+        ? `numeric(${column.precision},${column.scale})`
+        : `numeric(${column.precision})`;
+  }
+  if (column.isArray) dataType = `${dataType}[]`;
+  return dataType;
+}
+
+// Stable signature of a column's default so an unchanged default never produces
+// a spurious ALTER — compares the raw fields, not a rendered SQL string.
+function columnDefaultSignature(c: ColumnDefinition): string {
+  return JSON.stringify([
+    c.defaultValue ?? null,
+    c.defaultType ?? null,
+    c.sequenceName ?? null
+  ]);
+}
+
+// The SQL expression to feed a SET DEFAULT, or null for DROP DEFAULT.
+function columnDefaultSql(c: ColumnDefinition): string | null {
+  if (c.defaultValue === undefined || c.defaultValue === "") return null;
+  if (c.defaultType === "sequence" && c.sequenceName) {
+    return `nextval('${c.sequenceName}')`;
+  }
+  return c.defaultValue;
+}
+
+function normalizedComment(comment?: string): string | null {
+  return comment && comment.length > 0 ? comment : null;
+}
+
+/**
+ * Result of diffing an edited table definition against its original.
+ * - `noop`: nothing to apply.
+ * - `batch`: an ALTER batch to execute.
+ * - `unsupported`: the edit contains a change the visual editor can't safely
+ *   express as an in-place ALTER; the caller should surface `reason` and NOT
+ *   fall back to any other DDL (silently doing the wrong thing loses edits).
+ */
+export type TableDiffResult =
+  | { kind: "noop" }
+  | { kind: "batch"; batch: AlterTableBatch }
+  | { kind: "unsupported"; reason: string };
+
+/**
+ * Diff an edited table definition against the original loaded from the database
+ * and produce the ALTER operations needed to reconcile them.
+ *
+ * Columns are matched by their stable client-side `id` (assigned when the
+ * definition is loaded and preserved through edits), so a rename is detected
+ * unambiguously rather than guessed from a name heuristic. Anything the batch
+ * model can't safely express in place — table rename/schema move, primary-key
+ * or unique changes, constraint or index edits — returns `unsupported` so the
+ * caller refuses the save with guidance instead of mis-applying it.
+ */
+export function diffTableDefinitions(
+  original: TableDefinition,
+  edited: TableDefinition
+): TableDiffResult {
+  if (edited.name !== original.name) {
+    return {
+      kind: "unsupported",
+      reason:
+        "Renaming a table isn't supported in the visual editor yet — rename it with a SQL query (ALTER TABLE … RENAME TO …)."
+    };
+  }
+  if (edited.schema !== original.schema) {
+    return {
+      kind: "unsupported",
+      reason:
+        "Moving a table to another schema isn't supported in the visual editor yet — use a SQL query (ALTER TABLE … SET SCHEMA …)."
+    };
+  }
+  if (!!edited.unlogged !== !!original.unlogged) {
+    return {
+      kind: "unsupported",
+      reason:
+        "Changing whether a table is UNLOGGED isn't supported in the visual editor yet — use a SQL query."
+    };
+  }
+  if (
+    JSON.stringify(original.constraints) !== JSON.stringify(edited.constraints)
+  ) {
+    return {
+      kind: "unsupported",
+      reason:
+        "Editing constraints isn't supported in the visual editor yet — apply constraint changes with a SQL query."
+    };
+  }
+  if (JSON.stringify(original.indexes) !== JSON.stringify(edited.indexes)) {
+    return {
+      kind: "unsupported",
+      reason:
+        "Editing indexes isn't supported in the visual editor yet — apply index changes with a SQL query."
+    };
+  }
+
+  const columnOperations: AlterColumnOperation[] = [];
+  const editById = new Map(edited.columns.map((c) => [c.id, c]));
+  const origById = new Map(original.columns.map((c) => [c.id, c]));
+
+  // Dropped columns (present originally, gone from the edited set).
+  for (const orig of original.columns) {
+    if (!editById.has(orig.id)) {
+      columnOperations.push({ type: "drop", columnName: orig.name });
+    }
+  }
+
+  for (const edit of edited.columns) {
+    const orig = origById.get(edit.id);
+    if (!orig) {
+      columnOperations.push({ type: "add", column: edit });
+      continue;
+    }
+
+    // Structural per-column changes the batch model can't express as a plain
+    // column op (PK/UNIQUE are also constraints; collation/CHECK have no op).
+    if (
+      !!edit.isPrimaryKey !== !!orig.isPrimaryKey ||
+      !!edit.isUnique !== !!orig.isUnique
+    ) {
+      return {
+        kind: "unsupported",
+        reason: `Changing the primary key or unique flag on "${edit.name}" isn't supported in the visual editor yet — use a SQL query.`
+      };
+    }
+    if ((edit.collation ?? "") !== (orig.collation ?? "")) {
+      return {
+        kind: "unsupported",
+        reason: `Changing the collation on "${edit.name}" isn't supported in the visual editor yet — use a SQL query.`
+      };
+    }
+    if ((edit.checkConstraint ?? "") !== (orig.checkConstraint ?? "")) {
+      return {
+        kind: "unsupported",
+        reason: `Changing the CHECK constraint on "${edit.name}" isn't supported in the visual editor yet — use a SQL query.`
+      };
+    }
+
+    // Rename first so subsequent ops reference the new name.
+    if (edit.name !== orig.name) {
+      columnOperations.push({
+        type: "rename",
+        oldName: orig.name,
+        newName: edit.name
+      });
+    }
+    if (formatColumnType(orig) !== formatColumnType(edit)) {
+      columnOperations.push({
+        type: "set_type",
+        columnName: edit.name,
+        newType: formatColumnType(edit)
+      });
+    }
+    if (!!orig.isNullable !== !!edit.isNullable) {
+      columnOperations.push({
+        type: "set_nullable",
+        columnName: edit.name,
+        nullable: edit.isNullable
+      });
+    }
+    if (columnDefaultSignature(orig) !== columnDefaultSignature(edit)) {
+      columnOperations.push({
+        type: "set_default",
+        columnName: edit.name,
+        defaultValue: columnDefaultSql(edit)
+      });
+    }
+    if ((orig.comment ?? "") !== (edit.comment ?? "")) {
+      columnOperations.push({
+        type: "set_comment",
+        columnName: edit.name,
+        comment: normalizedComment(edit.comment)
+      });
+    }
+  }
+
+  const commentChanged = (original.comment ?? "") !== (edited.comment ?? "");
+  if (columnOperations.length === 0 && !commentChanged) {
+    return { kind: "noop" };
+  }
+
+  const batch: AlterTableBatch = {
+    schema: original.schema,
+    table: original.name,
+    columnOperations,
+    constraintOperations: [],
+    indexOperations: []
+  };
+  if (commentChanged) batch.comment = normalizedComment(edited.comment);
+  return { kind: "batch", batch };
+}
+
+/**
  * Result of DDL operations
  */
 export interface DDLResult {


### PR DESCRIPTION
## Table Designer edit mode now issues ALTER, not CREATE

Reopens #228 against `main` (the original was auto-closed when its stacked base branch `quality/correctness-pass` was deleted on merge of #227 — the work is identical, now rebased onto `main` so it's just the two feature commits).

Fixes the headline bug-hunt finding: **"Edit Table" always called `ddl.createTable`, even for an existing table** — best case a `relation "…" already exists` error, worst case (after a rename in the editor) it silently created a second table under the new name and left the original untouched — lost edits presented as success.

### What this does
Adds a pure `diffTableDefinitions(original, edited)` to `@data-peek/shared`. The store already keeps `originalDefinition` (a `structuredClone` at load) and assigns **stable client-side column `id`s**, so the diff matches columns by `id` — renames are detected, not guessed. All the ALTER machinery (types, `buildAlterTable`, the IPC handler — including the envelope fix from #227) already existed; this wires up the missing diff + call.

`handleSave` now branches on `tab.mode`: **create** → `createTable` (unchanged); **edit** → diff → `alterTable(config, batch)`, then reloads the table so a second save diffs against fresh state.

### Deliberately scoped — refuses rather than mis-applies
Emits `add`/`drop`/`rename`/`set_type`/`set_nullable`/`set_default`/`set_comment` column ops + table-comment changes. Anything it can't safely express in place returns `{ kind: 'unsupported', reason }` and the save is refused with guidance to use SQL — **never a silent partial apply**: table rename/schema move, PK/unique/collation/CHECK changes, constraint/index edits. (Follow-ups: full constraint/index ALTER, and fixing `buildAlterTable`'s rename-first ordering so a table rename can combine with column ops.)

Also extracts the type formatter into shared `formatColumnType()` so CREATE and the ALTER diff can't drift (the 86 `ddl-builder` tests confirm identical CREATE output).

### Tests
`diff-table.test.ts` — 20 cases incl. rename-before-set_type, sequence default → `nextval()`, bare reorder → noop, and a parameterized sweep asserting all 9 unsupported changes are refused with a "use SQL" reason. Full main suite **496 passed**, typecheck (node + web) clean, lint clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for safely saving edits to existing tables.
  * Detects column additions, removals, renames, type, nullability, default, and comment changes.
  * Refreshes table definitions after successful edits.

* **Bug Fixes**
  * Ensures column types and defaults are rendered consistently.
  * Prevents unsupported structural changes from being applied.
  * Ignores changes that only reorder columns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->