### PR TITLE
feat(ai): chat superpowers — suggestion chips, pin-to-artifacts, @mentions, mini-reports

### DIFF
--- a/apps/desktop/src/main/ai-schema.ts
+++ b/apps/desktop/src/main/ai-schema.ts
@@ -75,7 +75,11 @@ export const responseSchema = z.object({
     .enum(['number', 'currency', 'percent', 'duration'])
     .nullish()
     .describe('Value format - for metric type'),
-  tables: z.array(z.string()).nullish().describe('Table names - for schema type')
+  tables: z.array(z.string()).nullish().describe('Table names - for schema type'),
+  suggestions: z
+    .array(z.string())
+    .nullish()
+    .describe('2-3 short follow-up questions the user might ask next (any type)')
 })
 
 /**
@@ -103,7 +107,8 @@ export const RESPONSE_JSON_SCHEMA = {
     yKeys: { type: ['array', 'null'], items: { type: 'string' } },
     label: { type: ['string', 'null'] },
     format: { type: ['string', 'null'], enum: ['number', 'currency', 'percent', 'duration', null] },
-    tables: { type: ['array', 'null'], items: { type: 'string' } }
+    tables: { type: ['array', 'null'], items: { type: 'string' } },
+    suggestions: { type: ['array', 'null'], items: { type: 'string' } }
   }
 } as const
 
@@ -130,7 +135,8 @@ export function normalizeStructuredResponse(
     yKeys: object.yKeys ?? null,
     label: object.label ?? null,
     format: object.format ?? null,
-    tables: object.tables ?? null
+    tables: object.tables ?? null,
+    suggestions: object.suggestions ?? null
   } as AIStructuredResponse
 }
 
@@ -197,7 +203,13 @@ Use when user asks about table structure or columns.
 ### type: "message"
 Use for general questions, clarifications, or when no SQL is needed.
 - Fill: message
-- Null: ALL other fields
+- Null: all other fields (suggestions is still allowed — see below)
+
+### suggestions (any type)
+Optionally include "suggestions": 2-3 SHORT (≤6 words) natural next questions the
+user is likely to ask given this answer and schema (e.g. "Break down by month",
+"Compare to last quarter", "Show as a chart"). Phrase them as prompts the user
+would send. Omit (null) if nothing useful comes to mind.
 
 ## SQL Guidelines
 - Use proper ${dbType} syntax

--- a/apps/desktop/src/main/ai-schema.ts
+++ b/apps/desktop/src/main/ai-schema.ts
@@ -53,7 +53,9 @@ Design a concise, useful dashboard for this database. Return ONLY a JSON object:
 // Flat object (not discriminatedUnion) for Anthropic/OpenAI tool compatibility;
 // .nullish() so missing fields are accepted and normalized to null below.
 export const responseSchema = z.object({
-  type: z.enum(['query', 'chart', 'metric', 'schema', 'message']).describe('Response type'),
+  type: z
+    .enum(['query', 'chart', 'metric', 'schema', 'message', 'report'])
+    .describe('Response type'),
   message: z.string().describe('Brief explanation or response message'),
   sql: z.string().nullish().describe('SQL query - for query/chart/metric types'),
   explanation: z.string().nullish().describe('Detailed explanation - for query type'),
@@ -76,6 +78,10 @@ export const responseSchema = z.object({
     .nullish()
     .describe('Value format - for metric type'),
   tables: z.array(z.string()).nullish().describe('Table names - for schema type'),
+  widgets: z
+    .array(dashboardWidgetSpecSchema)
+    .nullish()
+    .describe('For report type: 2-6 widgets (kpi/chart/table), each with read-only SQL'),
   suggestions: z
     .array(z.string())
     .nullish()
@@ -94,7 +100,7 @@ export const RESPONSE_JSON_SCHEMA = {
   additionalProperties: false,
   required: ['type', 'message'],
   properties: {
-    type: { type: 'string', enum: ['query', 'chart', 'metric', 'schema', 'message'] },
+    type: { type: 'string', enum: ['query', 'chart', 'metric', 'schema', 'message', 'report'] },
     message: { type: 'string' },
     sql: { type: ['string', 'null'] },
     explanation: { type: ['string', 'null'] },
@@ -108,6 +114,26 @@ export const RESPONSE_JSON_SCHEMA = {
     label: { type: ['string', 'null'] },
     format: { type: ['string', 'null'], enum: ['number', 'currency', 'percent', 'duration', null] },
     tables: { type: ['array', 'null'], items: { type: 'string' } },
+    widgets: {
+      type: ['array', 'null'],
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['title', 'kind', 'sql'],
+        properties: {
+          title: { type: 'string' },
+          kind: { type: 'string', enum: ['kpi', 'chart', 'table'] },
+          sql: { type: 'string' },
+          chartType: { type: ['string', 'null'], enum: ['bar', 'line', 'pie', 'area', null] },
+          format: {
+            type: ['string', 'null'],
+            enum: ['number', 'currency', 'percent', 'duration', null]
+          },
+          xKey: { type: ['string', 'null'] },
+          yKeys: { type: ['array', 'null'], items: { type: 'string' } }
+        }
+      }
+    },
     suggestions: { type: ['array', 'null'], items: { type: 'string' } }
   }
 } as const
@@ -136,6 +162,7 @@ export function normalizeStructuredResponse(
     label: object.label ?? null,
     format: object.format ?? null,
     tables: object.tables ?? null,
+    widgets: object.widgets ?? null,
     suggestions: object.suggestions ?? null
   } as AIStructuredResponse
 }
@@ -199,6 +226,17 @@ Use when user asks for a single KPI/number (total, count, average).
 Use when user asks about table structure or columns.
 - Fill: message, tables
 - Null: sql, explanation, warning, requiresConfirmation, title, description, chartType, xKey, yKeys, label, format
+
+### type: "report"
+Use when the user asks for an overview/summary/dashboard-like answer that needs
+SEVERAL metrics at once (e.g. "give me a business overview", "summarize signups").
+- Fill: message (1-2 sentence intro), widgets (2-6 items)
+- Each widget: { title, kind ("kpi"|"chart"|"table"), sql (READ-ONLY, valid for THIS
+  schema) }. For kind "chart" also set chartType + xKey + yKeys; for "kpi" set format
+  (sql returns a single row/column). Lead with KPIs, then charts, optionally a table.
+- Null: sql, chartType, xKey, yKeys, label, format, tables (those are for single-widget types)
+- Prefer a single "query"/"chart"/"metric" response for one focused ask; only use
+  "report" when multiple widgets genuinely help.
 
 ### type: "message"
 Use for general questions, clarifications, or when no SQL is needed.

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -123,7 +123,17 @@ interface AIMessage {
 }
 
 // Structured AI response types
-type AIResponseType = 'message' | 'query' | 'chart' | 'metric' | 'schema'
+type AIResponseType = 'message' | 'query' | 'chart' | 'metric' | 'schema' | 'report'
+
+interface AIReportWidget {
+  title: string
+  kind: 'kpi' | 'chart' | 'table'
+  sql: string
+  chartType?: 'bar' | 'line' | 'pie' | 'area' | null
+  format?: 'number' | 'currency' | 'percent' | 'duration' | null
+  xKey?: string | null
+  yKeys?: string[] | null
+}
 
 // Incremental event from a streaming chat run (mirror of shared AIChatStreamEvent)
 type AIChatStreamEvent = { type: 'message'; text: string } | { type: 'activity'; label: string }
@@ -148,6 +158,8 @@ interface AIChatResponse {
   format: 'number' | 'currency' | 'percent' | 'duration' | null
   // Schema fields (null when type is not schema)
   tables: string[] | null
+  // Report fields (null when type is not report)
+  widgets: AIReportWidget[] | null
   // 2–3 short follow-up prompts (any type). null when none.
   suggestions: string[] | null
 }

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -148,6 +148,8 @@ interface AIChatResponse {
   format: 'number' | 'currency' | 'percent' | 'duration' | null
   // Schema fields (null when type is not schema)
   tables: string[] | null
+  // 2–3 short follow-up prompts (any type). null when none.
+  suggestions: string[] | null
 }
 
 // Stored response data types (without message field since it's in content)

--- a/apps/desktop/src/renderer/src/components/ai/ai-chat-panel.tsx
+++ b/apps/desktop/src/renderer/src/components/ai/ai-chat-panel.tsx
@@ -34,7 +34,7 @@ import {
 
 import { AIMessage } from './ai-message'
 import { AISuggestions } from './ai-suggestions'
-import type { ConnectionConfig, SchemaInfo } from '@data-peek/shared'
+import type { ConnectionConfig, SchemaInfo, AIReportWidget } from '@data-peek/shared'
 
 // Chat session type (matching preload)
 interface ChatSession {
@@ -88,7 +88,13 @@ export interface AISchemaData {
   tables: string[]
 }
 
-export type AIResponseData = AIQueryData | AIChartData | AIMetricData | AISchemaData | null
+export interface AIReportData {
+  type: 'report'
+  widgets: AIReportWidget[]
+}
+
+export type AIResponseData =
+  AIQueryData | AIChartData | AIMetricData | AISchemaData | AIReportData | null
 
 export interface AIChatMessage {
   id: string
@@ -222,7 +228,8 @@ export function AIChatPanel({
           id: m.id,
           role: m.role,
           content: m.content,
-          responseData: m.responseData || null,
+          // Reports are ephemeral (re-run on demand), so they aren't persisted.
+          responseData: m.responseData && m.responseData.type !== 'report' ? m.responseData : null,
           createdAt: m.createdAt.toISOString()
         }))
         const response = await window.api.ai.updateSession(connectionId, currentSessionId, {
@@ -354,6 +361,11 @@ export function AIChatPanel({
           responseData = {
             type: 'schema',
             tables: data.tables
+          }
+        } else if (data.type === 'report' && data.widgets && data.widgets.length > 0) {
+          responseData = {
+            type: 'report',
+            widgets: data.widgets
           }
         }
 

--- a/apps/desktop/src/renderer/src/components/ai/ai-chat-panel.tsx
+++ b/apps/desktop/src/renderer/src/components/ai/ai-chat-panel.tsx
@@ -101,6 +101,8 @@ export interface AIChatMessage {
   streaming?: boolean
   /** Live label for the current grounding/tool step (e.g. "Running query…"). */
   activity?: string
