### PR TITLE
feat(blog): SEO content engine — related posts, breadcrumb schema, playbook

### DIFF
--- a/apps/web/src/app/blog/[slug]/page.tsx
+++ b/apps/web/src/app/blog/[slug]/page.tsx
@@ -8,28 +8,16 @@ import { Header } from "@/components/marketing/header";
 import { Footer } from "@/components/marketing/footer";
 import { Breadcrumbs } from "@/components/seo/breadcrumbs";
 import { StructuredData } from "@/components/seo/structured-data";
-import { getBlogPost, getAllBlogSlugs } from "@/lib/blog";
+import { getBlogPost, getAllBlogSlugs, getRelatedPosts } from "@/lib/blog";
 import { mdxComponents } from "@/components/blog/mdx-components";
 import { ReadingProgress } from "@/components/blog/reading-progress";
+import { RelatedPosts } from "@/components/blog/related-posts";
 import {
   generateMetadata as generateSeoMetadata,
   SITE_CONFIG,
 } from "@/lib/seo";
-import {
-  ArrowLeft,
-  Calendar,
-  Clock,
-  User,
-  Terminal,
-  Sparkles,
-  Database,
-} from "lucide-react";
-import {
-  FadeIn,
-  StaggerContainer,
-  StaggerItem,
-  ScaleIn,
-} from "@/components/ui/motion-wrapper";
+import { ArrowLeft, Calendar, Clock, User, Sparkles } from "lucide-react";
+import { FadeIn } from "@/components/ui/motion-wrapper";
 import { DataSubstrate } from "@/components/marketing/data-substrate";
 import { Button } from "@/components/ui/button";
 
@@ -84,6 +72,7 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
   }
 
   const postUrl = `${SITE_CONFIG.url}/blog/${slug}`;
+  const relatedPosts = getRelatedPosts(slug);
 
   return (
     <div className="min-h-screen">
@@ -99,6 +88,16 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
             author: post.author,
             url: postUrl,
           },
+        }}
+      />
+      <StructuredData
+        type="breadcrumb"
+        data={{
+          breadcrumb: [
+            { name: "Home", url: SITE_CONFIG.url },
+            { name: "Blog", url: `${SITE_CONFIG.url}/blog` },
+            { name: post.title, url: postUrl },
+          ],
         }}
       />
       <main className="relative pt-32 sm:pt-48 pb-24 overflow-hidden">
@@ -199,6 +198,12 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
               </div>
             </article>
           </FadeIn>
+
+          {relatedPosts.length > 0 && (
+            <FadeIn>
+              <RelatedPosts posts={relatedPosts} />
+            </FadeIn>
+          )}
 
           {/* CTA Section */}
           <FadeIn>

