### PR TITLE
fix(web): stop running Clerk middleware on public routes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -90,3 +90,74 @@ jobs:
           name: playwright-results
           path: apps/desktop/test-results
           retention-days: 7
+
+  web:
+    name: playwright (web)
+    # The marketing site's jsdom suite cannot observe media resource selection or
+    # hydration attribute reconciliation, and two real bugs shipped through that gap:
+    # a clip switch that kept playing the previous video, and a reduced-motion
+    # controls fallback that never reached the DOM. This job is the only place those
+    # are actually verified.
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Chromium only — these assertions are about media resource selection and
+      # hydration, not cross-browser rendering.
+      - name: Install Chromium
+        run: pnpm --filter @data-peek/web exec playwright install --with-deps chromium
+
+      # The Playwright config's webServer runs `next build && next start` itself, so
+      # there is no separate build step here.
+      - name: Run web browser tests
+        run: pnpm --filter @data-peek/web test:browser
+        env:
+          # Placeholders, never real, and only needed to be non-empty. Three API
+          # routes construct a DodoPayments client at module scope and Next collects
+          # page data for them at build time, so an absent key aborts the build.
+          #
+          # The Clerk values only have to exist for the build — they are never
+          # validated at request time any more, because middleware no longer runs on
+          # public routes. A bogus key used to return 400 for every page.
+          DODO_API_KEY: placeholder-not-a-real-key
+          DODO_PAYMENTS_API_KEY: placeholder-not-a-real-key
+          DODO_WEBHOOK_SECRET: placeholder-not-a-real-secret
+          DODO_PRO_PRODUCT_ID: placeholder-product-id
+          RESEND_API_KEY: placeholder-not-a-real-key
+          CLERK_SECRET_KEY: sk_test_placeholder
+          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: pk_test_ZXhhbXBsZS5jbGVyay5hY2NvdW50cy5kZXYk
+          DATABASE_URL: postgres://placeholder:placeholder@127.0.0.1:5432/placeholder
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report-web
+          path: apps/web/playwright-report
+          retention-days: 7

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -21,21 +21,15 @@ import { defineConfig, devices } from "@playwright/test";
  * and reduced-motion actually degrading. Behaviour that jsdom *can* see belongs in
  * the Vitest suite, which is far faster.
  *
- * Run it with `pnpm --filter @data-peek/web test:browser`.
+ * Run it with `pnpm --filter @data-peek/web test:browser`. Also runs in CI, as the
+ * `playwright (web)` job.
  *
- * NOT WIRED INTO CI YET, and the reason is not the tests. `src/middleware.ts` runs
- * clerkMiddleware on `/`, and Clerk answers 400 "Invalid host" for any request when
- * the publishable key does not belong to a real instance — so every page load in CI
- * returns an error body and nothing renders. A build-time placeholder is not enough,
- * because the rejection happens at request time inside clerkMiddleware, before the
- * route callback that decides `/` needs no auth.
- *
- * Resolving that means one of: a real Clerk test key as a repo secret; restructuring
- * the middleware so public routes never enter clerkMiddleware (a change to production
- * auth behaviour); or pointing this suite at the Vercel preview deployment, which
- * already builds each PR with real credentials. All three are judgement calls beyond
- * a bugfix branch, so for now this runs locally — where it does work, and where it
- * caught the bug this PR fixes.
+ * CI passes placeholder credentials. They exist only because the production build
+ * needs them non-empty — three API routes construct a DodoPayments client at module
+ * scope and Next collects page data for them at build time. The Clerk placeholders in
+ * particular are never validated at request time, because middleware no longer runs
+ * on public routes; before that change a bogus key made Clerk return 400 for every
+ * page, which is what blocked this suite from running in CI at all.
  */
 // Deliberately obscure. 3000/3100 collide with other dev servers, and combined with
 // `reuseExistingServer` a collision means silently testing an unrelated app — which

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,35 +1,37 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 
-// Define which routes require authentication
+// Routes that require a signed-in user. Kept as a check separate from the `matcher`
+// below on purpose: the matcher decides what Clerk sees at all, this decides what it
+// protects. If the matcher is ever widened, nothing becomes protected by accident.
 const isProtectedRoute = createRouteMatcher([
   "/account(.*)",
   "/api/account(.*)",
 ]);
 
