### PR TITLE
feat(ai): modernize chat — streaming + native structured output + session memory

### DIFF
--- a/apps/desktop/src/main/__tests__/ai-schema.test.ts
+++ b/apps/desktop/src/main/__tests__/ai-schema.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import { responseSchema, RESPONSE_JSON_SCHEMA, RESPONSE_JSON_SCHEMA_STRING } from '../ai-schema'
+
+describe('RESPONSE_JSON_SCHEMA', () => {
+  it('covers exactly the same fields as the zod responseSchema (drift guard)', () => {
+    const zodKeys = Object.keys(responseSchema.shape).sort()
+    const jsonKeys = Object.keys(RESPONSE_JSON_SCHEMA.properties).sort()
+    expect(jsonKeys).toEqual(zodKeys)
+  })
+
+  it('requires only type + message (the rest are optional/nullable)', () => {
+    expect([...RESPONSE_JSON_SCHEMA.required].sort()).toEqual(['message', 'type'])
+  })
+
+  it('serializes to valid JSON for the --json-schema flag', () => {
+    expect(() => JSON.parse(RESPONSE_JSON_SCHEMA_STRING)).not.toThrow()
+    expect(JSON.parse(RESPONSE_JSON_SCHEMA_STRING)).toEqual(RESPONSE_JSON_SCHEMA)
+  })
+
+  it('accepts a minimal valid object shape through the zod schema', () => {
+    // structured_output the CLI would return for a plain message
+    const parsed = responseSchema.safeParse({ type: 'message', message: 'hi' })
+    expect(parsed.success).toBe(true)
+  })
+})

--- a/apps/desktop/src/main/__tests__/harness-stream.test.ts
+++ b/apps/desktop/src/main/__tests__/harness-stream.test.ts
@@ -75,6 +75,14 @@ describe('classifyStreamLine', () => {
     expect(info.toolLabel).toBe('Running query…')
   })
 