--- a/apps/web/src/components/blog/related-posts.tsx
+++ b/apps/web/src/components/blog/related-posts.tsx
@@ -1,0 +1,59 @@
+import Link from "next/link";
+import { ArrowRight, Clock } from "lucide-react";
+import type { BlogPostMeta } from "@/lib/blog";
+
+interface RelatedPostsProps {
+  posts: BlogPostMeta[];
+}
+
+export function RelatedPosts({ posts }: RelatedPostsProps) {
+  if (posts.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="mb-16" aria-labelledby="related-posts-heading">
+      <div className="flex items-center gap-4 mb-8">
+        <h2
+          id="related-posts-heading"
+          className="text-xs font-mono uppercase tracking-widest text-(--color-text-muted)"
+        >
+          Read next
+        </h2>
+        <div className="h-px flex-1 bg-white/5" />
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {posts.map((post) => (
+          <Link
+            key={post.slug}
+            href={`/blog/${post.slug}`}
+            className="group flex flex-col rounded-2xl bg-white/[0.02] border border-white/10 p-6 transition-colors hover:border-(--color-accent)/40 hover:bg-white/[0.04]"
+          >
+            {post.tags.length > 0 && (
+              <span className="mb-4 inline-flex w-fit px-2.5 py-1 text-[10px] font-mono uppercase tracking-widest rounded-full bg-(--color-accent)/10 border border-(--color-accent)/20 text-(--color-accent)">
+                {post.tags[0]}
+              </span>
+            )}
+
+            <h3 className="text-sm font-mono uppercase tracking-tight font-bold text-white leading-snug mb-2 group-hover:text-(--color-accent) transition-colors">
+              {post.title}
+            </h3>
+
+            <p className="text-xs font-mono text-(--color-text-muted) leading-relaxed line-clamp-3 mb-6">
+              {post.description}
+            </p>
+
+            <div className="mt-auto flex items-center justify-between text-[10px] font-mono uppercase tracking-widest text-(--color-text-muted)">
+              <span className="flex items-center gap-2">
+                <Clock className="w-3 h-3" />
+                {post.readingTime}
+              </span>
+              <ArrowRight className="w-4 h-4 group-hover:translate-x-1 transition-transform" />
+            </div>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/lib/blog.ts
+++ b/apps/web/src/lib/blog.ts
@@ -96,6 +96,34 @@ export function getBlogPost(slug: string): BlogPost | null {
   return post;
 }
 
+export function getRelatedPosts(slug: string, limit = 3): BlogPostMeta[] {
+  const posts = getBlogPosts();
+  const current = posts.find((post) => post.slug === slug);
+
+  if (!current) {
+    return posts.filter((post) => post.slug !== slug).slice(0, limit);
+  }
+
+  const currentTags = new Set(current.tags.map((tag) => tag.toLowerCase()));
+
+  return posts
+    .filter((post) => post.slug !== slug)
+    .map((post) => {
+      const sharedTags = post.tags.filter((tag) =>
+        currentTags.has(tag.toLowerCase()),
+      ).length;
+      return { post, sharedTags };
+    })
+    .sort((a, b) => {
+      if (b.sharedTags !== a.sharedTags) {
+        return b.sharedTags - a.sharedTags;
+      }
+      return new Date(b.post.date).getTime() - new Date(a.post.date).getTime();
+    })
+    .slice(0, limit)
+    .map((entry) => entry.post);
+}
+
 export function getAllBlogSlugs(): string[] {
   if (!fs.existsSync(BLOG_DIR)) {
     return [];

--- a/notes/_ranking-post-playbook.md
+++ b/notes/_ranking-post-playbook.md
@@ -1,0 +1,107 @@
+# The Ranking-Post Playbook
+
+_Internal author guide. Not a blog post — the `_` prefix and `.md` extension keep it out of the published set (`getBlogPosts()` only reads `.mdx`)._
+
+## Why this exists
+
+One post — `listen-notify-without-tears` — pulled ~433 visitors, and **~438 of them came from Google**, not Twitter or Reddit. That is not a launch spike that decays in a week. It is organic search ranking: durable, compounding traffic that keeps paying out every month.
+
+This document reverse-engineers _why_ that post ranks and converts, so every future post is built the same way instead of by accident.
+
+**The thesis, in one line:** _Write problem-first tutorials that target a real developer Google search, and let data-peek show up as the relief — never the subject._
+
+## The anatomy of a ranking post
+
+Every part below is lifted from the winner. Follow the skeleton in order.
+
+### 1. Title = the search, phrased like a human
+
+The winner's title is **"Debugging Postgres LISTEN/NOTIFY Is Finally Pleasant."** It contains the exact words a stuck developer types into Google — `postgres`, `listen/notify`, `debugging` — but reads like a person wrote it, not a keyword robot.
+
+- Lead with the concrete technology and the verb of the pain (`debugging`, `killing`, `finding`, `fixing`).
+- Put the searchable terms in the first half of the title.
+- Earn the second half with voice ("Is Finally Pleasant"), not filler.
+
+**Test:** would someone in the middle of this exact problem type these words into Google? If not, the title is wrong.
+
+### 2. Open on visceral, specific pain — not on the product
+
+The winner's first sentence:
+
+> "I have written the same 40-line Node script to debug a Postgres `LISTEN` channel at least six times."
+
+Then it _shows the throwaway solution the reader is currently using_ (the `listen.js` snippet) and narrates the misery of it — the connection dropping, the Ctrl+C, the re-run, the event already gone.
+
+Rules for the hook:
+- First person, specific number ("six times", "40-line"), real artefact (`listen.js`).
+- Show the reader's **current** bad workflow before you show ours. They should think "yes, that is exactly what I do."
+- data-peek is not mentioned until the pain is fully established. In the winner it first appears at the _end_ of the hook: "the version I wish I had had the first time."
+
+### 3. Tool as relief, then real depth
+
+Once the pain lands, introduce the data-peek feature as the fix — then **go deep with real code and real trade-offs.** The winner shows the actual reconnect loop, the SQLite schema, the identifier-quoting footgun, and a candid "What I'd do differently" section.
+
+That depth is doing two jobs at once:
+- **Dwell time + credibility.** Google rewards pages people actually read to the end. Honest engineering ("I lost a channel on every reconnect until I noticed") keeps them there.
+- **It is genuinely useful** even to someone who never installs data-peek — which is exactly why it ranks.
+
+Never write a post that only makes sense if you already use the product. The winner teaches Postgres LISTEN/NOTIFY; the tool is the vehicle.
+
+### 4. Soft CTA at the very end
+
+The winner closes with a single line — free for personal use, MIT source, "if you have ever rewritten the listen.js script, you will know exactly why this exists." The page-level CTA card ("Download Free / More Articles") is already rendered by the post template, so the body just needs one honest closing nudge, not a sales pitch.
+
+### 5. Cross-link into the cluster
+
+Every post should link to 2–3 sibling posts where it is genuinely relevant (see the winner's links to connection-health, EXPLAIN, and table-sizes). These are added contextually, mid-sentence — never a "related links" dump in the body. The **"Read next" grid and breadcrumb schema are automatic** (Play 1); your job is only the in-body contextual links.
+
+## Frontmatter checklist
+
+```yaml
+---
+title: "..."          # the search, phrased like a human (see §1)
+description: "..."     # this IS the Google meta description — lead with the benefit, 150–160 chars
+date: "YYYY-MM-DD"
+author: "Rohith Gilla"
+tags: ["postgres", ...] # lowercase; shared tags drive the "Read next" grid, so tag deliberately
+published: true
+---
+```
+
+- **`description`** is the snippet Google shows under the title. Write it for a human deciding whether to click, not for a crawler.
+- **`tags`** are the cluster glue. `getRelatedPosts()` ranks siblings by shared-tag count, so a post tagged `["postgres", "performance"]` will surface next to other Postgres/performance posts. Tag with the cluster in mind.
+
+## What the template already does for you (Play 1)
+
+You do not need to hand-build any of this — it ships automatically on every post:
+
+- **`Article` JSON-LD** — publish date, author, headline (was already present).
+- **`BreadcrumbList` JSON-LD** — Home › Blog › Post, for breadcrumb rich results.
+- **"Read next" grid** — three tag-ranked sibling posts at the foot of the article.
+- **Sitemap entry, canonical URL, OpenGraph + Twitter cards** — via `sitemap.ts` and `lib/seo.ts`.
+
+## Pre-publish checklist
+
+- [ ] Title contains the real search phrase and reads like a human wrote it.
+- [ ] First paragraph names a specific, visceral pain in first person.
+- [ ] The reader's _current_ bad workflow is shown before data-peek appears.
+- [ ] At least one block of real code and one honest trade-off / "what I'd do differently".
+- [ ] The post is useful even to someone who never installs data-peek.
+- [ ] 2–3 contextual in-body links to sibling posts.
+- [ ] `description` is a click-worthy 150–160-char meta description.
+- [ ] `tags` are lowercase and chosen to sit the post inside a cluster.
+- [ ] One soft closing line — no hard sell.
+
+## Anti-patterns (why release notes do not rank)
+
+Posts like `watch-mode` or `sweat-the-details` serve people who already follow data-peek. They are worth writing for that audience — but they do **not** rank on search, because:
+
+- The title describes a _feature name_, not a _search_ ("Watch Mode" is not something a stranger Googles).
+- They assume the reader already cares about data-peek.
+- There is no external pain being solved for someone who has never heard of us.
+
+Keep writing them for your existing audience — just don't expect them to be the SEO engine. The engine is the problem-first tutorial.
+
+## An honest note on measurement
+
+We can see _which_ posts win in analytics, and we can research _which searches exist_ and how much competition they have. What we do **not** have is a keyword search-volume API — so the topic backlog (Play 3) prioritises by search intent and competition, not by hard monthly-search-volume numbers. Treat the ranking as a strong hypothesis to validate by shipping, not as a guaranteed traffic forecast.

--- a/notes/listen-notify-without-tears.mdx
+++ b/notes/listen-notify-without-tears.mdx
@@ -85,6 +85,10 @@ failures you end up with a listener that tries once an hour and you swear
 the panel "doesn't work anymore" when actually it just happens to be in
 a two-hour retry gap.
 
+The same reconnect-with-backoff discipline shows up elsewhere in the app —
+the [connection health monitor](/blog/connection-health-monitor-in-a-sql-client)
+applies it to every connection, not just the notification listener.
+
 The `destroyed` flag is the quiet hero. Every `ListenerEntry` has one:
 
 ```ts
@@ -151,6 +155,11 @@ sqliteDb.exec(`
 `);
 ```
 
+That composite index on `(connection_id, received_at DESC)` is what keeps the
+history query fast as the table fills toward 10,000 rows. If you are ever
+unsure an index like this is actually being used, the way to confirm it is to
+[read the EXPLAIN plan](/blog/understanding-explain-analyze).
+
 Three reasons this matters:
 
 1. **Close the panel, come back later.** Your events are still there. This
@@ -187,7 +196,9 @@ if (count > MAX_EVENTS_PER_CONNECTION) {
 The subquery guarantees we delete the oldest `excess` rows for _this
 connection_, not the oldest rows overall. On a laptop with two databases
 open, the global ordering would let one chatty channel evict events from
-the quiet one.
+the quiet one. Capping row growth like this is the same instinct behind
+[keeping an eye on table sizes](/blog/check-table-sizes-postgresql) in a
+production database — unbounded tables are how disks fill up at 3am.
 
 ## Identifier quoting for channel names
 


### PR DESCRIPTION
Plays 1 & 2 of the blog SEO content engine — compound the organic-search
winner (`listen-notify-without-tears`, ~438 visitors/mo from Google) instead
of letting visitors hit a dead end.

## Play 1 — milk the winner (code)
- `getRelatedPosts()` — tag-overlap ranking with recency tiebreak
- `RelatedPosts` "read next" grid on every `/blog/[slug]`
- emit `BreadcrumbList` JSON-LD (Article schema already existed)
- 3 contextual internal links from the winner into related Postgres posts
- trim pre-existing unused imports in the post page

## Play 2 — ranking-post playbook (docs)
- `notes/_ranking-post-playbook.md` — reverse-engineers why the winner ranks
  into a repeatable author guide. `_` prefix keeps it out of the published set.

## Why now
Internal linking is a real indexing signal. GSC shows ~28 posts "crawled –
currently not indexed"; a stronger internal-link graph is the most direct
lever we have to flip them.

Verified: typecheck ✓ · lint clean on touched files ✓ · build ✓ (26 posts prerendered).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a “Read next” section to blog posts, showing related articles based on shared topics.
  - Related post cards include tags, descriptions, reading times, and direct links.

- **Enhancements**
  - Improved blog page search-engine metadata with breadcrumb navigation structured data.

- **Documentation**
  - Added guidance for creating search-focused tutorials.
  - Clarified connection recovery, database performance, and event-history retention concepts in the notification tutorial.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->