### PR TITLE
Fix 404 on in-app license purchase and dashboard links

### DIFF
--- a/apps/desktop/src/renderer/src/components/license-activation-modal.tsx
+++ b/apps/desktop/src/renderer/src/components/license-activation-modal.tsx
@@ -12,7 +12,7 @@ import {
 } from '@data-peek/ui'
 
 import { useLicenseStore } from '@/stores/license-store'
-import { buildTrackingUrl } from '@shared/index'
+import { buildTrackingUrl, LICENSE_PURCHASE_PATH, LICENSE_DASHBOARD_PATH } from '@shared/index'
 
 const UTM_PARAMS = { source: 'desktop', medium: 'app', content: 'activation_modal' }
 
@@ -131,7 +131,7 @@ export function LicenseActivationModal({ open, onOpenChange }: LicenseActivation
             <p className="text-sm text-muted-foreground">
               Don&apos;t have a license?{' '}
               <a
-                href={buildTrackingUrl('/pricing', UTM_PARAMS)}
+                href={buildTrackingUrl(LICENSE_PURCHASE_PATH, UTM_PARAMS)}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-1 text-primary hover:underline"
@@ -143,7 +143,7 @@ export function LicenseActivationModal({ open, onOpenChange }: LicenseActivation
             <p className="mt-2 text-sm text-muted-foreground">
               Need to manage your license?{' '}
               <a
-                href={buildTrackingUrl('/dashboard', UTM_PARAMS)}
+                href={buildTrackingUrl(LICENSE_DASHBOARD_PATH, UTM_PARAMS)}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-1 text-primary hover:underline"

--- a/apps/desktop/src/renderer/src/components/license-settings-modal.tsx
+++ b/apps/desktop/src/renderer/src/components/license-settings-modal.tsx
@@ -18,7 +18,7 @@ import {
 } from '@data-peek/ui'
 
 import { useLicenseStore } from '@/stores/license-store'
-import { buildTrackingUrl } from '@shared/index'
+import { buildTrackingUrl, LICENSE_PURCHASE_PATH } from '@shared/index'
 
 interface LicenseSettingsModalProps {
   open: boolean
@@ -190,7 +190,7 @@ export function LicenseSettingsModal({ open, onOpenChange }: LicenseSettingsModa
               <Button
                 onClick={() =>
                   window.open(
-                    buildTrackingUrl('/pricing', {
+                    buildTrackingUrl(LICENSE_PURCHASE_PATH, {
                       source: 'desktop',
                       medium: 'app',
                       content: 'license_settings'

--- a/apps/desktop/src/renderer/src/lib/__tests__/license-links.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/license-links.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { readFileSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import {
   buildTrackingUrl,
@@ -40,21 +40,17 @@ describe('buildTrackingUrl', () => {
 })
 
 describe('license purchase link', () => {
-  // Regression test: the in-app "Purchase one" button used to point at /pricing,
-  // which has no page on the marketing site and returned a 404.
-  it('points at the home page pricing anchor, not a standalone /pricing route', () => {
+  // Regression test: the in-app "Purchase one" button used to point at /pricing
+  // before that page existed on the marketing site, so users got a 404.
+  it('builds a well-formed tracking URL', () => {
     const url = new URL(buildTrackingUrl(LICENSE_PURCHASE_PATH, { source: 'desktop' }))
-    expect(url.pathname).toBe('/')
-    expect(url.hash).toBe('#pricing')
+    expect(url.pathname).toBe(LICENSE_PURCHASE_PATH)
+    expect(url.searchParams.get('utm_source')).toBe('desktop')
   })
 
-  it('targets an anchor that exists on the marketing site', () => {
-    const pricingSection = readFileSync(
-      resolve(WEB_APP_DIR, 'src/components/marketing/pricing.tsx'),
-      'utf-8'
-    )
-    const anchor = LICENSE_PURCHASE_PATH.split('#')[1]
-    expect(pricingSection).toContain(`id="${anchor}"`)
+  it('targets a page that exists on the marketing site', () => {
+    const pagePath = resolve(WEB_APP_DIR, `src/app${LICENSE_PURCHASE_PATH}/page.tsx`)
+    expect(existsSync(pagePath)).toBe(true)
   })
 })
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/license-links.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/license-links.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import {
+  buildTrackingUrl,
+  DATAPEEK_BASE_URL,
+  LICENSE_PURCHASE_PATH,
+  LICENSE_DASHBOARD_PATH
+} from '@shared/index'
+
+const WEB_APP_DIR = resolve(__dirname, '../../../../../../web')
+
+describe('buildTrackingUrl', () => {
+  it('appends UTM params as a query string', () => {
+    const url = buildTrackingUrl('/download', { source: 'desktop', medium: 'app' })
+    expect(url).toBe(`${DATAPEEK_BASE_URL}/download?utm_source=desktop&utm_medium=app`)
+  })
+
+  it('returns the plain URL when no UTM params are given', () => {
+    expect(buildTrackingUrl('/download')).toBe(`${DATAPEEK_BASE_URL}/download`)
+  })
+
+  it('inserts UTM params before a hash fragment, not after it', () => {
+    const url = buildTrackingUrl('/#pricing', { source: 'desktop' })
+    expect(url).toBe(`${DATAPEEK_BASE_URL}/?utm_source=desktop#pricing`)
+
+    const parsed = new URL(url)
+    expect(parsed.hash).toBe('#pricing')
+    expect(parsed.searchParams.get('utm_source')).toBe('desktop')
+  })
+
+  it('appends to an existing query string while preserving the hash', () => {
+    const url = buildTrackingUrl('/download?os=mac#latest', { source: 'desktop' })
+    expect(url).toBe(`${DATAPEEK_BASE_URL}/download?os=mac&utm_source=desktop#latest`)
+  })
+
+  it('keeps a hash-only path intact without UTM params', () => {
+    expect(buildTrackingUrl('/#pricing')).toBe(`${DATAPEEK_BASE_URL}/#pricing`)
+  })
+})
+
+describe('license purchase link', () => {
+  // Regression test: the in-app "Purchase one" button used to point at /pricing,
+  // which has no page on the marketing site and returned a 404.
+  it('points at the home page pricing anchor, not a standalone /pricing route', () => {
+    const url = new URL(buildTrackingUrl(LICENSE_PURCHASE_PATH, { source: 'desktop' }))
+    expect(url.pathname).toBe('/')
+    expect(url.hash).toBe('#pricing')
+  })
+
+  it('targets an anchor that exists on the marketing site', () => {
+    const pricingSection = readFileSync(
+      resolve(WEB_APP_DIR, 'src/components/marketing/pricing.tsx'),
+      'utf-8'
+    )
+    const anchor = LICENSE_PURCHASE_PATH.split('#')[1]
+    expect(pricingSection).toContain(`id="${anchor}"`)
+  })
+})
+
+describe('license dashboard link', () => {
+  it('is covered by a marketing-site redirect so it does not 404', () => {
+    const nextConfig = readFileSync(resolve(WEB_APP_DIR, 'next.config.ts'), 'utf-8')
+    expect(nextConfig).toContain(`source: "${LICENSE_DASHBOARD_PATH}"`)
+  })
+})

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -33,13 +33,8 @@ const nextConfig: NextConfig = {
         destination: "https://www.datapeek.dev/:path*",
         permanent: true,
       },
-      // Shipped desktop builds link to /pricing and /dashboard, which have no
-      // standalone pages — keep these resolving instead of 404ing.
-      {
-        source: "/pricing",
-        destination: "/#pricing",
-        permanent: false,
-      },
+      // Shipped desktop builds link to /dashboard, which has no standalone
+      // page — keep it resolving instead of 404ing.
       {
         source: "/dashboard",
         destination: "/",

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -33,6 +33,18 @@ const nextConfig: NextConfig = {
         destination: "https://www.datapeek.dev/:path*",
         permanent: true,
       },
+      // Shipped desktop builds link to /pricing and /dashboard, which have no
+      // standalone pages — keep these resolving instead of 404ing.
+      {
+        source: "/pricing",
+        destination: "/#pricing",
+        permanent: false,
+      },
+      {
+        source: "/dashboard",
+        destination: "/",
+        permanent: false,
+      },
     ];
   },
 };

--- a/apps/web/src/app/pricing/page.tsx
+++ b/apps/web/src/app/pricing/page.tsx
@@ -1,0 +1,33 @@
+import { Metadata } from "next";
+import { Header } from "@/components/marketing/header";
+import { Pricing } from "@/components/marketing/pricing";
+import { Faq } from "@/components/marketing/faq";
+import { Footer } from "@/components/marketing/footer";
+import { generateMetadata as generateSeoMetadata } from "@/lib/seo";
+
+export const metadata: Metadata = generateSeoMetadata({
+  title: "Pricing",
+  description:
+    "data-peek is free for personal use. Buy a Pro license for commercial use — one payment, 1 year of updates, perpetual fallback license. No seats, no subscriptions.",
+  keywords: [
+    "data-peek pricing",
+    "data-peek license",
+    "database client pricing",
+    "SQL client license",
+    "buy data-peek",
+  ],
+  path: "/pricing",
+});
+
+export default function PricingPage() {
+  return (
+    <div className="neat min-h-screen">
+      <Header />
+      <main>
+        <Pricing />
+        <Faq />
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -37,6 +37,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.9,
     },
     {
+      url: `${BASE_URL}/pricing`,
+      lastModified: new Date(),
+      changeFrequency: "monthly" as const,
+      priority: 0.9,
+    },
+    {
       url: `${BASE_URL}/blog`,
       lastModified: new Date(),
       changeFrequency: "weekly" as const,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -24,9 +24,9 @@ export const DATAPEEK_BASE_URL = "https://www.datapeek.dev";
 
 /**
  * Marketing-site path for purchasing a license.
- * Pricing lives at an anchor on the home page — there is no standalone /pricing route.
+ * Must match a real page in apps/web — shipped desktop builds link here directly.
  */
-export const LICENSE_PURCHASE_PATH = "/#pricing";
+export const LICENSE_PURCHASE_PATH = "/pricing";
 
 /**
  * Marketing-site path for managing an existing license.

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -23,6 +23,18 @@ export {
 export const DATAPEEK_BASE_URL = "https://www.datapeek.dev";
 
 /**
+ * Marketing-site path for purchasing a license.
+ * Pricing lives at an anchor on the home page — there is no standalone /pricing route.
+ */
+export const LICENSE_PURCHASE_PATH = "/#pricing";
+
+/**
+ * Marketing-site path for managing an existing license.
+ * There is no standalone dashboard page yet; the site redirects this to the home page.
+ */
+export const LICENSE_DASHBOARD_PATH = "/dashboard";
+
+/**
  * UTM parameters for tracking
  */
 export interface UTMParams {
@@ -44,9 +56,15 @@ export function buildTrackingUrl(path: string, utm: UTMParams = {}): string {
   if (utm.content) params.set("utm_content", utm.content);
 
   const queryString = params.toString();
-  const separator = path.includes("?") ? "&" : "?";
 
-  return `${DATAPEEK_BASE_URL}${path}${queryString ? separator + queryString : ""}`;
+  // Query params must be inserted before any hash fragment:
+  // "/#pricing" → "/?utm_source=…#pricing", not "/#pricing?utm_source=…"
+  const hashIndex = path.indexOf("#");
+  const basePath = hashIndex === -1 ? path : path.slice(0, hashIndex);
+  const hash = hashIndex === -1 ? "" : path.slice(hashIndex);
+  const separator = basePath.includes("?") ? "&" : "?";
+
+  return `${DATAPEEK_BASE_URL}${basePath}${queryString ? separator + queryString : ""}${hash}`;
 }
 
 /**


### PR DESCRIPTION
## Summary

The "Purchase one" link in the Activate License modal (and the "Renew License" button in License Settings) pointed at `https://www.datapeek.dev/pricing`, which had no page on the marketing site — pricing only existed as the `/#pricing` anchor on the home page — so users hit a 404 when trying to buy a license. The "License Dashboard" link (`/dashboard`) 404'd for the same reason. Reported on X: https://x.com/emerald_d3v/status/2082563487293648915

The fix is server-first so desktop builds already in users' hands work as soon as the site deploys, with no app update required: a real `/pricing` page now exists at the exact URL shipped apps link to.

## Changes

**Web app (fixes shipped builds immediately)**
- Added a dedicated `/pricing` page rendering the existing `Pricing` and `Faq` sections with SEO metadata and a canonical URL
- Added `/pricing` to the sitemap
- Added a `/dashboard` → `/` redirect in `next.config.ts` (no license dashboard page exists yet, so this is a stopgap to stop the 404)

**Desktop app**
- Purchase/renew links now use a shared `LICENSE_PURCHASE_PATH` constant (`/pricing`) from `packages/shared`, with `LICENSE_DASHBOARD_PATH` for the dashboard link
- Fixed `buildTrackingUrl` to insert UTM query params before a hash fragment (`/?utm_source=…#pricing` instead of the malformed `/#pricing?utm_source=…`), so anchor paths work correctly if used

**Tests**
- Added `license-links.test.ts`: UTM/hash URL-building behaviour, the purchase link building a well-formed URL, the `/pricing` page actually existing in `apps/web` (guards against the 404 regressing), and the `/dashboard` redirect being present in `next.config.ts`

## Related Issues

N/A — reported via https://x.com/emerald_d3v/status/2082563487293648915

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have tested my changes (`pnpm test`: 1119 passed; desktop `pnpm typecheck` clean; `apps/web` `tsc --noEmit` clean; lint issues are pre-existing in untouched files)
- [ ] I have updated documentation if needed

## Screenshots (if applicable)

N/A — the new `/pricing` page reuses the existing home-page pricing and FAQ sections unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bpfhxij2UkLwY8MaZaYTkc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated **Pricing** page and included it in the sitemap.

* **Bug Fixes**
  * License purchase and dashboard links now route to the correct pages.
  * Tracking query parameters are now appended in the correct position (before any URL fragment), while preserving existing query strings and fragments.
  * Updated routing redirects to avoid missing-page issues for desktop builds.

* **Tests**
  * Expanded automated coverage for tracked URL generation and the updated license link/redirect behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->