### PR TITLE
fix(ai): one-click keyless provider (no misleading 'Save Key')

### DIFF
--- a/apps/desktop/src/renderer/src/components/ai/ai-settings-modal.tsx
+++ b/apps/desktop/src/renderer/src/components/ai/ai-settings-modal.tsx
@@ -168,6 +168,9 @@ export function AISettingsModal({
         apiKey: needsKey ? apiKey : undefined,
         baseUrl: baseUrl || undefined
       })
+      // Keyless providers (Claude Code CLI, Ollama) have nothing to configure —
+      // choosing one means "use it", so make it active in the same click.
+      if (!needsKey) await onSetActiveProvider(selectedProvider)
       setValidationResult('success')
     } catch (error) {
       console.error('Failed to save provider config:', error)
@@ -440,11 +443,15 @@ export function AISettingsModal({
             <Button
               size="sm"
               onClick={handleSaveProviderConfig}
-              disabled={!canSaveConfig}
+              disabled={!canSaveConfig || (!needsKey && isActiveProvider)}
               className="flex-1"
             >
               {isSaving ? <Loader2 className="size-4 animate-spin mr-1" /> : null}
-              {hasProviderConfig(selectedProvider) ? 'Update' : 'Save'} {providerConfig.name} Key
+              {needsKey
+                ? `${hasProviderConfig(selectedProvider) ? 'Update' : 'Save'} ${providerConfig.name} Key`
+                : isActiveProvider
+                  ? `✓ Using ${providerConfig.name}`
+                  : `Use ${providerConfig.name}`}
             </Button>
             {hasProviderConfig(selectedProvider) && !isActiveProvider && (
               <Button size="sm" variant="outline" onClick={handleSetActive} disabled={isSaving}>

--- a/apps/docs/content/docs/features/ai-assistant.mdx
+++ b/apps/docs/content/docs/features/ai-assistant.mdx
@@ -17,16 +17,15 @@ data-peek includes a powerful AI assistant that helps you write SQL queries, gen
 - Or click the sparkle icon in the toolbar
 - Or use the command palette (`Cmd+K`) and search for "AI"
 
-### Configure Your API Key
+### Choose a provider
 
-The AI assistant uses a "Bring Your Own Key" (BYOK) model. You need to provide your own API key:
+Open **AI Settings** (from the AI panel or the command palette) and pick one provider. The app always uses whichever provider is marked **Active** — you can switch anytime.
 
-1. Open AI Settings from the command palette or AI panel
-2. Select your preferred provider (OpenAI, Anthropic, or others)
-3. Enter your API key
-4. Click Save
+- **Claude Code (local CLI)** — _no API key._ If you have the `claude` CLI installed and signed in, select the tile and click **Use Claude Code**. That single click makes it active — nothing else to configure. See [Bring your own harness](#bring-your-own-harness-claude-code) below.
+- **API-key providers** (OpenAI, Anthropic, Google, …) — paste your key, click **Save … Key**, then **Set Active**. Keys are stored in your OS keychain and only ever sent to that provider.
+- **Ollama** — local models, no key; point it at your Ollama URL and click **Use Ollama**.
 
-Your API key is stored securely using your operating system's keychain.
+To use _only_ the local Claude CLI, just make **Claude Code (local CLI)** the active provider — the others can stay configured but unused.
 
 ## Supported Providers
 


### PR DESCRIPTION
Follow-up to the v0.27 AI work — the keyless-provider flow was confusing (reported: "how do I say ignore everything and only use claude -p?").

**Before:** picking **Claude Code (local CLI)** (or Ollama) showed a **"Save Claude Code (local CLI) Key"** button — but there's no key — and then required a separate **Set Active** click.

**After:**
- Keyless providers show **"Use <provider>"** (→ **"✓ Using <provider>"** once active). No "Key".
- Saving a keyless provider **makes it active in the same click** — one action to switch to `claude -p`.
- Docs (`ai-assistant`): the setup section now leads with *choosing* a provider — Claude Code (no key, one click) as a first-class option — plus an explicit "to use only the local Claude CLI, make it active" note.

Key-based providers (OpenAI/Anthropic/…) are unchanged (Save Key → Set Active). Typecheck (web) + lint + docs build clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Saving a keyless provider now automatically sets it as the active AI provider.
  * Provider controls clearly indicate whether a keyless provider is currently in use.

* **Documentation**
  * Updated AI assistant setup guidance to cover multiple provider options, including local Claude CLI, API-key providers, and Ollama.
  * Added instructions for using the local Claude CLI exclusively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->