### PR TITLE
docs(blog): Postgres cleanup cluster (duplicate rows, unused indexes, bloat)

### DIFF
--- a/notes/delete-duplicate-rows-postgres.mdx
+++ b/notes/delete-duplicate-rows-postgres.mdx
@@ -1,0 +1,130 @@
+---
+title: "Finding and Deleting Duplicate Rows in Postgres (Safely)"
+description: "How to find duplicate rows in Postgres and delete all but one — with the row_number() and ctid patterns, and how to run the DELETE inside a transaction so a wrong WHERE can't wreck the table."
+date: "2026-07-23"
+author: "Rohith Gilla"
+tags: ["postgres", "performance", "database", "sql"]
+published: true
+---
+
+An import ran twice. Or a retry fired before the first request finished. Or
+a missing unique constraint quietly let the same row in four times. However
+it happened, you now have duplicates, and you need to delete the copies
+without deleting the originals — and without a stray `WHERE` turning a cleanup
+into an incident.
+
+The deleting is the scary part, so let's be careful about it. But first you
+have to see what you're dealing with.
+
+## Find the duplicates
+
+Start read-only. Group by whatever *should* have been unique and count:
+
+```sql
+SELECT email, count(*)
+FROM users
+GROUP BY email
+HAVING count(*) > 1
+ORDER BY count(*) DESC;
+```
+
+That tells you which keys are duplicated and how badly. Look at it before you
+delete anything — sometimes "duplicates" turn out to be legitimately distinct
+rows that just share one column, and the fix is a better key, not a `DELETE`.
+
+## Delete all but one
+
+The safe, standard pattern uses `row_number()` to number the copies within
+each duplicate group, then deletes everything after the first:
+
+```sql
+DELETE FROM users
+WHERE id IN (
+  SELECT id FROM (
+    SELECT id,
+           row_number() OVER (
+             PARTITION BY email
+             ORDER BY created_at
+           ) AS rn
+    FROM users
+  ) t
+  WHERE t.rn > 1
+);
+```
+
+The `PARTITION BY` is your definition of "duplicate"; the `ORDER BY` decides
+*which* copy survives (here, the oldest). Get both right and the query keeps
+exactly one row per group.
+
+**No primary key to lean on?** Use the system column `ctid`:
+
+```sql
+DELETE FROM users a
+USING users b
+WHERE a.ctid < b.ctid
+  AND a.email = b.email;
+```
+
+(Tables without a primary key make this harder in general — it's one of the
+things data-peek's [Schema Intel](/blog/schema-intel-diagnostics) flags for
+exactly this reason.)
+
+## The part that saves you: run it in a transaction
+
+The failure mode here is not writing the query — it's running a `DELETE`
+whose `WHERE` is subtly wrong and watching too many rows disappear. The fix
+is to never run a destructive statement you haven't previewed. Wrap it:
+
+```sql
+BEGIN;
+
+-- how many rows will this remove?
+SELECT count(*) FROM users
+WHERE id IN ( /* …the rn > 1 subquery… */ );
+
+DELETE FROM users
+WHERE id IN ( /* …the same subquery… */ );
+
+-- sanity check the survivors before you commit
+SELECT email, count(*) FROM users GROUP BY email HAVING count(*) > 1;
+
+-- happy? COMMIT;  wrong? ROLLBACK;
+```
+
+If the count is 10× what you expected, `ROLLBACK` and nothing happened. This
+one habit — count first, delete, verify, *then* commit — turns "duplicate
+cleanup" from a heart-in-mouth operation into a boring one.
+
+This is where a fast client earns its keep, and I'll be honest about what it
+is: data-peek has no magic "de-dupe" button. What it has is the thing that
+actually matters — you run the `SELECT` and see the exact rows in the grid
+before you touch anything, and you can walk the `BEGIN → DELETE → verify →
+COMMIT/ROLLBACK` sequence one statement at a time with
+[multi-statement step-through](/blog/multi-statement-step-through), so the
+`ROLLBACK` is always one keystroke away. The safety comes from the workflow,
+not a feature.
+
+## Stop it recurring
+
+Once the table is clean, add the constraint that should have been there:
+
+```sql
+ALTER TABLE users ADD CONSTRAINT users_email_key UNIQUE (email);
+```
+
+It will fail if any duplicates remain — which is a useful final check that
+your cleanup actually worked. From then on the database refuses the fourth
+copy for you.
+
+## The short version
+
+- Find first with `GROUP BY … HAVING count(*) > 1` and *look* before deleting.
+- Delete all-but-one with `row_number() … PARTITION BY`, or `ctid` when there's
+  no primary key.
+- Wrap the `DELETE` in a transaction, count and verify before you `COMMIT`.
+- Add the `UNIQUE` constraint so it can't happen again.
+
+data-peek is at [datapeek.dev](https://datapeek.dev), free for personal use
+and MIT source. It won't dedupe your table for you — but running the find
+query, previewing the damage, and rolling back a bad `DELETE` is exactly the
+loop it's built for.

--- a/notes/find-unused-indexes-postgres.mdx
+++ b/notes/find-unused-indexes-postgres.mdx
@@ -1,0 +1,104 @@
+---
+title: "Find Your Unused (and Missing) Postgres Indexes"
+description: "Unused indexes slow every write and waste disk. How to find them with pg_stat_user_indexes, spot missing ones from sequential scans, and drop the dead weight safely — with the caveats that matter."
+date: "2026-07-23"
+author: "Rohith Gilla"
+tags: ["postgres", "performance", "database", "sql"]
+published: true
+---
+
+Indexes feel free. They are not. Every index you keep is paid for on every
+`INSERT`, `UPDATE`, and `DELETE` — the write has to maintain the index too —
+and it sits on disk taking up space and buffer cache. Most databases I've
+looked at carry a handful of indexes that nobody's query has touched in
+months: leftovers from an experiment, a migration that added one "just in
+case", or two indexes that do the same job because nobody dropped the old one.
+
+Here's how to find both the dead weight and the gaps.
+
+## Unused indexes
+
+Postgres tracks how many times each index has been scanned in
+`pg_stat_user_indexes`. An index with `idx_scan = 0` has not served a single
+lookup since stats were last reset:
+
+```sql
+SELECT
+  s.schemaname,
+  s.relname   AS table,
+  s.indexrelname AS index,
+  s.idx_scan  AS scans,
+  pg_size_pretty(pg_relation_size(s.indexrelid)) AS size
+FROM pg_stat_user_indexes s
+JOIN pg_index i ON i.indexrelid = s.indexrelid
+WHERE s.idx_scan = 0
+  AND NOT i.indisunique      -- keep unique/PK indexes; they enforce constraints
+ORDER BY pg_relation_size(s.indexrelid) DESC;
+```
+
+Then drop them without locking the table:
+
+```sql
+DROP INDEX CONCURRENTLY idx_that_never_gets_used;
+```
+
+**Read the caveats before you drop anything** — this is where people cause
+outages:
+
+- **Stats are cumulative since the last reset.** If someone ran
+  `pg_stat_reset()` yesterday, *everything* looks unused. Check
+  `stats_reset` in `pg_stat_database` — you want weeks of history, ideally
+  spanning your monthly/quarterly jobs.
+- **Replicas keep their own stats.** An index unused on the primary may be
+  doing heavy work serving reads on a replica. Check there too.
+- **Never drop a unique or primary-key index** just because `idx_scan` is 0 —
+  it's enforcing a constraint, not serving queries. The `NOT i.indisunique`
+  filter above excludes them.
+
+## Missing indexes
+
+The mirror image: tables taking sequential scans they shouldn't. Compare
+`seq_scan` against `idx_scan`:
+
+```sql
+SELECT relname AS table, seq_scan, idx_scan, n_live_tup AS est_rows
+FROM pg_stat_user_tables
+WHERE seq_scan > 1000
+ORDER BY seq_scan DESC;
+```
+
+A big table with lots of sequential scans and few index scans is a candidate.
+But "candidate" is not "add an index" — confirm the specific slow query needs
+one by [reading its EXPLAIN plan](/blog/understanding-explain-analyze) first.
+The most common concrete miss is a **foreign key column with no index**, which
+turns every join and parent-row delete into a scan.
+
+## The one-click version
+
+Writing and re-writing these queries is exactly the chore you keep meaning to
+automate and don't. data-peek's [Schema Intel](/blog/schema-intel-diagnostics)
+runs them for you as read-only checks and hands back copyable fixes —
+specifically:
+
+- **Unused indexes** — the `idx_scan = 0` check above, with a `DROP INDEX`
+  ready to copy.
+- **Duplicate or redundant indexes** — two indexes covering the same leading
+  columns, wasting writes.
+- **Foreign keys missing an index** — the most common *missing*-index case,
+  surfaced directly.
+
+That post is the feature tour; this one is the why and the SQL behind it. Use
+whichever you prefer — but do the thinking (the caveats above) before you drop.
+
+## The short version
+
+- Find dead indexes with `pg_stat_user_indexes` `idx_scan = 0`, excluding
+  unique/PK indexes, and drop with `DROP INDEX CONCURRENTLY`.
+- Check `stats_reset` age and your replicas before trusting "unused" — this is
+  how people drop an index that was actually in use.
+- For missing indexes, start from `seq_scan` heavy tables and unindexed FK
+  columns, then confirm with `EXPLAIN` — don't index on a hunch.
+
+data-peek is at [datapeek.dev](https://datapeek.dev), free for personal use
+and MIT source. The index checks live in Schema Intel, right next to the
+[bloat and vacuum diagnostics](/blog/postgres-table-bloat-dead-tuples).

--- a/notes/postgres-table-bloat-dead-tuples.mdx
+++ b/notes/postgres-table-bloat-dead-tuples.mdx
@@ -1,0 +1,95 @@
+---
+title: "Spotting Postgres Table Bloat Before It Bites"
+description: "Disk climbing while row counts stay flat? That's dead tuples. How to measure bloat with pg_stat_user_tables, tell when autovacuum is falling behind, and reclaim space without a heavy lock."
+date: "2026-07-23"
+author: "Rohith Gilla"
+tags: ["postgres", "performance", "database", "sql"]
+published: true
+---
+
+Here's the confusing version of the problem: your disk usage is climbing and
+queries on a table are getting slower, but the row count is basically flat.
+Nothing is growing — so what's eating the space?
+
+Dead tuples. Postgres doesn't overwrite a row on `UPDATE` or remove it on
+`DELETE`; it marks the old version dead and leaves it in place for `VACUUM` to
+reclaim later. On a table with heavy churn, if autovacuum can't keep up, those
+dead versions pile up — that's bloat. Sequential and index scans still have to
+step over the corpses, so the table gets both bigger and slower.
+
+## Measure it
+
+`pg_stat_user_tables` tracks live and dead tuples per table. The ratio is what
+matters:
+
+```sql
+SELECT
+  schemaname,
+  relname AS table,
+  n_live_tup AS live_rows,
+  n_dead_tup AS dead_rows,
+  ROUND(n_dead_tup::numeric / NULLIF(n_live_tup + n_dead_tup, 0) * 100, 1)
+    AS dead_pct,
+  last_autovacuum,
+  last_vacuum
+FROM pg_stat_user_tables
+WHERE n_dead_tup > 1000
+ORDER BY n_dead_tup DESC;
+```
+
+A table sitting at 20%+ dead tuples is bloated enough to care about. Look at
+`last_autovacuum` too: if it's null or ancient on a busy table, autovacuum
+isn't keeping pace. (For a byte-accurate estimate rather than a tuple ratio,
+the community `ioguix/pgsql-bloat-estimation` catalog queries are the standard
+tool — but the ratio above is enough to catch the problem day to day.)
+
+## Fix it — and mind the lock
+
+- **Plain `VACUUM`** reclaims dead tuples for reuse *without* an exclusive
+  lock. This is the normal answer and safe to run on a live table:
+  ```sql
+  VACUUM (VERBOSE, ANALYZE) my_table;
+  ```
+- **`VACUUM FULL` rewrites the whole table** and returns space to the OS, but
+  takes an `ACCESS EXCLUSIVE` lock — the table is unusable for the duration.
+  Never reach for it casually on production. For heavy bloat where you need the
+  disk back with minimal locking, `pg_repack` does the rewrite online.
+- **Tune autovacuum for hot tables** so it stops falling behind. The defaults
+  (`autovacuum_vacuum_scale_factor = 0.2`) mean a million-row table waits for
+  ~200k dead rows before vacuuming. For a high-churn table, make it aggressive
+  per-table:
+  ```sql
+  ALTER TABLE my_table SET (
+    autovacuum_vacuum_scale_factor = 0.02,
+    autovacuum_vacuum_threshold = 500
+  );
+  ```
+
+## The one-click version
+
+data-peek's [Schema Intel](/blog/schema-intel-diagnostics) runs the bloat math
+for you as read-only checks:
+
+- **Bloated tables** — flags tables where dead tuples are a large share of
+  storage (dead / (live + dead) over ~20%), with a VACUUM / `pg_repack`
+  suggestion attached.
+- **Never vacuumed or analyzed** — tables autovacuum has never touched, which
+  usually also means stale planner statistics and bad query plans.
+
+Pair that with the [Table Sizes panel](/blog/check-table-sizes-postgresql) to
+watch which tables are actually growing on disk, and you can see bloat forming
+before it turns into a 3am disk-full page.
+
+## The short version
+
+- Bloat = dead tuples from `UPDATE`/`DELETE` churn that `VACUUM` hasn't
+  reclaimed; it grows the table and slows scans while row counts stay flat.
+- Measure the dead-tuple ratio in `pg_stat_user_tables` and check
+  `last_autovacuum`.
+- Plain `VACUUM` is safe and usually enough; `VACUUM FULL` locks the table —
+  use `pg_repack` for online rewrites. Tune per-table autovacuum on hot tables
+  so it stops falling behind.
+
+data-peek is at [datapeek.dev](https://datapeek.dev), free for personal use
+and MIT source. Bloat and vacuum diagnostics sit in Schema Intel next to the
+[index checks](/blog/find-unused-indexes-postgres).


### PR DESCRIPTION
Play 4 Cluster B — three search-intent cleanup tutorials, cross-linked and
grounded in verified data-peek features.

- **delete-duplicate-rows-postgres** — row_number()/ctid; honest framing
  (no dedupe button; safety = run→preview→transaction via step-through)
- **find-unused-indexes-postgres** — pg_stat_user_indexes idx_scan=0 + caveats;
  ties to Schema Intel unused/duplicate/missing-FK-index checks. Search-intent
  how-to, cross-linked to (not duplicating) the schema-intel feature post.
- **postgres-table-bloat-dead-tuples** — n_dead_tup ratio + vacuum guidance;
  ties to Schema Intel bloated_tables / never_vacuumed + Table Sizes.

Verified: build ok, all three prerendered index,follow, cross-links resolve.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for safely identifying and removing duplicate PostgreSQL rows.
  * Added instructions for finding unused or missing indexes, including safety considerations.
  * Added an overview of PostgreSQL table bloat, dead tuples, vacuuming, and maintenance options.
  * Included diagnostic SQL examples, verification steps, and recommendations to prevent recurring database issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->