### PR TITLE
docs(blog): Postgres firefighting cluster (kill query, blocking, too many clients)

### DIFF
--- a/notes/kill-a-stuck-postgres-query.mdx
+++ b/notes/kill-a-stuck-postgres-query.mdx
@@ -149,10 +149,9 @@ that was stuck will happily show you where it spent its time.
 
 And if the query was not slow so much as *blocked* — waiting on a lock held
 by another session — cancelling it treats the symptom while the real
-offender keeps the lock. That is a different hunt, and it is why the same
-health monitor also surfaces the
-[connection and lock picture](/blog/connection-health-monitor-in-a-sql-client)
-alongside active queries.
+offender keeps the lock. That is a different hunt entirely:
+[finding what's blocking your query](/blog/what-is-blocking-my-postgres-query)
+means reading the lock tree, not the query plan.
 
 ## The short version
 

--- a/notes/kill-a-stuck-postgres-query.mdx
+++ b/notes/kill-a-stuck-postgres-query.mdx
@@ -1,0 +1,168 @@
+---
+title: "Killing a Stuck Postgres Query Without Killing the Wrong One"
+description: "How to find and stop a runaway Postgres query safely: pg_cancel_backend vs pg_terminate_backend, picking the right pid from pg_stat_activity, and not nuking your migration by mistake."
+date: "2026-07-23"
+author: "Rohith Gilla"
+tags: ["postgres", "devops", "troubleshooting", "sql"]
+published: true
+---
+
+The dashboard is timing out. Something is holding the database hostage — a
+report query that decided to sequential-scan a 200-million-row table, or a
+migration that grabbed a lock and wandered off. You SSH into the box, open
+`psql`, and run the query everyone runs:
+
+```sql
+SELECT pid, state, now() - query_start AS duration, query
+FROM pg_stat_activity
+WHERE state = 'active'
+ORDER BY duration DESC;
+```
+
+You get a wall of rows. You find the one that has been running for eleven
+minutes, copy its `pid`, and type the thing you always half-regret:
+
+```sql
+SELECT pg_terminate_backend(48213);
+```
+
+And then the doubt hits. Was `48213` the runaway analytics query, or the
+migration that was halfway through rebuilding an index? Did I just roll back
+something that was 90% done? On a bad day you paste the wrong pid entirely
+and terminate a healthy connection while the real culprit keeps running.
+
+I have done this enough times, at enough levels of caffeination, that I built
+the safe version into data-peek. But the SQL is worth understanding first,
+because the tool is just a faster, less error-prone way of doing exactly
+this.
+
+## Cancel, don't terminate (at least not first)
+
+Postgres gives you two ways to stop a backend, and the difference matters
+more than most people treat it:
+
+```sql
+SELECT pg_cancel_backend(pid);     -- polite: cancels the current query
+SELECT pg_terminate_backend(pid);  -- nuclear: kills the whole connection
+```
+
+`pg_cancel_backend` sends the equivalent of pressing Ctrl+C. It cancels the
+**currently running query**, the client gets an error, and the session stays
+alive. If a connection is chewing on one bad `SELECT`, this is almost always
+what you want — the query stops, nothing else is disturbed.
+
+`pg_terminate_backend` is `kill` for the whole backend. It tears down the
+entire session, not just the query. Any open transaction rolls back and the
+connection drops. You reach for this when cancelling did not work, or when
+the session itself is the problem — an `idle in transaction` connection
+sitting on a lock, for example, where there is no active query to cancel.
+
+The rule I follow: **cancel first, terminate only if cancel fails.** Starting
+with the nuclear option is how you turn a slow query into a rolled-back
+transaction you did not mean to lose.
+
+## Finding the right pid without guessing
+
+The dangerous part is never the kill — it is picking the wrong target. A
+better `pg_stat_activity` query gives you enough context to be sure:
+
+```sql
+SELECT
+  pid,
+  usename,
+  application_name,
+  state,
+  now() - query_start AS duration,
+  wait_event_type,
+  wait_event,
+  query
+FROM pg_stat_activity
+WHERE state <> 'idle'
+  AND pid <> pg_backend_pid()
+ORDER BY query_start ASC;
+```
+
+A few things in here save you from yourself:
+
+- **`state <> 'idle'`** drops the connections that are just sitting there
+  doing nothing, so you are only looking at sessions actually doing work.
+  Note this still shows `idle in transaction` — those are not idle, they are
+  holding a transaction open, and they are often the real villain.
+- **`pid <> pg_backend_pid()`** excludes your own session. Cancelling
+  yourself is a rite of passage you only need once.
+- **`ORDER BY query_start ASC`** puts the oldest queries first. The thing
+  that has been running longest is usually the thing you came here to kill.
+- **`wait_event`** tells you *why* it is stuck. A query waiting on `Lock`
+  is blocked by someone else — killing it might not help if the real problem
+  is the session holding the lock.
+
+Read the `query` text and the `usename` before you do anything. If it says
+`autovacuum` or it is a replication sender, leave it alone. Confirm the
+duration matches the pain you are feeling. *Then* cancel it.
+
+## The version I actually use now
+
+Doing this by hand works, but at 3am, over a slow SSH tunnel, copy-pasting
+pids between a `pg_stat_activity` query and a `pg_cancel_backend` call is
+exactly when mistakes happen. So data-peek's health monitor has an **Active
+Queries** panel that is just this query, kept live.
+
+It lists every non-idle session — pid, user, state, how long it has been
+running, the wait event, and the full query text — sorted oldest-first, so
+the runaway query floats to the top on its own. Each row has a stop button.
+
+The one deliberate decision worth calling out: **that button runs
+`pg_cancel_backend`, not `pg_terminate_backend`.** The default action is the
+graceful one. Here is the relevant slice from
+`src/main/adapters/postgres-adapter.ts`:
+
+```ts
+async killQuery(config, pid) {
+  const result = await client.query(
+    'SELECT pg_cancel_backend($1) AS cancelled',
+    [pid]
+  )
+  const cancelled = result.rows[0]?.cancelled === true
+  return cancelled
+    ? { success: true }
+    : { success: false, error: 'Failed to cancel query - may have already completed' }
+}
+```
+
+`pg_cancel_backend` returns a boolean, so we can tell you whether the cancel
+actually landed or whether the query had already finished on its own. You see
+the query, you see how long it has run, you click stop, and the safe thing
+happens. No copied pids, no accidental terminate.
+
+If cancelling genuinely is not enough — an `idle in transaction` session that
+will not budge — that is still a job for `pg_terminate_backend` in a query
+tab, deliberately, with the pid right in front of you. I would rather make
+the destructive path a conscious choice than hide it behind the same button.
+
+## Stopping it from happening again
+
+Killing the query is the tourniquet, not the cure. Once the fire is out, the
+question is why a query ran for eleven minutes in the first place. Usually it
+is a missing index or a plan gone wrong, and the way to find out is to
+[read its EXPLAIN plan](/blog/understanding-explain-analyze) — the same query
+that was stuck will happily show you where it spent its time.
+
+And if the query was not slow so much as *blocked* — waiting on a lock held
+by another session — cancelling it treats the symptom while the real
+offender keeps the lock. That is a different hunt, and it is why the same
+health monitor also surfaces the
+[connection and lock picture](/blog/connection-health-monitor-in-a-sql-client)
+alongside active queries.
+
+## The short version
+
+- Prefer `pg_cancel_backend` (cancels the query). Only reach for
+  `pg_terminate_backend` (kills the session) when cancel is not enough.
+- Query `pg_stat_activity` with `state`, `duration`, `wait_event`, and the
+  full query text so you kill the right pid on purpose, not by guess.
+- Exclude your own backend (`pg_backend_pid()`), and never assume — read the
+  query and the user before you stop it.
+
+data-peek is at [datapeek.dev](https://datapeek.dev). It is free for personal
+use and the source is MIT. The Active Queries panel is the one I open first
+when the database gets quiet in the bad way.

--- a/notes/postgres-too-many-clients-already.mdx
+++ b/notes/postgres-too-many-clients-already.mdx
@@ -1,0 +1,103 @@
+---
+title: "Postgres 'Too Many Clients Already': The 3am Fix and the Real Cause"
+description: "FATAL: sorry, too many clients already — how to get back online fast, and why bumping max_connections is the wrong long-term fix. Connection leaks, pooling, and idle-in-transaction."
+date: "2026-07-23"
+author: "Rohith Gilla"
+tags: ["postgres", "devops", "troubleshooting", "sql"]
+published: true
+---
+
+Your app is throwing this and the pager is going off:
+
+```
+FATAL: sorry, too many clients already
+```
+
+Every new connection is being refused, so the app is effectively down. This
+is one of the clearest error messages Postgres produces — you have hit
+`max_connections` — but the obvious fix is a trap, and the real cause is
+almost never "not enough connections."
+
+## Get back online first
+
+You need slots freed up. Look at what is actually connected, grouped by
+state:
+
+```sql
+SELECT state, count(*)
+FROM pg_stat_activity
+GROUP BY state
+ORDER BY count(*) DESC;
+```
+
+Nine times out of ten you will see a large pile of `idle` or, worse,
+`idle in transaction` connections. Those are the ones to clear. To end the
+idle sessions from a runaway client (adjust the filter to target the right
+application — do **not** blanket-kill everything):
+
+```sql
+SELECT pg_terminate_backend(pid)
+FROM pg_stat_activity
+WHERE state IN ('idle', 'idle in transaction')
+  AND application_name = 'the-leaking-app'
+  AND pid <> pg_backend_pid();
+```
+
+That buys you breathing room. **Bumping `max_connections` also works — and is
+usually the wrong instinct.** Each connection costs memory (work_mem and
+per-backend overhead), so raising the limit without also revisiting
+`shared_buffers` and RAM can trade a connection error for the OOM killer.
+Treat a `max_connections` bump as a deliberate capacity decision, not a
+reflex.
+
+## The real cause
+
+"Too many clients" is a symptom. The disease is almost always one of:
+
+- **No connection pooling.** Each app instance opens its own raw connections,
+  and under load the count multiplies past what the server allows. A pooler —
+  PgBouncer, or your framework's built-in pool — is the actual fix. It keeps a
+  small, bounded set of real Postgres connections and multiplexes your app
+  across them.
+- **Leaked connections.** Code that opens a connection and never returns it to
+  the pool (missing `finally`, an error path that skips cleanup). The count
+  only ever grows.
+- **`idle in transaction` sessions.** A transaction opened and never committed
+  holds its connection *and* any locks it took. Set
+  `idle_in_transaction_session_timeout` so Postgres reaps them automatically.
+
+If you take one thing from an outage like this: **put a pooler in front of
+Postgres and cap it.** It is the difference between a load spike causing
+slightly slower queries versus a hard outage.
+
+## Where a client helps (and where it doesn't)
+
+I want to be straight about this one, because it is where a GUI is only
+partly useful. data-peek's health monitor has an **Active Queries** panel,
+and it deliberately shows non-idle sessions — including
+`idle in transaction`, which is exactly the state you care about here. If a
+transaction-leaking client is the culprit, you will see those sessions and
+can cancel them from the panel, the same way you would
+[kill any stuck query](/blog/kill-a-stuck-postgres-query).
+
+What it does **not** show is the full count of plain `idle` connections or a
+running total against `max_connections` — so for the triage query above
+(grouping every state, counting toward the limit) you will still reach for a
+SQL tab. The panel is good for spotting the *offending transactions*; the
+`GROUP BY state` count is how you see the *whole* picture. Use both.
+
+## The short version
+
+- Clear the `idle` / `idle in transaction` pile-up to get back online; target
+  the offending app, don't blanket-kill.
+- Do not reach for a bigger `max_connections` as the fix — it costs memory and
+  hides the real problem.
+- The real fix is a **connection pooler** with a bounded size, plus
+  `idle_in_transaction_session_timeout` to reap abandoned transactions.
+
+data-peek is at [datapeek.dev](https://datapeek.dev), free for personal use
+and MIT source. When the database is refusing connections, the fastest path
+is still a `GROUP BY state` in a query tab — and once you have found the
+transaction-leaking session, the [Active Queries](/blog/kill-a-stuck-postgres-query)
+panel and the [lock view](/blog/what-is-blocking-my-postgres-query) are right
+there to deal with it.

--- a/notes/what-is-blocking-my-postgres-query.mdx
+++ b/notes/what-is-blocking-my-postgres-query.mdx
@@ -1,0 +1,116 @@
+---
+title: "What's Blocking My Postgres Query? Reading the Lock Tree"
+description: "Your query isn't slow — it's blocked. How to find the session holding the lock with pg_blocking_pids and pg_locks, cancel the right one, and stop idle-in-transaction from doing it again."
+date: "2026-07-23"
+author: "Rohith Gilla"
+tags: ["postgres", "devops", "troubleshooting", "sql"]
+published: true
+---
+
+There is a specific kind of Postgres problem that feels like a slow query but
+is not one. A `SELECT` or an `UPDATE` that should take twenty milliseconds
+just… sits there. You check `pg_stat_activity` and it has been "running" for
+four minutes. You start reading its query plan looking for the missing index,
+and there is nothing to find — because the query is not doing any work. It is
+**waiting**. Someone else is holding a lock it needs, and it will wait,
+politely, forever.
+
+The tell is in `pg_stat_activity`: the state is `active` but `wait_event_type`
+is `Lock`. It is not slow. It is blocked. And killing *it* will not help —
+you have to find and stop whoever is holding the lock.
+
+## Finding the blocker
+
+The old way to do this was a `pg_locks` self-join that nobody remembers
+without looking it up. Modern Postgres gives you `pg_blocking_pids()`, which
+turns the whole thing into one readable query:
+
+```sql
+SELECT
+  blocked.pid            AS blocked_pid,
+  blocked.query          AS blocked_query,
+  blocking.pid           AS blocking_pid,
+  blocking.query         AS blocking_query,
+  blocking.state         AS blocking_state
+FROM pg_stat_activity AS blocked
+JOIN pg_stat_activity AS blocking
+  ON blocking.pid = ANY(pg_blocking_pids(blocked.pid))
+WHERE blocked.wait_event_type = 'Lock';
+```
+
+This gives you the pair that matters: the query that is stuck, and the query
+that is holding it hostage. Read the `blocking_query` — that is the one you
+have to deal with.
+
+Two things trip people up here:
+
+- **Cancelling the blocked query does nothing useful.** It is the victim, not
+  the cause. Cancel the *blocker* (`blocking_pid`) and the blocked query
+  usually completes on its own a moment later.
+- **The blocker is often not running a query at all.** If `blocking_state` is
+  `idle in transaction`, there is no active statement to cancel — someone
+  opened a transaction, took a lock, and walked away (a debugger paused on a
+  breakpoint, an app that forgot to `COMMIT`). For those you need
+  `pg_terminate_backend`, because there is no live query for
+  `pg_cancel_backend` to interrupt.
+
+## The version I actually use
+
+Reconstructing the lock tree by hand, at the exact moment the app is down, is
+not where I want to be spending my attention. So data-peek's health monitor
+has a **Locks & Blocking** panel that keeps this query live and renders the
+pairs directly: blocked PID and query on one side, blocking PID and query on
+the other, with how long the blocked session has been waiting. When nothing
+is blocked it just says "No blocking locks", which is its own kind of relief.
+
+Under the hood it is the classic `pg_locks` join (from
+`src/main/adapters/postgres-adapter.ts`), matching a waiting lock against the
+lock that is granted on the same object:
+
+```sql
+FROM pg_locks blocked
+JOIN pg_stat_activity blocked_activity ON blocked.pid = blocked_activity.pid
+JOIN pg_locks blocking ON (
+  blocked.locktype = blocking.locktype
+  AND blocked.relation IS NOT DISTINCT FROM blocking.relation
+  -- …the rest of the lock-identity columns…
+  AND blocked.pid != blocking.pid
+)
+JOIN pg_stat_activity blocking_activity ON blocking.pid = blocking_activity.pid
+WHERE NOT blocked.granted AND blocking.granted
+```
+
+Each blocking row has a "Kill Blocker" action, so once you have spotted the
+session at the root of the pile-up you can stop it in place. That kill runs
+the same graceful `pg_cancel_backend` path described in
+[killing a stuck query](/blog/kill-a-stuck-postgres-query) — cancel first,
+and drop to a deliberate `pg_terminate_backend` only for the
+`idle in transaction` holders that have no query to cancel.
+
+## Stopping the pile-up
+
+Blocking is almost always a transaction that holds a lock longer than it
+should. A few habits make it rare:
+
+- **Keep transactions short.** Do the slow work (HTTP calls, file I/O, user
+  think-time) *outside* the transaction, not while holding a row lock.
+- **Set `idle_in_transaction_session_timeout`.** It automatically kills
+  sessions that open a transaction and go idle — the single most common
+  source of mystery blocking.
+- **Set `lock_timeout` for risky statements.** Better to fail fast with a
+  clear lock-timeout error than to wedge behind a lock indefinitely.
+
+## The short version
+
+- A query stuck with `wait_event_type = 'Lock'` is blocked, not slow — don't
+  go hunting for a missing index.
+- Use `pg_blocking_pids()` to find the blocking session, and act on the
+  *blocker*, not the victim.
+- `idle in transaction` blockers have no query to cancel — terminate them,
+  and add `idle_in_transaction_session_timeout` so they cannot happen again.
+
+data-peek is at [datapeek.dev](https://datapeek.dev), free for personal use
+and MIT source. The Locks & Blocking panel sits right next to
+[Active Queries](/blog/kill-a-stuck-postgres-query) in the same health
+monitor — because when the database goes quiet in the bad way, "is something
+blocked?" is the very next question after "what is running?".


### PR DESCRIPTION
Play 4 of the SEO content engine — the first cluster of problem-first
tutorials, targeting real high-intent Postgres searches. All three grounded
in verified data-peek health-monitor features and cross-linked.

- **kill-a-stuck-postgres-query** — Active Queries + pg_cancel_backend
- **what-is-blocking-my-postgres-query** — Locks & Blocking (getLocks) + Kill Blocker
- **postgres-too-many-clients-already** — error-string target; honest framing
  (health monitor surfaces idle-in-transaction, not the full connection count)

Each gets the related-posts grid + breadcrumb schema from #237 automatically.
Verified: build ok, all three prerendered index,follow, cross-links resolve.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a guide for safely identifying and canceling stuck PostgreSQL queries.
  * Added troubleshooting guidance for “too many clients” errors, including connection management and session cleanup.
  * Added an article explaining how to identify blocking sessions, interpret lock relationships, and resolve PostgreSQL lock contention.
  * Included practical SQL examples, operational checklists, and links to related resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->