+  /** Short follow-up prompts the model suggested (clickable chips). */
+  suggestions?: string[]
   createdAt: Date
 }
 
@@ -253,12 +255,17 @@ export function AIChatPanel({
   }, [isOpen])
 
   const handleSendMessage = async () => {
-    if (!input.trim() || isLoading || !isConfigured || !connection) return
+    await sendPrompt(input.trim())
+  }
+
+  // Send an explicit prompt (used by the composer and by follow-up chips).
+  const sendPrompt = async (text: string) => {
+    if (!text || isLoading || !isConfigured || !connection) return
 
     const userMessage: AIChatMessage = {
       id: crypto.randomUUID(),
       role: 'user',
-      content: input.trim(),
+      content: text,
       createdAt: new Date()
     }
 
@@ -352,6 +359,7 @@ export function AIChatPanel({
           content: data.message,
           responseData,
           grounded: response.meta?.grounded ?? false,
+          suggestions: data.suggestions ?? undefined,
           streaming: false,
           activity: undefined
         })
@@ -837,6 +845,7 @@ export function AIChatPanel({
                       key={message.id}
                       message={message}
                       onOpenInTab={onOpenInTab}
+                      onSuggestionClick={sendPrompt}
                       connection={connection}
                       schemas={schemas}
                     />

--- a/apps/desktop/src/renderer/src/components/ai/ai-chat-panel.tsx
+++ b/apps/desktop/src/renderer/src/components/ai/ai-chat-panel.tsx
@@ -127,6 +127,10 @@ export function AIChatPanel({
 }: AIChatPanelProps) {
   const [messages, setMessages] = React.useState<AIChatMessage[]>([])
   const [input, setInput] = React.useState('')
+  // @-mention autocomplete for schema tables/columns in the composer.
+  const [mentionStart, setMentionStart] = React.useState(-1)
+  const [mentionQuery, setMentionQuery] = React.useState('')
+  const [mentionIndex, setMentionIndex] = React.useState(0)
   const [isLoading, setIsLoading] = React.useState(false)
   const [isExpanded, setIsExpanded] = React.useState(false)
   const [showSessionsList, setShowSessionsList] = React.useState(false)
@@ -382,7 +386,83 @@ export function AIChatPanel({
     }
   }
 
+  // Flat, ordered candidate list (tables first, then columns) for @-mentions.
+  const mentionItems = React.useMemo(() => {
+    if (mentionStart < 0) return []
+    const tables: Array<{ label: string; detail: string; insert: string }> = []
+    const cols: Array<{ label: string; detail: string; insert: string }> = []
+    for (const schema of schemas) {
+      for (const t of schema.tables) {
+        tables.push({ label: t.name, detail: 'table', insert: t.name })
+        for (const c of t.columns) {
+          cols.push({
+            label: `${t.name}.${c.name}`,
+            detail: c.dataType || 'column',
+            insert: `${t.name}.${c.name}`
+          })
+        }
+      }
+    }
+    const all = [...tables, ...cols]
+    const q = mentionQuery.toLowerCase()
+    return (q ? all.filter((i) => i.label.toLowerCase().includes(q)) : all).slice(0, 8)
+  }, [schemas, mentionStart, mentionQuery])
+
+  // Detect a trailing `@token` before the caret and open the mention menu.
+  const computeMention = (value: string, caret: number) => {
+    const match = value.slice(0, caret).match(/@([\w.]*)$/)
+    if (match) {
+      setMentionStart(caret - match[0].length)
+      setMentionQuery(match[1])
+      setMentionIndex(0)
+    } else if (mentionStart !== -1) {
+      setMentionStart(-1)
+      setMentionQuery('')
+    }
+  }
+
+  const applyMention = (item: { insert: string }) => {
+    if (mentionStart < 0) return
+    const end = mentionStart + 1 + mentionQuery.length
+    const next = input.slice(0, mentionStart) + item.insert + ' ' + input.slice(end)
+    setInput(next)
+    setMentionStart(-1)
+    setMentionQuery('')
+    const pos = mentionStart + item.insert.length + 1
+    requestAnimationFrame(() => {
+      const el = inputRef.current
+      if (el) {
+        el.focus()
+        el.setSelectionRange(pos, pos)
+      }
+    })
+  }
+
+  const mentionOpen = mentionStart >= 0 && mentionItems.length > 0
+
   const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (mentionOpen) {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        setMentionIndex((i) => (i + 1) % mentionItems.length)
+        return
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        setMentionIndex((i) => (i - 1 + mentionItems.length) % mentionItems.length)
+        return
+      }
+      if (e.key === 'Enter' || e.key === 'Tab') {
+        e.preventDefault()
+        applyMention(mentionItems[mentionIndex])
+        return
+      }
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        setMentionStart(-1)
+        return
+      }
+    }
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault()
       handleSendMessage()
@@ -892,10 +972,43 @@ export function AIChatPanel({
                   'focus-within:border-blue-500/30 focus-within:ring-2 focus-within:ring-blue-500/10'
                 )}
               >
+                {/* @-mention autocomplete menu (tables + columns) */}
+                {mentionOpen && (
+                  <div className="absolute bottom-full left-0 mb-2 w-72 max-h-56 overflow-auto rounded-lg border border-border/60 bg-popover shadow-xl z-50 py-1">
+                    <div className="px-2.5 py-1 text-[10px] uppercase tracking-wide text-muted-foreground/50">
+                      Reference a table or column
+                    </div>
+                    {mentionItems.map((item, i) => (
+                      <button
+                        key={item.label}
+                        type="button"
+                        onMouseDown={(e) => {
+                          e.preventDefault()
+                          applyMention(item)
+                        }}
+                        onMouseEnter={() => setMentionIndex(i)}
+                        className={cn(
+                          'flex w-full items-center justify-between gap-2 px-2.5 py-1.5 text-left text-xs',
+                          i === mentionIndex
+                            ? 'bg-blue-500/15 text-blue-200'
+                            : 'text-foreground/80 hover:bg-muted/40'
+                        )}
+                      >
+                        <span className="font-mono truncate">{item.label}</span>
+                        <span className="text-[10px] text-muted-foreground/60 shrink-0">
+                          {item.detail}
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                )}
                 <textarea
                   ref={inputRef}
                   value={input}
-                  onChange={(e) => setInput(e.target.value)}
+                  onChange={(e) => {
+                    setInput(e.target.value)
+                    computeMention(e.target.value, e.target.selectionStart ?? e.target.value.length)
+                  }}
                   onKeyDown={handleKeyDown}
                   placeholder="Ask about your data..."
                   rows={1}
@@ -934,7 +1047,7 @@ export function AIChatPanel({
                 </Button>
               </div>
               <p className="text-[10px] text-muted-foreground/50 mt-2 text-center">
-                Press Enter to send, Shift+Enter for new line
+                Press Enter to send, Shift+Enter for new line · Type @ to reference a table
               </p>
             </div>
           </>

--- a/apps/desktop/src/renderer/src/components/ai/ai-message.tsx
+++ b/apps/desktop/src/renderer/src/components/ai/ai-message.tsx
@@ -25,13 +25,15 @@ import { AIChart, type ChartData } from './ai-chart'
 import { AIMetricCard, type MetricData } from './ai-metric-card'
 import { AISchemaCard } from './ai-schema-card'
 import { AIQueryResult } from './ai-query-result'
+import { AIReport } from './ai-report'
 import type {
   AIChatMessage,
   AIResponseData,
   AIQueryData,
   AIChartData,
   AIMetricData,
-  AISchemaData
+  AISchemaData,
+  AIReportData
 } from './ai-chat-panel'
 import type { ConnectionConfig, SchemaInfo } from '@data-peek/shared'
 import { isReadOnlySql } from '@data-peek/shared'
@@ -500,6 +502,17 @@ export function AIMessage({
               <AISchemaCard key={table.name} table={table} />
             ))}
           </div>
+        )
+      }
+
+      case 'report': {
+        const reportData = data as AIReportData
+        return (
+          <AIReport
+            widgets={reportData.widgets}
+            connection={connection}
+            onOpenInTab={onOpenInTab}
+          />
         )
       }
 

--- a/apps/desktop/src/renderer/src/components/ai/ai-message.tsx
+++ b/apps/desktop/src/renderer/src/components/ai/ai-message.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { User, Sparkles, Copy, Check, AlertTriangle, Loader2 } from 'lucide-react'
+import { User, Sparkles, Copy, Check, AlertTriangle, Loader2, CornerDownRight } from 'lucide-react'
 import { cn } from '@data-peek/ui'
 import { AISQLPreview } from './ai-sql-preview'
 import { AIChart, type ChartData } from './ai-chart'
@@ -20,6 +20,7 @@ import { isReadOnlySql } from '@data-peek/shared'
 interface AIMessageProps {
   message: AIChatMessage
   onOpenInTab: (sql: string) => void
+  onSuggestionClick?: (prompt: string) => void
   connection?: ConnectionConfig | null
   schemas?: SchemaInfo[]
 }
@@ -32,7 +33,13 @@ interface QueryResultState {
   duration: number
 }
 
-export function AIMessage({ message, onOpenInTab, connection, schemas = [] }: AIMessageProps) {
+export function AIMessage({
+  message,
+  onOpenInTab,
+  onSuggestionClick,
+  connection,
+  schemas = []
+}: AIMessageProps) {
   const [copiedContent, setCopiedContent] = React.useState(false)
   const [chartData, setChartData] = React.useState<Record<string, unknown>[] | null>(null)
   const [chartLoading, setChartLoading] = React.useState(false)
@@ -465,6 +472,27 @@ export function AIMessage({ message, onOpenInTab, connection, schemas = [] }: AI
 
         {/* Response data (query, chart, metric, schema) */}
         {message.responseData && renderResponseData(message.responseData)}
+
+        {/* Follow-up suggestion chips */}
+        {!isUser &&
+          !message.streaming &&
+          onSuggestionClick &&
+          message.suggestions &&
+          message.suggestions.length > 0 && (
+            <div className="flex flex-wrap gap-1.5 mt-2.5">
+              {message.suggestions.slice(0, 3).map((s, i) => (
+                <button
+                  key={i}
+                  type="button"
+                  onClick={() => onSuggestionClick(s)}
+                  className="inline-flex items-center gap-1 rounded-full border border-blue-500/25 bg-blue-500/5 px-2.5 py-1 text-xs text-blue-300/90 hover:bg-blue-500/10 hover:border-blue-500/40 transition-colors"
+                >
+                  <CornerDownRight className="size-3 opacity-60" />
+                  {s}
+                </button>
+              ))}
+            </div>
+          )}
 
         {/* Timestamp */}
         <p className="text-[10px] text-muted-foreground/50 mt-1">

--- a/apps/desktop/src/renderer/src/components/ai/ai-message.tsx
+++ b/apps/desktop/src/renderer/src/components/ai/ai-message.tsx
@@ -1,6 +1,25 @@
 import * as React from 'react'
-import { User, Sparkles, Copy, Check, AlertTriangle, Loader2, CornerDownRight } from 'lucide-react'
-import { cn } from '@data-peek/ui'
+import {
+  User,
+  Sparkles,
+  Copy,
+  Check,
+  AlertTriangle,
+  Loader2,
+  CornerDownRight,
+  Pin,
+  BookmarkPlus,
+  LayoutDashboard,
+  NotebookPen
+} from 'lucide-react'
+import {
+  cn,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger
+} from '@data-peek/ui'
+import { buildWidgetConfig, widgetNameFor, type WidgetSourceData } from '@/lib/ai-widget'
 import { AISQLPreview } from './ai-sql-preview'
 import { AIChart, type ChartData } from './ai-chart'
 import { AIMetricCard, type MetricData } from './ai-metric-card'
@@ -51,7 +70,122 @@ export function AIMessage({
   const [queryExecuting, setQueryExecuting] = React.useState(false)
   const [queryError, setQueryError] = React.useState<string | null>(null)
 
+  const [pinBusy, setPinBusy] = React.useState(false)
+  const [pinResult, setPinResult] = React.useState<string | null>(null)
+
   const isUser = message.role === 'user'
+
+  // SQL-bearing responses (query/chart/metric) can be pinned into artifacts.
+  const rd = message.responseData
+  const pinnableSql =
+    rd && (rd.type === 'query' || rd.type === 'chart' || rd.type === 'metric') ? rd.sql : null
+
+  const toWidgetSource = (): WidgetSourceData => {
+    if (rd?.type === 'chart') {
+      return {
+        type: 'chart',
+        message: message.content,
+        chartType: rd.chartType,
+        xKey: rd.xKey,
+        yKeys: rd.yKeys,
+        title: rd.title
+      }
+    }
+    if (rd?.type === 'metric') {
+      return { type: 'metric', message: message.content, label: rd.label, format: rd.format }
+    }
+    return { type: 'query', message: message.content }
+  }
+
+  const saveQuery = async () => {
+    if (!pinnableSql) return
+    setPinBusy(true)
+    try {
+      const now = Date.now()
+      await window.api.savedQueries.add({
+        id: crypto.randomUUID(),
+        name: (message.content || 'AI query').slice(0, 60),
+        query: pinnableSql,
+        tags: [],
+        connectionId: connection?.id,
+        usageCount: 0,
+        createdAt: now,
+        updatedAt: now
+      })
+      setPinResult('Saved to Saved Queries')
+    } catch {
+      setPinResult('Save failed')
+    } finally {
+      setPinBusy(false)
+    }
+  }
+
+  const pinToDashboard = async () => {
+    if (!pinnableSql || !connection) return
+    setPinBusy(true)
+    try {
+      const run = await window.api.db.query(connection, pinnableSql)
+      const rows = (run.success && (run.data as { rows?: Record<string, unknown>[] })?.rows) || []
+      const cols = rows[0] ? Object.keys(rows[0]) : []
+      const source = toWidgetSource()
+      const { config, w, h } = buildWidgetConfig(source, cols)
+
+      const list = await window.api.dashboards.list()
+      let dash = list.success && list.data && list.data.length > 0 ? list.data[0] : null
+      if (!dash) {
+        const created = await window.api.dashboards.create({
+          name: 'AI Dashboard',
+          tags: [],
+          widgets: [],
+          layoutCols: 12
+        })
+        dash = created.success ? (created.data ?? null) : null
+      }
+      if (!dash) throw new Error('no dashboard')
+
+      await window.api.dashboards.addWidget(dash.id, {
+        name: widgetNameFor(source),
+        dataSource: { type: 'inline', sql: pinnableSql, connectionId: connection.id },
+        config,
+        layout: { x: 0, y: 0, w, h, minW: 2, minH: 2 },
+        aiGenerated: true
+      })
+      setPinResult(`Added to ${dash.name}`)
+    } catch {
+      setPinResult('Pin failed')
+    } finally {
+      setPinBusy(false)
+    }
+  }
+
+  const addToNotebook = async () => {
+    if (!pinnableSql || !connection) return
+    setPinBusy(true)
+    try {
+      const list = await window.api.notebooks.list()
+      let nb =
+        list.success && list.data
+          ? (list.data.find((n) => n.connectionId === connection.id) ?? null)
+          : null
+      if (!nb) {
+        const created = await window.api.notebooks.create({
+          title: 'AI Notebook',
+          connectionId: connection.id
+        })
+        nb = created.success ? (created.data ?? null) : null
+      }
+      if (!nb) throw new Error('no notebook')
+
+      const full = await window.api.notebooks.get(nb.id)
+      const order = full.success && full.data ? full.data.cells.length : 0
+      await window.api.notebooks.addCell(nb.id, { type: 'sql', content: pinnableSql, order })
+      setPinResult(`Added to ${nb.title}`)
+    } catch {
+      setPinResult('Add failed')
+    } finally {
+      setPinBusy(false)
+    }
+  }
 
   const handleCopyContent = () => {
     navigator.clipboard.writeText(message.content)
@@ -472,6 +606,48 @@ export function AIMessage({
 
         {/* Response data (query, chart, metric, schema) */}
         {message.responseData && renderResponseData(message.responseData)}
+
+        {/* Pin to a dashboard / notebook / saved query */}
+        {!isUser && !message.streaming && pinnableSql && connection && (
+          <div className="flex items-center gap-2 mt-2">
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  type="button"
+                  disabled={pinBusy}
+                  className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[11px] text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
+                >
+                  {pinBusy ? (
+                    <Loader2 className="size-3 animate-spin" />
+                  ) : (
+                    <Pin className="size-3" />
+                  )}
+                  Pin
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start" className="w-48">
+                <DropdownMenuItem onClick={saveQuery}>
+                  <BookmarkPlus className="size-3.5" />
+                  Save query
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={pinToDashboard}>
+                  <LayoutDashboard className="size-3.5" />
+                  Add to dashboard
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={addToNotebook}>
+                  <NotebookPen className="size-3.5" />
+                  Add to notebook cell
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+            {pinResult && (
+              <span className="inline-flex items-center gap-1 text-[11px] text-green-400/90">
+                <Check className="size-3" />
+                {pinResult}
+              </span>
+            )}
+          </div>
+        )}
 
         {/* Follow-up suggestion chips */}
         {!isUser &&

--- a/apps/desktop/src/renderer/src/components/ai/ai-report.tsx
+++ b/apps/desktop/src/renderer/src/components/ai/ai-report.tsx
@@ -1,0 +1,143 @@
+import * as React from 'react'
+import { Loader2, AlertTriangle } from 'lucide-react'
+import type { AIReportWidget, ConnectionConfig } from '@data-peek/shared'
+import { isReadOnlySql } from '@data-peek/shared'
+import { AIChart } from './ai-chart'
+import { AIMetricCard } from './ai-metric-card'
+import { AIQueryResult } from './ai-query-result'
+
+interface AIReportProps {
+  widgets: AIReportWidget[]
+  connection?: ConnectionConfig | null
+  onOpenInTab: (sql: string) => void
+}
+
+/** One report widget: runs its own read-only SQL and renders kpi/chart/table. */
+function ReportWidgetView({
+  widget,
+  connection,
+  onOpenInTab
+}: {
+  widget: AIReportWidget
+  connection?: ConnectionConfig | null
+  onOpenInTab: (sql: string) => void
+}) {
+  const [rows, setRows] = React.useState<Record<string, unknown>[] | null>(null)
+  const [error, setError] = React.useState<string | null>(null)
+  const [loading, setLoading] = React.useState(false)
+
+  React.useEffect(() => {
+    if (!connection) return
+    if (!isReadOnlySql(widget.sql)) {
+      setError('Skipped — not a read-only query')
+      return
+    }
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    window.api.db
+      .query(connection, widget.sql)
+      .then((res) => {
+        if (cancelled) return
+        if (res.success && res.data) {
+          setRows((res.data as { rows: Record<string, unknown>[] }).rows)
+        } else {
+          setError(res.error || 'Query failed')
+        }
+      })
+      .catch((e) => !cancelled && setError(e instanceof Error ? e.message : 'Query failed'))
+      .finally(() => !cancelled && setLoading(false))
+    return () => {
+      cancelled = true
+    }
+  }, [connection, widget.sql])
+
+  if (loading) {
+    return (
+      <div className="rounded-lg border border-border/50 bg-muted/20 p-4 flex items-center gap-2">
+        <Loader2 className="size-4 animate-spin text-blue-400" />
+        <span className="text-xs text-muted-foreground">{widget.title}…</span>
+      </div>
+    )
+  }
+  if (error) {
+    return (
+      <div className="rounded-lg border border-red-500/30 bg-red-500/5 p-3">
+        <div className="flex items-start gap-2 text-red-400">
+          <AlertTriangle className="size-4 shrink-0 mt-0.5" />
+          <div>
+            <p className="text-xs font-medium">{widget.title}</p>
+            <p className="text-[11px] opacity-70 mt-0.5">{error}</p>
+          </div>
+        </div>
+      </div>
+    )
+  }
+  if (!rows) return null
+  const cols = rows[0] ? Object.keys(rows[0]) : []
+
+  if (widget.kind === 'kpi') {
+    const value = rows[0] ? (Object.values(rows[0])[0] as number | string | null) : null
+    return (
+      <AIMetricCard metric={{ label: widget.title, value, format: widget.format ?? 'number' }} />
+    )
+  }
+
+  if (widget.kind === 'chart') {
+    const xKey = widget.xKey && cols.includes(widget.xKey) ? widget.xKey : cols[0]
+    const usable = (widget.yKeys ?? []).filter((k) => cols.includes(k))
+    const yKeys = usable.length > 0 ? usable : cols.filter((c) => c !== xKey).slice(0, 1)
+    return (
+      <AIChart
+        chartData={{
+          title: widget.title,
+          chartType: widget.chartType ?? 'bar',
+          data: rows,
+          xKey: xKey ?? cols[0] ?? '',
+          yKeys: yKeys.length ? yKeys : cols.slice(0, 1)
+        }}
+      />
+    )
+  }
+
+  // table
+  return (
+    <AIQueryResult
+      columns={cols.map((c) => ({ name: c, type: 'text' }))}
+      rows={rows}
+      totalRows={rows.length}
+      duration={0}
+      onOpenInTab={() => onOpenInTab(widget.sql)}
+    />
+  )
+}
+
+/** A small inline dashboard: KPIs in a 2-up grid, charts/tables stacked. */
+export function AIReport({ widgets, connection, onOpenInTab }: AIReportProps) {
+  const kpis = widgets.filter((w) => w.kind === 'kpi')
+  const rest = widgets.filter((w) => w.kind !== 'kpi')
+  return (
+    <div className="space-y-2 mt-3">
+      {kpis.length > 0 && (
+        <div className="grid grid-cols-2 gap-2">
+          {kpis.map((w, i) => (
+            <ReportWidgetView
+              key={`kpi-${i}`}
+              widget={w}
+              connection={connection}
+              onOpenInTab={onOpenInTab}
+            />
+          ))}
+        </div>
+      )}
+      {rest.map((w, i) => (
+        <ReportWidgetView
+          key={`w-${i}`}
+          widget={w}
+          connection={connection}
+          onOpenInTab={onOpenInTab}
+        />
+      ))}
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/src/components/dashboard/ai-widget-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/dashboard/ai-widget-dialog.tsx
@@ -9,10 +9,11 @@ import {
   DialogHeader,
   DialogTitle
 } from '@data-peek/ui'
-import type { CreateWidgetInput, WidgetConfig, SchemaInfo } from '@data-peek/shared'
+import type { CreateWidgetInput, SchemaInfo } from '@data-peek/shared'
 import { isReadOnlySql } from '@data-peek/shared'
 import { useDashboardStore } from '@/stores/dashboard-store'
 import { useConnectionStore } from '@/stores/connection-store'
+import { buildWidgetConfig, widgetNameFor } from '@/lib/ai-widget'
 
 interface AIWidgetDialogProps {
   open: boolean
@@ -81,12 +82,8 @@ export function AIWidgetDialog({ open, onOpenChange, dashboardId }: AIWidgetDial
       const rows = (run.success && (run.data as { rows?: Record<string, unknown>[] })?.rows) || []
       const cols = rows[0] ? Object.keys(rows[0]) : []
 
-      const { config, w, h } = buildConfig(data, cols)
-      const name =
-        (data.type === 'chart' && data.title) ||
-        (data.type === 'metric' && data.label) ||
-        data.message?.slice(0, 60) ||
-        'AI widget'
+      const { config, w, h } = buildWidgetConfig(data, cols)
+      const name = widgetNameFor(data)
 
       const input: CreateWidgetInput = {
         name,
@@ -167,51 +164,4 @@ export function AIWidgetDialog({ open, onOpenChange, dashboardId }: AIWidgetDial
       </DialogContent>
     </Dialog>
   )
-}
-
-type ChatData = NonNullable<Awaited<ReturnType<typeof window.api.ai.chat>>['data']>
-
-/** Map an AI structured response + real columns → a widget config + grid size. */
-function buildConfig(
-  data: ChatData,
-  cols: string[]
-): { config: WidgetConfig; w: number; h: number } {
-  // Chart when the model returned a usable chart spec.
-  if (data.type === 'chart' && data.chartType && (data.xKey || cols[0])) {
-    const xKey = data.xKey && cols.includes(data.xKey) ? data.xKey : cols[0]
-    const yKeys =
-      (data.yKeys ?? []).filter((k) => cols.includes(k)).length > 0
-        ? (data.yKeys ?? []).filter((k) => cols.includes(k))
-        : cols.filter((c) => c !== xKey).slice(0, 1)
-    return {
-      config: {
-        widgetType: 'chart',
-        chartType: data.chartType,
-        xKey,
-        yKeys: yKeys.length ? yKeys : cols.slice(0, 1),
-        title: data.title ?? undefined,
-        showLegend: true,
-        showGrid: true
-      },
-      w: 6,
-      h: 4
-    }
-  }
-
-  // KPI for a single-value metric.
-  if (data.type === 'metric' && cols[0]) {
-    return {
-      config: {
-        widgetType: 'kpi',
-        format: data.format ?? 'number',
-        label: data.label ?? data.message?.slice(0, 40) ?? 'Metric',
-        valueKey: cols[0]
-      },
-      w: 3,
-      h: 2
-    }
-  }
-
-  // Otherwise show the rows as a table.
-  return { config: { widgetType: 'table', maxRows: 50 }, w: 6, h: 4 }
 }

--- a/apps/desktop/src/renderer/src/lib/ai-widget.ts
+++ b/apps/desktop/src/renderer/src/lib/ai-widget.ts
@@ -1,0 +1,70 @@
+import type { WidgetConfig } from '@data-peek/shared'
+
+/** The subset of an AI structured response that widget construction reads. */
+export interface WidgetSourceData {
+  type: 'query' | 'chart' | 'metric' | 'schema' | 'message'
+  message?: string | null
+  chartType?: 'bar' | 'line' | 'pie' | 'area' | null
+  xKey?: string | null
+  yKeys?: string[] | null
+  title?: string | null
+  label?: string | null
+  format?: 'number' | 'currency' | 'percent' | 'duration' | null
+}
+
+/**
+ * Map an AI structured response + the real result columns → a dashboard widget
+ * config + grid size. Shared by the "Ask AI" widget dialog and the chat
+ * "pin to dashboard" action so both build identical widgets.
+ */
+export function buildWidgetConfig(
+  data: WidgetSourceData,
+  cols: string[]
+): { config: WidgetConfig; w: number; h: number } {
+  // Chart when the model returned a usable chart spec.
+  if (data.type === 'chart' && data.chartType && (data.xKey || cols[0])) {
+    const xKey = data.xKey && cols.includes(data.xKey) ? data.xKey : cols[0]
+    const usableYKeys = (data.yKeys ?? []).filter((k) => cols.includes(k))
+    const yKeys = usableYKeys.length > 0 ? usableYKeys : cols.filter((c) => c !== xKey).slice(0, 1)
+    return {
+      config: {
+        widgetType: 'chart',
+        chartType: data.chartType,
+        xKey,
+        yKeys: yKeys.length ? yKeys : cols.slice(0, 1),
+        title: data.title ?? undefined,
+        showLegend: true,
+        showGrid: true
+      },
+      w: 6,
+      h: 4
+    }
+  }
+
+  // KPI for a single-value metric.
+  if (data.type === 'metric' && cols[0]) {
+    return {
+      config: {
+        widgetType: 'kpi',
+        format: data.format ?? 'number',
+        label: data.label ?? data.message?.slice(0, 40) ?? 'Metric',
+        valueKey: cols[0]
+      },
+      w: 3,
+      h: 2
+    }
+  }
+
+  // Otherwise show the rows as a table.
+  return { config: { widgetType: 'table', maxRows: 50 }, w: 6, h: 4 }
+}
+
+/** A short widget/artifact name from an AI response. */
+export function widgetNameFor(data: WidgetSourceData): string {
+  return (
+    (data.type === 'chart' && data.title) ||
+    (data.type === 'metric' && data.label) ||
+    data.message?.slice(0, 60) ||
+    'AI widget'
+  )
+}

--- a/apps/desktop/src/renderer/src/lib/ai-widget.ts
+++ b/apps/desktop/src/renderer/src/lib/ai-widget.ts
@@ -2,7 +2,7 @@ import type { WidgetConfig } from '@data-peek/shared'
 
 /** The subset of an AI structured response that widget construction reads. */
 export interface WidgetSourceData {
-  type: 'query' | 'chart' | 'metric' | 'schema' | 'message'
+  type: 'query' | 'chart' | 'metric' | 'schema' | 'message' | 'report'
   message?: string | null
   chartType?: 'bar' | 'line' | 'pie' | 'area' | null
   xKey?: string | null

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -442,7 +442,19 @@ export type AIResponseType =
   | "query"
   | "chart"
   | "metric"
-  | "schema";
+  | "schema"
+  | "report";
+
+/** One widget in a multi-widget chat "report" (a mini inline dashboard). */
+export interface AIReportWidget {
+  title: string;
+  kind: "kpi" | "chart" | "table";
+  sql: string;
+  chartType?: "bar" | "line" | "pie" | "area" | null;
+  format?: "number" | "currency" | "percent" | "duration" | null;
+  xKey?: string | null;
+  yKeys?: string[] | null;
+}
 
 /**
  * AI structured response - flat object with nullable fields.
@@ -469,6 +481,8 @@ export interface AIStructuredResponse {
   format: "number" | "currency" | "percent" | "duration" | null;
   // Schema fields (null when type is not schema)
   tables: string[] | null;
+  // Report fields (null when type is not report): a small set of widgets.
+  widgets: AIReportWidget[] | null;
   // 2–3 short follow-up prompts the user might ask next (any type). null when none.
   suggestions: string[] | null;
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -469,6 +469,8 @@ export interface AIStructuredResponse {
   format: "number" | "currency" | "percent" | "duration" | null;
   // Schema fields (null when type is not schema)
   tables: string[] | null;
+  // 2–3 short follow-up prompts the user might ask next (any type). null when none.
+  suggestions: string[] | null;
 }
 
 /**


### PR DESCRIPTION
Four chat enhancements, building on the streaming/structured-output work merged in #233. (Supersedes #234, which GitHub auto-closed when its stacked base branch was deleted on the #233 merge.)

## 1. Follow-up suggestion chips
The model can return 2–3 short `suggestions` with any answer; they render as clickable chips, and clicking one sends it as the next prompt.

## 2. Pin from chat → dashboard / notebook / saved query
SQL-bearing answers (query/chart/metric) get a **Pin** menu: Save query, Add to dashboard (builds a chart/kpi/table widget), Add to notebook cell. Reuses the widget-builder extracted into `src/lib/ai-widget.ts`.

## 3. `@table` / `@column` autocomplete
Type `@` in the composer to autocomplete real schema objects (tables first, then columns). Keyboard-first (arrows / Enter-Tab / Esc).

## 4. Multi-widget mini-reports
New `report` response type: one prompt ("give me a business overview") returns 2–6 widgets. `AIReport` renders an inline mini-dashboard — KPIs 2-up, charts/tables stacked — each widget running its own read-only query. Ephemeral (re-run on demand).

## Quality
- **1111 tests passing** (drift-guard keeps `RESPONSE_JSON_SCHEMA` in sync with the zod schema), typecheck (node + web) + lint clean, verified live on the seeded DB (video walkthrough recorded).
- Backward-compatible response contract; writes still gated by the approval dialog; reads single-statement checked.

https://claude.ai/code/session_01Khhdnw9aShE87ALovgMqax

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added AI-generated reports with KPI cards, charts, and tables in a dashboard-style layout.
  - Added follow-up suggestion chips that can send prompts directly from the chat.
  - Added `@`-mention autocomplete for schema tables and columns.
  - Added options to save, pin, or add eligible AI-generated results to notebooks.

- **Improvements**
  - Improved widget configuration and naming for AI-generated visualizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->