-// Define which routes are public API endpoints (no auth needed)
-const isPublicApiRoute = createRouteMatcher([
-  "/api/license/(.*)",
-  "/api/updates/(.*)",
-  "/api/webhooks/(.*)",
-]);
-
 export default clerkMiddleware(async (auth, req) => {
-  // Skip auth for public API routes
-  if (isPublicApiRoute(req)) {
-    return;
-  }
-
-  // Protect dashboard routes
   if (isProtectedRoute(req)) {
     await auth.protect();
   }
 });
 
 export const config = {
-  matcher: [
-    // Skip Next.js internals and all static files
-    "/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)",
-    // Always run for API routes
-    "/(api|trpc)(.*)",
-  ],
+  // Only the authenticated surface.
+  //
+  // This previously matched every page and API route except Next internals and static
+  // files, so every marketing request paid a Clerk round trip for nothing. Worse,
+  // Clerk answers 400 "Invalid host" whenever it cannot attribute the publishable key
+  // to a real instance — so a bad or missing key took down the entire site rather
+  // than just the signed-in area.
+  //
+  // Safe to narrow because nothing outside these routes touches Clerk: there is no
+  // auth() or currentUser() call anywhere in the app, and <ClerkProvider> in
+  // app/layout.tsx is static (no `dynamic` prop), so it renders without middleware
+  // having run. The former `isPublicApiRoute` early-return is gone with it — those
+  // routes are simply no longer matched, so the check was unreachable.
+  //
+  // Two things to remember as the authenticated area grows: a page or route handler
+  // that calls auth() or currentUser() must be listed here or it will throw, and
+  // Clerk's handshake can only be processed on a matched path — so any post-sign-in
+  // landing route belongs here too.
+  matcher: ["/account(.*)", "/api/account(.*)"],
 };


### PR DESCRIPTION
`clerkMiddleware` ran on every marketing page. Two costs: a Clerk round trip per request for pages that need no auth, and a hard runtime dependency — Clerk answers 400 `host_invalid` whenever it cannot attribute the publishable key, which took down the **whole site**, not just the signed-in area.

## What I verified before narrowing it

The old matcher covered every page and API route except Next internals and static files. Narrowing that is only safe if nothing outside the authenticated surface touches Clerk, so I checked:

- **No `auth()` or `currentUser()` anywhere in `apps/web`.** Only two files reference Clerk at all: `src/middleware.ts` and `app/layout.tsx`.
- **`<ClerkProvider>` is static** — it carries only an `appearance` prop, no `dynamic`, so on `@clerk/nextjs` v6 it renders without requiring middleware to have run.
- **`/account` and `/api/account` do not exist.** So `isProtectedRoute` matched nothing: the middleware was protecting zero routes while running on all of them.

Also dropped the `isPublicApiRoute` early-return — those routes are no longer matched, so the check was unreachable.

## Evidence

Built and served with a deliberately bogus publishable key — the exact condition that used to 400 every request:

| | before | after |
|---|---|---|
| `/` with bogus Clerk key | 400 `host_invalid`, nothing renders | 200, renders |
| browser smoke tests | 4 failed | **4 passed** |

Then re-checked with real credentials that behaviour is unchanged: `/`, `/pricing`, `/download`, `/blog` all 200 with no Clerk error; `/api/updates/check` returns its own 400 (19 bytes, not Clerk's 313-byte payload); `/api/license/validate` 405 for GET; `/account` 404. Identical to before, minus a Clerk round trip per request.

## Knock-on

Restores the `playwright (web)` CI job, which had to be dropped from #243 for exactly this reason. The placeholder credentials it passes are now only needed so the production build can complete — three API routes construct a DodoPayments client at module scope, and Next collects page data for them at build time. The Clerk placeholders are never validated at request time any more.

## Follow-up worth considering separately

`<ClerkProvider>` currently wraps a site with no Clerk UI in it. If there is no near-term plan for an account area it is dead weight in every page's tree; if there is, this middleware is ready for it. Left alone either way — that is a product call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated browser smoke tests to the continuous integration workflow.
  * Failed browser test runs now provide downloadable test reports.

* **Bug Fixes**
  * Refined authentication protection so only account pages and account APIs require authentication.
  * Public routes can now be accessed without being blocked by authentication middleware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->