+  it('ignores internal/output tools like StructuredOutput', () => {
+    const info = classifyStreamLine({
+      type: 'assistant',
+      message: { content: [{ type: 'tool_use', name: 'StructuredOutput' }] }
+    })
+    expect(info.toolLabel).toBeUndefined()
+  })
+
   it('captures the result envelope', () => {
     const env = { type: 'result', subtype: 'success', result: '{}', num_turns: 3 }
     expect(classifyStreamLine(env).resultEnvelope).toEqual(env)
@@ -93,7 +101,8 @@ describe('toolLabel', () => {
     expect(toolLabel('mcp__datapeek__explain_query')).toBe('Explaining query…')
     expect(toolLabel('mcp__datapeek__list_schemas')).toBe('Reading schema…')
   })
-  it('falls back for unknown tools', () => {
-    expect(toolLabel('mcp__datapeek__something_else')).toBe('Using something_else…')
+  it('returns undefined for unknown / internal tools', () => {
+    expect(toolLabel('mcp__datapeek__something_else')).toBeUndefined()
+    expect(toolLabel('StructuredOutput')).toBeUndefined()
   })
 })

--- a/apps/desktop/src/main/__tests__/harness-stream.test.ts
+++ b/apps/desktop/src/main/__tests__/harness-stream.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import { extractPartialMessage, classifyStreamLine, toolLabel } from '../harness-stream'
+
+describe('extractPartialMessage', () => {
+  it('returns empty string before the message field appears', () => {
+    expect(extractPartialMessage('')).toBe('')
+    expect(extractPartialMessage('{"type":"query",')).toBe('')
+    expect(extractPartialMessage('{"type":"query","mess')).toBe('')
+  })
+
+  it('returns the partial value while the string is still open', () => {
+    expect(extractPartialMessage('{"type":"query","message":"Here are the')).toBe('Here are the')
+  })
+
+  it('returns the full value once the string closes', () => {
+    expect(extractPartialMessage('{"message":"Done.","sql":"SELECT 1"}')).toBe('Done.')
+  })
+
+  it('decodes escapes and stops safely on an incomplete escape', () => {
+    expect(extractPartialMessage('{"message":"line1\\nline2"')).toBe('line1\nline2')
+    expect(extractPartialMessage('{"message":"quote \\"x\\""')).toBe('quote "x"')
+    // trailing backslash that hasn't been completed must not throw
+    expect(extractPartialMessage('{"message":"end\\')).toBe('end')
+  })
+
+  it('handles incomplete unicode escapes without throwing', () => {
+    expect(extractPartialMessage('{"message":"a\\u00')).toBe('a')
+    expect(extractPartialMessage('{"message":"a\\u0041"')).toBe('aA')
+  })
+
+  it('tolerates whitespace between key, colon, and value', () => {
+    expect(extractPartialMessage('{ "message" : "hi"')).toBe('hi')
+  })
+})
+
+describe('classifyStreamLine', () => {
+  it('extracts text deltas from stream_event frames', () => {
+    const info = classifyStreamLine({
+      type: 'stream_event',
+      event: { type: 'content_block_delta', delta: { type: 'text_delta', text: 'hello' } }
+    })
+    expect(info.textDelta).toBe('hello')
+  })
+
+  it('ignores non-text stream events', () => {
+    expect(classifyStreamLine({ type: 'stream_event', event: { type: 'message_start' } })).toEqual(
+      {}
+    )
+  })
+
+  it('labels tool_use from assistant frames', () => {
+    const info = classifyStreamLine({
+      type: 'assistant',
+      message: { content: [{ type: 'tool_use', name: 'mcp__datapeek__run_query' }] }
+    })
+    expect(info.toolLabel).toBe('Running query…')
+  })
+
+  it('captures the result envelope', () => {
+    const env = { type: 'result', subtype: 'success', result: '{}', num_turns: 3 }
+    expect(classifyStreamLine(env).resultEnvelope).toEqual(env)
+  })
+
+  it('ignores noise frames and non-objects', () => {
+    expect(classifyStreamLine({ type: 'rate_limit_event' })).toEqual({})
+    expect(classifyStreamLine({ type: 'system', subtype: 'hook_started' })).toEqual({})
+    expect(classifyStreamLine(null)).toEqual({})
+    expect(classifyStreamLine('boom')).toEqual({})
+  })
+})
+
+describe('toolLabel', () => {
+  it('maps known MCP read tools', () => {
+    expect(toolLabel('mcp__datapeek__explain_query')).toBe('Explaining query…')
+    expect(toolLabel('mcp__datapeek__list_schemas')).toBe('Reading schema…')
+  })
+  it('falls back for unknown tools', () => {
+    expect(toolLabel('mcp__datapeek__something_else')).toBe('Using something_else…')
+  })
+})

--- a/apps/desktop/src/main/__tests__/harness-stream.test.ts
+++ b/apps/desktop/src/main/__tests__/harness-stream.test.ts
@@ -42,10 +42,29 @@ describe('classifyStreamLine', () => {
     expect(info.textDelta).toBe('hello')
   })
 
+  it('extracts json deltas (structured output under --json-schema)', () => {
+    const info = classifyStreamLine({
+      type: 'stream_event',
+      event: {
+        type: 'content_block_delta',
+        delta: { type: 'input_json_delta', partial_json: '{"ty' }
+      }
+    })
+    expect(info.jsonDelta).toBe('{"ty')
+    expect(info.textDelta).toBeUndefined()
+  })
+
   it('ignores non-text stream events', () => {
     expect(classifyStreamLine({ type: 'stream_event', event: { type: 'message_start' } })).toEqual(
       {}
     )
+    // thinking deltas are not answer content
+    expect(
+      classifyStreamLine({
+        type: 'stream_event',
+        event: { type: 'content_block_delta', delta: { type: 'thinking_delta', thinking: 'hmm' } }
+      })
+    ).toEqual({})
   })
 
   it('labels tool_use from assistant frames', () => {

--- a/apps/desktop/src/main/ai-schema.ts
+++ b/apps/desktop/src/main/ai-schema.ts
@@ -79,6 +79,38 @@ export const responseSchema = z.object({
 })
 
 /**
+ * JSON Schema mirror of {@link responseSchema}, for the CLI's `--json-schema`
+ * flag (native structured output). zod v3 has no `toJSONSchema()`, so this is
+ * hand-authored and kept in sync by a drift-guard test (its property set must
+ * equal the zod schema's). Only `type` + `message` are required; the rest are
+ * optional and nullable, matching the `.nullish()` fields above.
+ */
+export const RESPONSE_JSON_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['type', 'message'],
+  properties: {
+    type: { type: 'string', enum: ['query', 'chart', 'metric', 'schema', 'message'] },
+    message: { type: 'string' },
+    sql: { type: ['string', 'null'] },
+    explanation: { type: ['string', 'null'] },
+    warning: { type: ['string', 'null'] },
+    requiresConfirmation: { type: ['boolean', 'null'] },
+    title: { type: ['string', 'null'] },
+    description: { type: ['string', 'null'] },
+    chartType: { type: ['string', 'null'], enum: ['bar', 'line', 'pie', 'area', null] },
+    xKey: { type: ['string', 'null'] },
+    yKeys: { type: ['array', 'null'], items: { type: 'string' } },
+    label: { type: ['string', 'null'] },
+    format: { type: ['string', 'null'], enum: ['number', 'currency', 'percent', 'duration', null] },
+    tables: { type: ['array', 'null'], items: { type: 'string' } }
+  }
+} as const
+
+/** Serialized form for the `--json-schema` CLI flag. */
+export const RESPONSE_JSON_SCHEMA_STRING = JSON.stringify(RESPONSE_JSON_SCHEMA)
+
+/**
  * Normalize a raw structured response: undefined → null for every optional field,
  * so the renderer always sees a complete object. Shared by both provider paths.
  */

--- a/apps/desktop/src/main/ai-service.ts
+++ b/apps/desktop/src/main/ai-service.ts
@@ -408,12 +408,13 @@ export async function generateChatResponseStream(
   schemas: SchemaInfo[],
   dbType: string,
   connectionId: string | undefined,
+  resumeSessionId: string | undefined,
   onEvent: (event: AIChatStreamEvent) => void
 ): Promise<{
   success: boolean
   data?: AIStructuredResponse
   error?: string
-  meta?: { grounded: boolean; agentic: boolean; turns?: number }
+  meta?: { grounded: boolean; agentic: boolean; turns?: number; sessionId?: string }
 }> {
   if (config.provider === 'claude-cli') {
     const { generateChatResponseViaHarnessStream } = await import('./harness-service')
@@ -423,10 +424,12 @@ export async function generateChatResponseStream(
       schemas,
       dbType,
       connectionId,
+      resumeSessionId,
       onEvent
     )
   }
 
+  // Non-CLI providers have no CLI session to resume; ignore resumeSessionId.
   const result = await generateChatResponse(config, messages, schemas, dbType, connectionId)
   if (result.success && result.data) onEvent({ type: 'message', text: result.data.message })
   return result

--- a/apps/desktop/src/main/ai-service.ts
+++ b/apps/desktop/src/main/ai-service.ts
@@ -25,7 +25,8 @@ import type {
   StoredChatMessage,
   ChatSession,
   AIMultiProviderConfig,
-  AIProviderConfig
+  AIProviderConfig,
+  AIChatStreamEvent
 } from '@shared/index'
 import { DEFAULT_MODELS } from '@shared/index'
 import { randomUUID } from 'crypto'
@@ -393,6 +394,42 @@ export async function generateChatResponse(
 
     return { success: false, error: message }
   }
+}
+
+/**
+ * Streaming chat: for the BYOH `claude-cli` provider, drives the CLI in
+ * stream-json mode and forwards incremental events through `onEvent`. Other
+ * (AI SDK) providers don't stream here — they run normally and emit their final
+ * message as one event so the caller's rendering path stays uniform.
+ */
+export async function generateChatResponseStream(
+  config: AIConfig,
+  messages: AIMessage[],
+  schemas: SchemaInfo[],
+  dbType: string,
+  connectionId: string | undefined,
+  onEvent: (event: AIChatStreamEvent) => void
+): Promise<{
+  success: boolean
+  data?: AIStructuredResponse
+  error?: string
+  meta?: { grounded: boolean; agentic: boolean; turns?: number }
+}> {
+  if (config.provider === 'claude-cli') {
+    const { generateChatResponseViaHarnessStream } = await import('./harness-service')
+    return generateChatResponseViaHarnessStream(
+      config,
+      messages,
+      schemas,
+      dbType,
+      connectionId,
+      onEvent
+    )
+  }
+
+  const result = await generateChatResponse(config, messages, schemas, dbType, connectionId)
+  if (result.success && result.data) onEvent({ type: 'message', text: result.data.message })
+  return result
 }
 
 /**

--- a/apps/desktop/src/main/harness-service.ts
+++ b/apps/desktop/src/main/harness-service.ts
@@ -17,7 +17,13 @@ import { spawn } from 'child_process'
 import { existsSync } from 'fs'
 import { homedir } from 'os'
 import { join } from 'path'
-import type { AIConfig, AIMessage, SchemaInfo, AIStructuredResponse } from '@shared/index'
+import type {
+  AIConfig,
+  AIMessage,
+  SchemaInfo,
+  AIStructuredResponse,
+  AIChatStreamEvent
+} from '@shared/index'
 import { DEFAULT_MODELS } from '@shared/index'
 import {
   buildSystemPrompt,
@@ -27,6 +33,7 @@ import {
   dashboardSpecSchema,
   type DashboardSpec
 } from './ai-schema'
+import { classifyStreamLine, extractPartialMessage } from './harness-stream'
 import { getMcpRuntimeInfo, type McpRuntimeInfo } from './mcp-runtime'
 import { createLogger } from './lib/logger'
 
@@ -85,22 +92,30 @@ export function resolveClaudeBinary(): string {
   return 'claude'
 }
 
-/** Build the argv for a one-shot structured generation call. Pure — unit-tested. */
+/**
+ * Build the argv for a structured generation call. Pure — unit-tested.
+ * With `stream: true` the CLI emits NDJSON (stream-json) with token-level deltas
+ * instead of a single buffered JSON envelope.
+ */
 export function buildHarnessArgs(
   userPrompt: string,
   systemPrompt: string,
-  model: string
+  model: string,
+  opts?: { stream?: boolean }
 ): string[] {
-  return [
+  const args = [
     '-p',
     userPrompt,
     '--output-format',
-    'json',
+    opts?.stream ? 'stream-json' : 'json',
     '--append-system-prompt',
     systemPrompt,
     '--model',
     model
   ]
+  // stream-json requires --verbose; token-level deltas require partial messages.
+  if (opts?.stream) args.push('--verbose', '--include-partial-messages')
+  return args
 }
 
 // Server name registered in the generated mcp-config. No hyphen so the derived
@@ -142,10 +157,11 @@ export function buildAgenticHarnessArgs(
   systemPrompt: string,
   model: string,
   mcpConfigJson: string,
-  allowedTools: string[]
+  allowedTools: string[],
+  opts?: { stream?: boolean }
 ): string[] {
   return [
-    ...buildHarnessArgs(userPrompt, systemPrompt, model),
+    ...buildHarnessArgs(userPrompt, systemPrompt, model, opts),
     '--mcp-config',
     mcpConfigJson,
     // Use ONLY this config's MCP server — ignore the user's global/project MCP
@@ -182,6 +198,15 @@ export function parseHarnessResult(stdout: string): AIStructuredResponse {
   } catch {
     throw new Error('Claude CLI did not return valid JSON (is --output-format json supported?)')
   }
+  return parseResultEnvelope(outer)
+}
+
+/**
+ * Parse an already-decoded CLI result envelope into an AIStructuredResponse.
+ * Shared by the one-shot (`json`) and streaming (`stream-json`) paths — the
+ * streaming path hands us the parsed `result` frame directly.
+ */
+export function parseResultEnvelope(outer: unknown): AIStructuredResponse {
   const envelope = (outer ?? {}) as Record<string, unknown>
   if (envelope.is_error) {
     const msg =
@@ -319,16 +344,32 @@ export interface HarnessMeta {
   turns?: number
 }
 
+/** num_turns + permission-denial count from a decoded CLI result envelope. */
+function readEnvelopeStatsFromObject(env: Record<string, unknown>): {
+  turns?: number
+  denials: number
+} {
+  const turns = typeof env.num_turns === 'number' ? env.num_turns : undefined
+  const denials = Array.isArray(env.permission_denials) ? env.permission_denials.length : 0
+  return { turns, denials }
+}
+
 /** Read num_turns + permission-denial count from the CLI's JSON envelope. */
 function readEnvelopeStats(stdout: string): { turns?: number; denials: number } {
   try {
-    const env = JSON.parse(stdout) as Record<string, unknown>
-    const turns = typeof env.num_turns === 'number' ? env.num_turns : undefined
-    const denials = Array.isArray(env.permission_denials) ? env.permission_denials.length : 0
-    return { turns, denials }
+    return readEnvelopeStatsFromObject(JSON.parse(stdout) as Record<string, unknown>)
   } catch {
     return { denials: 0 }
   }
+}
+
+/**
+ * "Grounded" only if agentic AND the model actually took tool round-trips
+ * (turns > 1) AND no tool call was denied — a denied read means it couldn't
+ * query, so claiming "grounded" would be false.
+ */
+function isGrounded(agentic: boolean, turns: number | undefined, denials: number): boolean {
+  return agentic && (turns ?? 0) > 1 && denials === 0
 }
 
 export async function generateChatResponseViaHarness(
@@ -378,10 +419,7 @@ export async function generateChatResponseViaHarness(
     if (stdout.trim()) {
       const data = parseHarnessResult(stdout)
       const { turns, denials } = readEnvelopeStats(stdout)
-      // "Grounded" only if agentic AND the model actually took tool round-trips
-      // (turns > 1) AND no tool call was denied — a denied read means it couldn't
-      // query, so claiming "grounded" would be false.
-      const grounded = agentic && (turns ?? 0) > 1 && denials === 0
+      const grounded = isGrounded(agentic, turns, denials)
       return { success: true, data, meta: { grounded, agentic, turns } }
     }
     const detail = stderr.trim() || `exited with code ${code}`
@@ -389,6 +427,151 @@ export async function generateChatResponseViaHarness(
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error)
     log.error('generateChatResponseViaHarness error:', message)
+    return { success: false, error: message }
+  }
+}
+
+/**
+ * Spawn the CLI and deliver each NDJSON line to `onLine` as it arrives. Buffers
+ * across chunk boundaries so a line split across two `data` events is only
+ * parsed once complete. Non-JSON noise lines are skipped.
+ */
+function runProcessStreaming(
+  bin: string,
+  args: string[],
+  timeoutMs: number,
+  onLine: (obj: unknown) => void
+): Promise<{ stderr: string; code: number | null }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(bin, args, { env: harnessEnv(), shell: false })
+    let stderr = ''
+    let buf = ''
+    const timer = setTimeout(() => {
+      child.kill('SIGTERM')
+      reject(new Error(`Claude CLI timed out after ${Math.round(timeoutMs / 1000)}s`))
+    }, timeoutMs)
+
+    const consume = (chunk: string): void => {
+      buf += chunk
+      let nl: number
+      while ((nl = buf.indexOf('\n')) !== -1) {
+        const line = buf.slice(0, nl).trim()
+        buf = buf.slice(nl + 1)
+        if (!line) continue
+        try {
+          onLine(JSON.parse(line))
+        } catch {
+          /* ignore a non-JSON noise line */
+        }
+      }
+    }
+
+    child.stdout.on('data', (d) => consume(d.toString()))
+    child.stderr.on('data', (d) => (stderr += d.toString()))
+    child.on('error', (err) => {
+      clearTimeout(timer)
+      reject(
+        (err as NodeJS.ErrnoException).code === 'ENOENT'
+          ? new Error('Claude CLI not found. Install it and run `claude` once to sign in.')
+          : err
+      )
+    })
+    child.on('close', (code) => {
+      clearTimeout(timer)
+      const rest = buf.trim()
+      if (rest) {
+        try {
+          onLine(JSON.parse(rest))
+        } catch {
+          /* ignore trailing noise */
+        }
+      }
+      resolve({ stderr, code })
+    })
+  })
+}
+
+/**
+ * Streaming variant of {@link generateChatResponseViaHarness}. Same inputs,
+ * same final return shape — but pushes incremental `AIChatStreamEvent`s through
+ * `onEvent` as the CLI streams: the assistant prose (extracted live from the
+ * partial JSON) and a label for each grounding/tool step. The authoritative
+ * structured response is still parsed from the terminal `result` frame.
+ */
+export async function generateChatResponseViaHarnessStream(
+  config: AIConfig,
+  messages: AIMessage[],
+  schemas: SchemaInfo[],
+  dbType: string,
+  connectionId: string | undefined,
+  onEvent: (event: AIChatStreamEvent) => void
+): Promise<{ success: boolean; data?: AIStructuredResponse; error?: string; meta?: HarnessMeta }> {
+  try {
+    const bin = resolveClaudeBinary()
+    const model = config.model || DEFAULT_MODELS['claude-cli']
+    const userPrompt = buildUserPrompt(messages)
+
+    const mcp = getMcpRuntimeInfo()
+    const agentic = mcp !== null && !!connectionId
+
+    let args: string[]
+    let timeoutMs: number
+    if (agentic && mcp && connectionId) {
+      const systemPrompt =
+        buildSystemPrompt(schemas, dbType) +
+        buildAgenticInstruction(connectionId) +
+        JSON_ONLY_INSTRUCTION
+      args = buildAgenticHarnessArgs(
+        userPrompt,
+        systemPrompt,
+        model,
+        buildMcpConfigJson(mcp),
+        mcpAllowedTools(),
+        { stream: true }
+      )
+      timeoutMs = AGENTIC_TIMEOUT_MS
+    } else {
+      const systemPrompt = buildSystemPrompt(schemas, dbType) + JSON_ONLY_INSTRUCTION
+      args = buildHarnessArgs(userPrompt, systemPrompt, model, { stream: true })
+      timeoutMs = GENERATION_TIMEOUT_MS
+    }
+
+    log.debug('Running claude CLI (streaming)', { bin, model, agentic })
+
+    let raw = ''
+    let lastMessage = ''
+    let lastActivity = ''
+    let resultEnvelope: Record<string, unknown> | undefined
+
+    const { stderr, code } = await runProcessStreaming(bin, args, timeoutMs, (obj) => {
+      const info = classifyStreamLine(obj)
+      if (info.textDelta) {
+        raw += info.textDelta
+        const message = extractPartialMessage(raw)
+        if (message && message !== lastMessage) {
+          lastMessage = message
+          onEvent({ type: 'message', text: message })
+        }
+      }
+      if (info.toolLabel && info.toolLabel !== lastActivity) {
+        lastActivity = info.toolLabel
+        onEvent({ type: 'activity', label: info.toolLabel })
+      }
+      if (info.resultEnvelope) resultEnvelope = info.resultEnvelope
+    })
+
+    if (!resultEnvelope) {
+      const detail = stderr.trim() || `exited with code ${code}`
+      throw new Error(`Claude CLI failed: ${detail}`)
+    }
+
+    const data = parseResultEnvelope(resultEnvelope)
+    const { turns, denials } = readEnvelopeStatsFromObject(resultEnvelope)
+    const grounded = isGrounded(agentic, turns, denials)
+    return { success: true, data, meta: { grounded, agentic, turns } }
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error)
+    log.error('generateChatResponseViaHarnessStream error:', message)
     return { success: false, error: message }
   }
 }

--- a/apps/desktop/src/main/harness-service.ts
+++ b/apps/desktop/src/main/harness-service.ts
@@ -31,6 +31,7 @@ import {
   normalizeStructuredResponse,
   buildDashboardPrompt,
   dashboardSpecSchema,
+  RESPONSE_JSON_SCHEMA_STRING,
   type DashboardSpec
 } from './ai-schema'
 import { classifyStreamLine, extractPartialMessage } from './harness-stream'
@@ -45,15 +46,6 @@ const AGENTIC_TIMEOUT_MS = 180_000
 // Generating a whole dashboard verifies several queries — allow more time.
 const DASHBOARD_TIMEOUT_MS = 300_000
 const DETECT_TIMEOUT_MS = 10_000
-
-// Instruction appended to the schema-aware system prompt so the CLI returns a
-// bare JSON object (generateObject enforces this structurally; the CLI can't).
-const JSON_ONLY_INSTRUCTION = `
-
-## Output contract (STRICT)
-Respond with ONLY a single JSON object matching the response format above.
-No prose, no explanation outside the JSON, no markdown code fences. The first
-character of your reply must be "{" and the last must be "}".`
 
 /** Common places the `claude` binary lands that a GUI-launched app's PATH misses. */
 function candidateBinDirs(): string[] {
@@ -97,11 +89,20 @@ export function resolveClaudeBinary(): string {
  * With `stream: true` the CLI emits NDJSON (stream-json) with token-level deltas
  * instead of a single buffered JSON envelope.
  */
+export interface HarnessArgOpts {
+  /** NDJSON token streaming (stream-json + verbose + partial messages). */
+  stream?: boolean
+  /** Serialized JSON Schema for native structured output (`--json-schema`). */
+  jsonSchema?: string
+  /** Resume a prior CLI session so the model keeps conversation memory. */
+  resumeSessionId?: string
+}
+
 export function buildHarnessArgs(
   userPrompt: string,
   systemPrompt: string,
   model: string,
-  opts?: { stream?: boolean }
+  opts?: HarnessArgOpts
 ): string[] {
   const args = [
     '-p',
@@ -115,6 +116,10 @@ export function buildHarnessArgs(
   ]
   // stream-json requires --verbose; token-level deltas require partial messages.
   if (opts?.stream) args.push('--verbose', '--include-partial-messages')
+  // Native structured output: the CLI constrains + validates the reply to schema.
+  if (opts?.jsonSchema) args.push('--json-schema', opts.jsonSchema)
+  // Multi-turn memory: continue the prior conversation server-side.
+  if (opts?.resumeSessionId) args.push('--resume', opts.resumeSessionId)
   return args
 }
 
@@ -158,7 +163,7 @@ export function buildAgenticHarnessArgs(
   model: string,
   mcpConfigJson: string,
   allowedTools: string[],
-  opts?: { stream?: boolean }
+  opts?: HarnessArgOpts
 ): string[] {
   return [
     ...buildHarnessArgs(userPrompt, systemPrompt, model, opts),
@@ -213,15 +218,23 @@ export function parseResultEnvelope(outer: unknown): AIStructuredResponse {
       typeof envelope.result === 'string' ? envelope.result : 'Claude CLI reported an error'
     throw new Error(msg)
   }
-  const resultText = typeof envelope.result === 'string' ? envelope.result : ''
-  if (!resultText.trim()) throw new Error('Claude CLI returned an empty result')
 
+  // Native structured output (--json-schema): the CLI already validated the
+  // object against our schema, so use it directly. Fall back to parsing the
+  // `result` text for older CLIs / the non-schema path.
   let parsed: unknown
-  try {
-    parsed = JSON.parse(extractJsonObject(resultText))
-  } catch {
-    throw new Error('Could not parse a JSON response from the model output')
+  if (envelope.structured_output && typeof envelope.structured_output === 'object') {
+    parsed = envelope.structured_output
+  } else {
+    const resultText = typeof envelope.result === 'string' ? envelope.result : ''
+    if (!resultText.trim()) throw new Error('Claude CLI returned an empty result')
+    try {
+      parsed = JSON.parse(extractJsonObject(resultText))
+    } catch {
+      throw new Error('Could not parse a JSON response from the model output')
+    }
   }
+
   const validated = responseSchema.safeParse(parsed)
   if (!validated.success) {
     throw new Error(
@@ -342,20 +355,28 @@ export interface HarnessMeta {
   agentic: boolean
   /** Turns reported by the CLI (>1 implies tool round-trips happened). */
   turns?: number
+  /** CLI session id — pass back as resumeSessionId next turn for conversation memory. */
+  sessionId?: string
 }
 
-/** num_turns + permission-denial count from a decoded CLI result envelope. */
+/** num_turns + permission-denial count + session id from a decoded CLI envelope. */
 function readEnvelopeStatsFromObject(env: Record<string, unknown>): {
   turns?: number
   denials: number
+  sessionId?: string
 } {
   const turns = typeof env.num_turns === 'number' ? env.num_turns : undefined
   const denials = Array.isArray(env.permission_denials) ? env.permission_denials.length : 0
-  return { turns, denials }
+  const sessionId = typeof env.session_id === 'string' ? env.session_id : undefined
+  return { turns, denials, sessionId }
 }
 
-/** Read num_turns + permission-denial count from the CLI's JSON envelope. */
-function readEnvelopeStats(stdout: string): { turns?: number; denials: number } {
+/** Read num_turns + permission-denial count + session id from the CLI envelope. */
+function readEnvelopeStats(stdout: string): {
+  turns?: number
+  denials: number
+  sessionId?: string
+} {
   try {
     return readEnvelopeStatsFromObject(JSON.parse(stdout) as Record<string, unknown>)
   } catch {
@@ -391,22 +412,24 @@ export async function generateChatResponseViaHarness(
 
     let args: string[]
     let timeoutMs: number
+    // Native structured output via --json-schema (no prose-only instruction needed).
     if (agentic && mcp && connectionId) {
       const systemPrompt =
-        buildSystemPrompt(schemas, dbType) +
-        buildAgenticInstruction(connectionId) +
-        JSON_ONLY_INSTRUCTION
+        buildSystemPrompt(schemas, dbType) + buildAgenticInstruction(connectionId)
       args = buildAgenticHarnessArgs(
         userPrompt,
         systemPrompt,
         model,
         buildMcpConfigJson(mcp),
-        mcpAllowedTools()
+        mcpAllowedTools(),
+        { jsonSchema: RESPONSE_JSON_SCHEMA_STRING }
       )
       timeoutMs = AGENTIC_TIMEOUT_MS
     } else {
-      const systemPrompt = buildSystemPrompt(schemas, dbType) + JSON_ONLY_INSTRUCTION
-      args = buildHarnessArgs(userPrompt, systemPrompt, model)
+      const systemPrompt = buildSystemPrompt(schemas, dbType)
+      args = buildHarnessArgs(userPrompt, systemPrompt, model, {
+        jsonSchema: RESPONSE_JSON_SCHEMA_STRING
+      })
       timeoutMs = GENERATION_TIMEOUT_MS
     }
 
@@ -418,9 +441,9 @@ export async function generateChatResponseViaHarness(
     // reason; fall back to stderr/exit code only when there's no output.
     if (stdout.trim()) {
       const data = parseHarnessResult(stdout)
-      const { turns, denials } = readEnvelopeStats(stdout)
+      const { turns, denials, sessionId } = readEnvelopeStats(stdout)
       const grounded = isGrounded(agentic, turns, denials)
-      return { success: true, data, meta: { grounded, agentic, turns } }
+      return { success: true, data, meta: { grounded, agentic, turns, sessionId } }
     }
     const detail = stderr.trim() || `exited with code ${code}`
     throw new Error(`Claude CLI failed: ${detail}`)
@@ -504,39 +527,49 @@ export async function generateChatResponseViaHarnessStream(
   schemas: SchemaInfo[],
   dbType: string,
   connectionId: string | undefined,
+  resumeSessionId: string | undefined,
   onEvent: (event: AIChatStreamEvent) => void
 ): Promise<{ success: boolean; data?: AIStructuredResponse; error?: string; meta?: HarnessMeta }> {
   try {
     const bin = resolveClaudeBinary()
     const model = config.model || DEFAULT_MODELS['claude-cli']
-    const userPrompt = buildUserPrompt(messages)
+    // Resuming a session restores the prior turns server-side, so we send only
+    // the latest user message instead of replaying the whole transcript.
+    const userPrompt = resumeSessionId
+      ? messages[messages.length - 1].content
+      : buildUserPrompt(messages)
 
     const mcp = getMcpRuntimeInfo()
     const agentic = mcp !== null && !!connectionId
+
+    // Native structured output via --json-schema; optional session resume.
+    const argOpts: HarnessArgOpts = {
+      stream: true,
+      jsonSchema: RESPONSE_JSON_SCHEMA_STRING,
+      resumeSessionId
+    }
 
     let args: string[]
     let timeoutMs: number
     if (agentic && mcp && connectionId) {
       const systemPrompt =
-        buildSystemPrompt(schemas, dbType) +
-        buildAgenticInstruction(connectionId) +
-        JSON_ONLY_INSTRUCTION
+        buildSystemPrompt(schemas, dbType) + buildAgenticInstruction(connectionId)
       args = buildAgenticHarnessArgs(
         userPrompt,
         systemPrompt,
         model,
         buildMcpConfigJson(mcp),
         mcpAllowedTools(),
-        { stream: true }
+        argOpts
       )
       timeoutMs = AGENTIC_TIMEOUT_MS
     } else {
-      const systemPrompt = buildSystemPrompt(schemas, dbType) + JSON_ONLY_INSTRUCTION
-      args = buildHarnessArgs(userPrompt, systemPrompt, model, { stream: true })
+      const systemPrompt = buildSystemPrompt(schemas, dbType)
+      args = buildHarnessArgs(userPrompt, systemPrompt, model, argOpts)
       timeoutMs = GENERATION_TIMEOUT_MS
     }
 
-    log.debug('Running claude CLI (streaming)', { bin, model, agentic })
+    log.debug('Running claude CLI (streaming)', { bin, model, agentic, resume: !!resumeSessionId })
 
     let raw = ''
     let lastMessage = ''
@@ -545,8 +578,12 @@ export async function generateChatResponseViaHarnessStream(
 
     const { stderr, code } = await runProcessStreaming(bin, args, timeoutMs, (obj) => {
       const info = classifyStreamLine(obj)
-      if (info.textDelta) {
-        raw += info.textDelta
+      // With --json-schema the reply streams as input_json_delta fragments; the
+      // non-schema path streams text_delta. Either way `raw` accumulates the JSON
+      // string, and extractPartialMessage surfaces the "message" field live.
+      const delta = info.jsonDelta ?? info.textDelta
+      if (delta) {
+        raw += delta
         const message = extractPartialMessage(raw)
         if (message && message !== lastMessage) {
           lastMessage = message
@@ -566,9 +603,9 @@ export async function generateChatResponseViaHarnessStream(
     }
 
     const data = parseResultEnvelope(resultEnvelope)
-    const { turns, denials } = readEnvelopeStatsFromObject(resultEnvelope)
+    const { turns, denials, sessionId } = readEnvelopeStatsFromObject(resultEnvelope)
     const grounded = isGrounded(agentic, turns, denials)
-    return { success: true, data, meta: { grounded, agentic, turns } }
+    return { success: true, data, meta: { grounded, agentic, turns, sessionId } }
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error)
     log.error('generateChatResponseViaHarnessStream error:', message)

--- a/apps/desktop/src/main/harness-stream.ts
+++ b/apps/desktop/src/main/harness-stream.ts
@@ -1,0 +1,147 @@
+/**
+ * Streaming helpers for the BYOH harness — Pure Module.
+ *
+ * `claude -p --output-format stream-json --include-partial-messages` emits NDJSON:
+ * one JSON object per line. This module turns those lines into the two things the
+ * chat UI needs — the assistant's prose as it streams, and a live label for each
+ * grounding/tool step — without any Electron / process imports, so it unit-tests
+ * in plain node.
+ */
+
+/** A single classified NDJSON line. Any field may be absent. */
+export interface StreamLineInfo {
+  /** Incremental assistant text (from a content_block_delta / text_delta). */
+  textDelta?: string
+  /** Human label for a tool the assistant just invoked (grounding step). */
+  toolLabel?: string
+  /** The terminal `result` envelope, carrying the model's final reply + stats. */
+  resultEnvelope?: Record<string, unknown>
+}
+
+const TOOL_LABELS: Record<string, string> = {
+  run_query: 'Running query…',
+  explain_query: 'Explaining query…',
+  list_schemas: 'Reading schema…'
+}
+
+/** Friendly label for an MCP tool id like `mcp__datapeek__run_query`. */
+export function toolLabel(name: string): string {
+  const short = name.split('__').pop() || name
+  return TOOL_LABELS[short] ?? `Using ${short}…`
+}
+
+/**
+ * Classify one parsed NDJSON line from the CLI's stream-json output. Only the
+ * frames we care about produce a non-empty result; everything else (rate_limit,
+ * hook_*, status, message_start/stop, user tool-results) is ignored.
+ */
+export function classifyStreamLine(obj: unknown): StreamLineInfo {
+  const info: StreamLineInfo = {}
+  if (!obj || typeof obj !== 'object') return info
+  const line = obj as Record<string, unknown>
+
+  if (line.type === 'stream_event') {
+    const event = line.event as
+      { type?: string; delta?: { type?: string; text?: unknown } } | undefined
+    if (event?.type === 'content_block_delta' && event.delta?.type === 'text_delta') {
+      info.textDelta = String(event.delta.text ?? '')
+    }
+    return info
+  }
+
+  if (line.type === 'assistant') {
+    const message = line.message as { content?: unknown } | undefined
+    const content = message?.content
+    if (Array.isArray(content)) {
+      for (const block of content) {
+        if (block && typeof block === 'object') {
+          const b = block as { type?: string; name?: unknown }
+          if (b.type === 'tool_use' && typeof b.name === 'string') {
+            info.toolLabel = toolLabel(b.name)
+            break
+          }
+        }
+      }
+    }
+    return info
+  }
+
+  if (line.type === 'result') {
+    info.resultEnvelope = line
+    return info
+  }
+
+  return info
+}
+
+/**
+ * Extract the current (possibly partial) value of the top-level "message" field
+ * from an in-progress JSON string. The model streams its structured reply
+ * character by character, so once it starts writing `"message": "…"` we can
+ * surface that prose live — before the JSON is complete. Returns the decoded
+ * string so far, or '' when the field hasn't started yet.
+ *
+ * Handles JSON escapes and stops cleanly at an incomplete escape/unicode run so
+ * a half-streamed value never throws.
+ */
+export function extractPartialMessage(raw: string): string {
+  const keyIndex = raw.indexOf('"message"')
+  if (keyIndex === -1) return ''
+
+  let i = raw.indexOf(':', keyIndex + '"message"'.length)
+  if (i === -1) return ''
+  i++
+  while (i < raw.length && /\s/.test(raw[i])) i++
+  if (raw[i] !== '"') return ''
+  i++ // past the opening quote
+
+  let out = ''
+  while (i < raw.length) {
+    const c = raw[i]
+    if (c === '\\') {
+      const next = raw[i + 1]
+      if (next === undefined) return out // incomplete escape — stop, don't throw
+      switch (next) {
+        case 'n':
+          out += '\n'
+          break
+        case 't':
+          out += '\t'
+          break
+        case 'r':
+          out += '\r'
+          break
+        case 'b':
+          out += '\b'
+          break
+        case 'f':
+          out += '\f'
+          break
+        case '"':
+          out += '"'
+          break
+        case '\\':
+          out += '\\'
+          break
+        case '/':
+          out += '/'
+          break
+        case 'u': {
+          const hex = raw.slice(i + 2, i + 6)
+          if (hex.length < 4) return out // incomplete unicode escape — stop
+          out += String.fromCharCode(parseInt(hex, 16))
+          i += 4
+          break
+        }
+        default:
+          out += next
+      }
+      i += 2
+      continue
+    }
+    if (c === '"') return out // closing quote — string complete
+    out += c
+    i++
+  }
+  return out // string not yet closed — return what streamed so far
+}

--- a/apps/desktop/src/main/harness-stream.ts
+++ b/apps/desktop/src/main/harness-stream.ts
@@ -12,6 +12,12 @@
 export interface StreamLineInfo {
   /** Incremental assistant text (from a content_block_delta / text_delta). */
   textDelta?: string
+  /**
+   * Incremental structured-output JSON (from an input_json_delta). Emitted when
+   * the CLI runs with `--json-schema`: the reply streams as JSON fragments rather
+   * than plain text. Accumulated, it reconstructs the same JSON object.
+   */
+  jsonDelta?: string
   /** Human label for a tool the assistant just invoked (grounding step). */
   toolLabel?: string
   /** The terminal `result` envelope, carrying the model's final reply + stats. */
@@ -42,9 +48,14 @@ export function classifyStreamLine(obj: unknown): StreamLineInfo {
 
   if (line.type === 'stream_event') {
     const event = line.event as
-      { type?: string; delta?: { type?: string; text?: unknown } } | undefined
-    if (event?.type === 'content_block_delta' && event.delta?.type === 'text_delta') {
-      info.textDelta = String(event.delta.text ?? '')
+      | { type?: string; delta?: { type?: string; text?: unknown; partial_json?: unknown } }
+      | undefined
+    if (event?.type === 'content_block_delta') {
+      if (event.delta?.type === 'text_delta') {
+        info.textDelta = String(event.delta.text ?? '')
+      } else if (event.delta?.type === 'input_json_delta') {
+        info.jsonDelta = String(event.delta.partial_json ?? '')
+      }
     }
     return info
   }

--- a/apps/desktop/src/main/harness-stream.ts
+++ b/apps/desktop/src/main/harness-stream.ts
@@ -30,10 +30,15 @@ const TOOL_LABELS: Record<string, string> = {
   list_schemas: 'Reading schema…'
 }
 
-/** Friendly label for an MCP tool id like `mcp__datapeek__run_query`. */
-export function toolLabel(name: string): string {
+/**
+ * Friendly label for one of our MCP read tools (e.g. `mcp__datapeek__run_query`).
+ * Returns undefined for anything else — including the CLI's internal
+ * `StructuredOutput` tool used to enforce --json-schema, which is an output
+ * mechanism, not a grounding step, and shouldn't show as activity.
+ */
+export function toolLabel(name: string): string | undefined {
   const short = name.split('__').pop() || name
-  return TOOL_LABELS[short] ?? `Using ${short}…`
+  return TOOL_LABELS[short]
 }
 
 /**
@@ -68,8 +73,13 @@ export function classifyStreamLine(obj: unknown): StreamLineInfo {
         if (block && typeof block === 'object') {
           const b = block as { type?: string; name?: unknown }
           if (b.type === 'tool_use' && typeof b.name === 'string') {
-            info.toolLabel = toolLabel(b.name)
-            break
+            const label = toolLabel(b.name)
+            // Skip internal/output tools (e.g. StructuredOutput) — only real
+            // grounding tools become activity.
+            if (label) {
+              info.toolLabel = label
+              break
+            }
           }
         }
       }

--- a/apps/desktop/src/main/ipc/ai-handlers.ts
+++ b/apps/desktop/src/main/ipc/ai-handlers.ts
@@ -6,6 +6,7 @@ import {
   clearAIConfig,
   validateAPIKey,
   generateChatResponse,
+  generateChatResponseStream,
   generateDashboard,
   getChatHistory,
   saveChatHistory,
@@ -236,6 +237,58 @@ export function registerAIHandlers(): void {
         log.error('Chat error:', error)
         const errorMessage = error instanceof Error ? error.message : String(error)
         return { success: false, error: errorMessage }
+      }
+    }
+  )
+
+  // Streaming chat: same as ai:chat, but pushes incremental events on
+  // 'ai:chat-stream:event' (keyed by requestId) while the invoke resolves with
+  // the final structured response. Used by the main chat panel; the modal
+  // dialogs keep using the one-shot ai:chat handler above.
+  ipcMain.handle(
+    'ai:chat-stream',
+    async (
+      event,
+      {
+        requestId,
+        messages,
+        schemas,
+        dbType,
+        connectionId
+      }: {
+        requestId: string
+        messages: AIMessage[]
+        schemas: SchemaInfo[]
+        dbType: string
+        connectionId?: string
+      }
+    ) => {
+      try {
+        const config = getAIConfig()
+        if (!config) {
+          return { success: false, error: 'AI not configured. Please set up your API key.' }
+        }
+
+        const result = await generateChatResponseStream(
+          config,
+          messages,
+          schemas,
+          dbType,
+          connectionId,
+          (streamEvent) => {
+            if (!event.sender.isDestroyed()) {
+              event.sender.send('ai:chat-stream:event', { requestId, event: streamEvent })
+            }
+          }
+        )
+
+        if (result.success && result.data) {
+          return { success: true, data: result.data, meta: result.meta }
+        }
+        return { success: false, error: result.error }
+      } catch (error: unknown) {
+        log.error('Chat stream error:', error)
+        return { success: false, error: error instanceof Error ? error.message : String(error) }
       }
     }
   )

--- a/apps/desktop/src/main/ipc/ai-handlers.ts
+++ b/apps/desktop/src/main/ipc/ai-handlers.ts
@@ -254,13 +254,15 @@ export function registerAIHandlers(): void {
         messages,
         schemas,
         dbType,
-        connectionId
+        connectionId,
+        resumeSessionId
       }: {
         requestId: string
         messages: AIMessage[]
         schemas: SchemaInfo[]
         dbType: string
         connectionId?: string
+        resumeSessionId?: string
       }
     ) => {
       try {
@@ -275,6 +277,7 @@ export function registerAIHandlers(): void {
           schemas,
           dbType,
           connectionId,
+          resumeSessionId,
           (streamEvent) => {
             if (!event.sender.isDestroyed()) {
               event.sender.send('ai:chat-stream:event', { requestId, event: streamEvent })

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -126,9 +126,7 @@ interface AIMessage {
 type AIResponseType = 'message' | 'query' | 'chart' | 'metric' | 'schema'
 
 // Incremental event from a streaming chat run (mirror of shared AIChatStreamEvent)
-type AIChatStreamEvent =
-  | { type: 'message'; text: string }
-  | { type: 'activity'; label: string }
+type AIChatStreamEvent = { type: 'message'; text: string } | { type: 'activity'; label: string }
 
 // Flat schema with nullable fields for AI provider compatibility
 interface AIChatResponse {
@@ -458,10 +456,11 @@ interface DataPeekApi {
       schemas: SchemaInfo[],
       dbType: string,
       connectionId: string | undefined,
+      resumeSessionId: string | undefined,
       onEvent: (event: AIChatStreamEvent) => void
     ) => Promise<
       IpcResponse<AIChatResponse> & {
-        meta?: { grounded: boolean; agentic: boolean; turns?: number }
+        meta?: { grounded: boolean; agentic: boolean; turns?: number; sessionId?: string }
       }
     >
     // Chat history persistence (legacy API)

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -125,6 +125,11 @@ interface AIMessage {
 // Structured AI response types
 type AIResponseType = 'message' | 'query' | 'chart' | 'metric' | 'schema'
 
+// Incremental event from a streaming chat run (mirror of shared AIChatStreamEvent)
+type AIChatStreamEvent =
+  | { type: 'message'; text: string }
+  | { type: 'activity'; label: string }
+
 // Flat schema with nullable fields for AI provider compatibility
 interface AIChatResponse {
   type: AIResponseType
@@ -443,6 +448,17 @@ interface DataPeekApi {
       schemas: SchemaInfo[],
       dbType: string,
       connectionId?: string
+    ) => Promise<
+      IpcResponse<AIChatResponse> & {
+        meta?: { grounded: boolean; agentic: boolean; turns?: number }
+      }
+    >
+    chatStream: (
+      messages: AIMessage[],
+      schemas: SchemaInfo[],
+      dbType: string,
+      connectionId: string | undefined,
+      onEvent: (event: AIChatStreamEvent) => void
     ) => Promise<
       IpcResponse<AIChatResponse> & {
         meta?: { grounded: boolean; agentic: boolean; turns?: number }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -22,6 +22,7 @@ import type {
   AIConfig,
   AIMessage,
   AIChatResponse,
+  AIChatStreamEvent,
   StoredChatMessage,
   ChatSession,
   AIMultiProviderConfig,
@@ -97,6 +98,7 @@ export type {
   AIConfig,
   AIMessage,
   AIChatResponse,
+  AIChatStreamEvent,
   StoredChatMessage,
   ChatSession,
   AIMultiProviderConfig,
@@ -585,8 +587,38 @@ const api = {
       dbType: string,
       connectionId?: string
     ): Promise<
-      IpcResponse<AIChatResponse> & { meta?: { grounded: boolean; agentic: boolean; turns?: number } }
+      IpcResponse<AIChatResponse> & {
+        meta?: { grounded: boolean; agentic: boolean; turns?: number }
+      }
     > => ipcRenderer.invoke('ai:chat', { messages, schemas, dbType, connectionId }),
+    // Streaming chat: resolves with the final response; `onEvent` fires with
+    // incremental prose/activity while it runs. Each call is keyed by a
+    // requestId so concurrent chats don't cross streams.
+    chatStream: (
+      messages: AIMessage[],
+      schemas: SchemaInfo[],
+      dbType: string,
+      connectionId: string | undefined,
+      onEvent: (event: AIChatStreamEvent) => void
+    ): Promise<
+      IpcResponse<AIChatResponse> & {
+        meta?: { grounded: boolean; agentic: boolean; turns?: number }
+      }
+    > => {
+      const requestId =
+        globalThis.crypto?.randomUUID?.() ??
+        `req-${Date.now()}-${Math.random().toString(36).slice(2)}`
+      const listener = (
+        _e: unknown,
+        payload: { requestId: string; event: AIChatStreamEvent }
+      ): void => {
+        if (payload?.requestId === requestId) onEvent(payload.event)
+      }
+      ipcRenderer.on('ai:chat-stream:event', listener)
+      return ipcRenderer
+        .invoke('ai:chat-stream', { requestId, messages, schemas, dbType, connectionId })
+        .finally(() => ipcRenderer.removeListener('ai:chat-stream:event', listener))
+    },
     // Chat history persistence (legacy API)
     getChatHistory: (connectionId: string): Promise<IpcResponse<StoredChatMessage[]>> =>
       ipcRenderer.invoke('ai:get-chat-history', connectionId),

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -599,10 +599,11 @@ const api = {
       schemas: SchemaInfo[],
       dbType: string,
       connectionId: string | undefined,
+      resumeSessionId: string | undefined,
       onEvent: (event: AIChatStreamEvent) => void
     ): Promise<
       IpcResponse<AIChatResponse> & {
-        meta?: { grounded: boolean; agentic: boolean; turns?: number }
+        meta?: { grounded: boolean; agentic: boolean; turns?: number; sessionId?: string }
       }
     > => {
       const requestId =
@@ -616,7 +617,14 @@ const api = {
       }
       ipcRenderer.on('ai:chat-stream:event', listener)
       return ipcRenderer
-        .invoke('ai:chat-stream', { requestId, messages, schemas, dbType, connectionId })
+        .invoke('ai:chat-stream', {
+          requestId,
+          messages,
+          schemas,
+          dbType,
+          connectionId,
+          resumeSessionId
+        })
         .finally(() => ipcRenderer.removeListener('ai:chat-stream:event', listener))
     },
     // Chat history persistence (legacy API)

--- a/apps/desktop/src/renderer/src/components/ai/ai-chat-panel.tsx
+++ b/apps/desktop/src/renderer/src/components/ai/ai-chat-panel.tsx
@@ -843,8 +843,9 @@ export function AIChatPanel({
                   ))
                 )}
 
-                {/* Loading indicator */}
-                {isLoading && (
+                {/* Loading indicator — only when there's no streaming bubble
+                    already showing live activity (avoids a double "Thinking"). */}
+                {isLoading && !messages.some((m) => m.streaming) && (
                   <div className="flex items-start gap-3 animate-in fade-in-0 slide-in-from-bottom-2 duration-200">
                     <div className="flex items-center justify-center size-7 rounded-full bg-gradient-to-br from-blue-500/10 to-purple-500/10 border border-blue-500/20 shrink-0">
                       <Sparkles className="size-3.5 text-blue-400" />

--- a/apps/desktop/src/renderer/src/components/ai/ai-chat-panel.tsx
+++ b/apps/desktop/src/renderer/src/components/ai/ai-chat-panel.tsx
@@ -136,6 +136,13 @@ export function AIChatPanel({
   const inputRef = React.useRef<HTMLTextAreaElement>(null)
   const previousConnectionId = React.useRef<string | null>(null)
   const isInitialLoad = React.useRef(true)
+  // CLI session id from the last BYOH turn, so the next turn resumes the same
+  // conversation (server-side memory). Reset when the chat/connection changes.
+  const harnessSessionIdRef = React.useRef<string | undefined>(undefined)
+
+  React.useEffect(() => {
+    harnessSessionIdRef.current = undefined
+  }, [connection?.id, currentSessionId])
 
   // Load sessions when connection changes
   React.useEffect(() => {
@@ -285,11 +292,15 @@ export function AIChatPanel({
         schemas,
         dbType,
         connection.id,
+        harnessSessionIdRef.current,
         (event) => {
           if (event.type === 'message') patchAssistant({ content: event.text })
           else if (event.type === 'activity') patchAssistant({ activity: event.label })
         }
       )
+
+      // Remember the CLI session so the next turn resumes it (conversation memory).
+      if (response.meta?.sessionId) harnessSessionIdRef.current = response.meta.sessionId
 
       if (response.success && response.data) {
         const data = response.data
@@ -460,6 +471,9 @@ export function AIChatPanel({
   // Clear current session's chat
   const handleClearChat = async () => {
     setMessages([])
+    // Start a fresh CLI session too — resuming the old one would restore the
+    // conversation we just cleared.
+    harnessSessionIdRef.current = undefined
     if (connection?.id && currentSessionId) {
       try {
         await window.api.ai.updateSession(connection.id, currentSessionId, { messages: [] })

--- a/apps/desktop/src/renderer/src/components/ai/ai-chat-panel.tsx
+++ b/apps/desktop/src/renderer/src/components/ai/ai-chat-panel.tsx
@@ -97,6 +97,10 @@ export interface AIChatMessage {
   responseData?: AIResponseData
   /** True when a BYOH harness answered agentically by querying the live DB. */
   grounded?: boolean
+  /** True while the assistant reply is still streaming in. */
+  streaming?: boolean
+  /** Live label for the current grounding/tool step (e.g. "Running query…"). */
+  activity?: string
   createdAt: Date
 }
 
@@ -251,29 +255,46 @@ export function AIChatPanel({
       createdAt: new Date()
     }
 
-    setMessages((prev) => [...prev, userMessage])
+    // Build message history BEFORE we add the empty streaming placeholder, so
+    // the placeholder itself is never sent to the model.
+    const aiMessages = [...messages, userMessage].map((m) => ({
+      role: m.role,
+      content: m.content
+    }))
+    const dbType = connection.dbType || 'postgresql'
+
+    // Placeholder assistant bubble that fills in as the reply streams.
+    const assistantId = crypto.randomUUID()
+    setMessages((prev) => [
+      ...prev,
+      userMessage,
+      { id: assistantId, role: 'assistant', content: '', streaming: true, createdAt: new Date() }
+    ])
     setInput('')
     setIsLoading(true)
 
+    const patchAssistant = (patch: Partial<AIChatMessage>): void =>
+      setMessages((prev) => prev.map((m) => (m.id === assistantId ? { ...m, ...patch } : m)))
+
     try {
-      // Build message history for AI context
-      const aiMessages = [...messages, userMessage].map((m) => ({
-        role: m.role,
-        content: m.content
-      }))
-
-      // Determine database type from connection
-      const dbType = connection.dbType || 'postgresql'
-
-      // Call actual AI service via IPC. Pass the connection id so a harness
-      // provider can query this database through the MCP server (agentic mode).
-      const response = await window.api.ai.chat(aiMessages, schemas, dbType, connection.id)
+      // Stream the reply. Prose arrives as `message` events; grounding/tool
+      // steps as `activity`. Pass the connection id so a harness provider can
+      // query this database through the MCP server (agentic mode).
+      const response = await window.api.ai.chatStream(
+        aiMessages,
+        schemas,
+        dbType,
+        connection.id,
+        (event) => {
+          if (event.type === 'message') patchAssistant({ content: event.text })
+          else if (event.type === 'activity') patchAssistant({ activity: event.label })
+        }
+      )
 
       if (response.success && response.data) {
         const data = response.data
 
-        // Extract response data based on type
-        // Note: Backend uses flat schema with nullable fields for AI provider compatibility
+        // Map the flat, nullable backend schema to the renderer's response data.
         let responseData: AIResponseData = null
         if (data.type === 'query' && data.sql) {
           responseData = {
@@ -314,35 +335,29 @@ export function AIChatPanel({
           }
         }
 
-        const assistantMessage: AIChatMessage = {
-          id: crypto.randomUUID(),
-          role: 'assistant',
+        // Finalize with the authoritative parsed response (replaces the live
+        // partial text, clears the activity indicator).
+        patchAssistant({
           content: data.message,
           responseData,
           grounded: response.meta?.grounded ?? false,
-          createdAt: new Date()
-        }
-
-        setMessages((prev) => [...prev, assistantMessage])
+          streaming: false,
+          activity: undefined
+        })
       } else {
-        // Show error message
-        const errorMessage: AIChatMessage = {
-          id: crypto.randomUUID(),
-          role: 'assistant',
+        patchAssistant({
           content: `Sorry, I encountered an error: ${response.error || 'Unknown error'}`,
-          createdAt: new Date()
-        }
-        setMessages((prev) => [...prev, errorMessage])
+          streaming: false,
+          activity: undefined
+        })
       }
     } catch (error) {
       console.error('AI chat error:', error)
-      const errorMessage: AIChatMessage = {
-        id: crypto.randomUUID(),
-        role: 'assistant',
+      patchAssistant({
         content: `Sorry, I encountered an error: ${error instanceof Error ? error.message : 'Unknown error'}`,
-        createdAt: new Date()
-      }
-      setMessages((prev) => [...prev, errorMessage])
+        streaming: false,
+        activity: undefined
+      })
     } finally {
       setIsLoading(false)
     }

--- a/apps/desktop/src/renderer/src/components/ai/ai-message.tsx
+++ b/apps/desktop/src/renderer/src/components/ai/ai-message.tsx
@@ -422,6 +422,10 @@ export function AIMessage({ message, onOpenInTab, connection, schemas = [] }: AI
                 }
                 return part
               })}
+              {/* Streaming caret while prose is still arriving */}
+              {!isUser && message.streaming && (
+                <span className="inline-block w-1 h-3.5 ml-0.5 -mb-0.5 bg-blue-400/80 animate-pulse align-middle" />
+              )}
             </div>
 
             {/* Copy button */}
@@ -439,6 +443,15 @@ export function AIMessage({ message, onOpenInTab, connection, schemas = [] }: AI
                 )}
               </button>
             )}
+          </div>
+        )}
+
+        {/* Live streaming activity: a grounding/tool step, or "Thinking…" before
+            any prose has arrived. Hidden once prose is streaming with no active step. */}
+        {!isUser && message.streaming && (message.activity || !message.content) && (
+          <div className="flex items-center gap-1.5 text-[11px] text-blue-400/90">
+            <Loader2 className="size-3 animate-spin" />
+            {message.activity ?? 'Thinking…'}
           </div>
         )}
 

--- a/apps/docs/content/docs/features/ai-assistant.mdx
+++ b/apps/docs/content/docs/features/ai-assistant.mdx
@@ -55,7 +55,7 @@ New in v0.27: instead of pasting an API key, point the assistant at the `claude`
 1. Install the Claude Code CLI and sign in (run `claude` once).
 2. In AI Settings, choose **Claude Code (local CLI)** — no API key required.
 3. Enable the MCP server (Settings → MCP) so the assistant can query your database.
-4. Ask in plain English. Read-only queries run automatically, and grounded answers show a **"Grounded against your database"** badge.
+4. Ask in plain English. The reply **streams in live** — you see the answer as it's written, and while it grounds itself you get a running indicator of each step ("_Running query…_", "_Reading schema…_"). Read-only queries run automatically, and grounded answers show a **"Grounded against your database"** badge.
 
 ## Features
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -476,6 +476,15 @@ export interface AIStructuredResponse {
  */
 export type AIChatResponse = AIStructuredResponse;
 
+/**
+ * Incremental event pushed from a streaming chat run (BYOH `stream-json`).
+ * `message` carries the assistant's prose as it is written; `activity` is a
+ * short human label for a live grounding/tool step (e.g. "Running query…").
+ */
+export type AIChatStreamEvent =
+  | { type: "message"; text: string }
+  | { type: "activity"; label: string };
+
 // Stored response data types (without message field since it's in content)
 
 /**


### PR DESCRIPTION
Modernizes BYOH (`claude-cli`) chat with the three primitives the current Claude Code CLI exposes. Each was spiked against the real CLI (`2.1.216`) before wiring, and each layer is verified live.

## Phase 1 — Streaming
Chat was one-shot (`--output-format json`, buffer, render — a dead spinner). Now `stream-json --verbose --include-partial-messages`:
- reply streams token-by-token, and
- each grounding/tool step shows live ("Running query…", "Reading schema…") with a caret.

`harness-stream.ts` (pure, unit-tested): `classifyStreamLine` maps NDJSON frames; `extractPartialMessage` pulls prose from the still-incomplete JSON. `runProcessStreaming` buffers NDJSON across chunk boundaries.

## Phase 2 — Native structured output (`--json-schema`)
- Pass `RESPONSE_JSON_SCHEMA` (hand-authored mirror of the zod `responseSchema`, kept in sync by a **drift-guard test**) so the CLI *constrains and validates* the reply. `parseResultEnvelope` prefers the validated `structured_output` object; falls back to text parsing. Drops the prompt-engineered `JSON_ONLY_INSTRUCTION`.
- Under `--json-schema` the reply streams as `input_json_delta` fragments (not `text_delta`); `classifyStreamLine` handles both, so live prose streaming still works.
- Applied to the one-shot path too (widget / notebook dialogs) → structured output is native everywhere.

## Phase 3 — Session memory (`--resume`)
- Capture `session_id` into `meta`; the chat panel keeps it per conversation and passes it back as `resumeSessionId` next turn. On resume we send **only the latest user message** (prior turns live in the CLI session), so history isn't re-sent each turn. Reset on connection/session switch and on clear.

## Verification
- Live against the CLI: streaming (`message` extracts incrementally); schema mode (`structured_output` populated, streams via `input_json_delta`); **combined resume+schema** (a resumed turn recalled `orders_2024` from the prior turn *and* returned schema-valid `SELECT COUNT(*) FROM orders_2024;`).
- **1110 tests passing** (18 new parser/schema unit tests), typecheck (node + web) + lint clean.

Response contract unchanged → dashboards & notebooks untouched. Writes still go through the approval dialog. Non-CLI (API-key) providers keep working; they emit their final message as a single stream event and ignore resume.

https://claude.ai/code/session_01Khhdnw9aShE87ALovgMqax

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live-streaming AI chat responses with incremental assistant text rendering and real-time activity/tool-use labels during grounding.
  * Introduced a streaming chat API end-to-end (IPC + renderer), including session continuity via `sessionId`.
* **Documentation**
  * Updated Claude Code setup steps to reflect streamed replies and the grounding/progress indicators.
* **Tests**
  * Added coverage for streaming frame parsing (text deltas, tool labels, malformed/incomplete fragments) and for response JSON schema drift/validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->