### PR TITLE
feat(desktop): add default schema support for PostgreSQL connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ A minimal, fast SQL client desktop application with AI-powered querying. Built f
 - **Fast** - Opens in under 2 seconds, low memory footprint
 - **Multi-Database** - PostgreSQL, MySQL, Microsoft SQL Server, SQLite
 - **SSH Tunnels** - Connect securely through bastion hosts with password or key auth
+- **Default Schema** - Pin a PostgreSQL connection's `search_path` and focus the sidebar on one schema
 - **Secure** - Connection credentials encrypted locally using OS keychain, no telemetry
 
 ### AI Assistant

--- a/apps/desktop/src/main/__tests__/pg-client-config.test.ts
+++ b/apps/desktop/src/main/__tests__/pg-client-config.test.ts
@@ -33,6 +33,15 @@ describe('parseSchemaList', () => {
     expect(parseSchemaList('bbl, public')).toEqual(['bbl', 'public'])
     expect(parseSchemaList('  bbl  ')).toEqual(['bbl'])
   })
+
+  it('unwraps a value pasted straight out of SHOW search_path', () => {
+    expect(parseSchemaList('"bbl","public"')).toEqual(['bbl', 'public'])
+    expect(parseSchemaList('"blocktree"')).toEqual(['blocktree'])
+  })
+
+  it('re-quotes an unwrapped paste rather than nesting the quotes', () => {
+    expect(buildSearchPathOption('"bbl","public"')).toBe('-c search_path="bbl","public"')
+  })
 })
 
 describe('buildSearchPathOption', () => {

--- a/apps/desktop/src/main/__tests__/pg-client-config.test.ts
+++ b/apps/desktop/src/main/__tests__/pg-client-config.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest'
+import type { ConnectionConfig } from '@shared/index'
+import {
+  buildClientConfig,
+  buildSearchPathOption,
+  parseSchemaList
+} from '../adapters/pg-client-config'
+
+function makeConfig(overrides: Partial<ConnectionConfig> = {}): ConnectionConfig {
+  return {
+    id: 'cfg-1',
+    name: 'test',
+    host: 'localhost',
+    port: 5432,
+    database: 'db',
+    user: 'u',
+    password: 'p',
+    dbType: 'postgresql',
+    dstPort: 5432,
+    ...overrides
+  }
+}
+
+describe('parseSchemaList', () => {
+  it('returns an empty list for absent or blank values', () => {
+    expect(parseSchemaList(undefined)).toEqual([])
+    expect(parseSchemaList('')).toEqual([])
+    expect(parseSchemaList('   ')).toEqual([])
+    expect(parseSchemaList(' , , ')).toEqual([])
+  })
+
+  it('splits and trims a comma-separated fallback chain', () => {
+    expect(parseSchemaList('bbl, public')).toEqual(['bbl', 'public'])
+    expect(parseSchemaList('  bbl  ')).toEqual(['bbl'])
+  })
+})
+
+describe('buildSearchPathOption', () => {
+  it('leaves the server default in place when no schema is configured', () => {
+    expect(buildSearchPathOption(undefined)).toBeUndefined()
+    expect(buildSearchPathOption('')).toBeUndefined()
+    expect(buildSearchPathOption('  ')).toBeUndefined()
+  })
+
+  it('double-quotes the schema so mixed case and reserved words survive', () => {
+    expect(buildSearchPathOption('bbl')).toBe('-c search_path="bbl"')
+    expect(buildSearchPathOption('MySchema')).toBe('-c search_path="MySchema"')
+    expect(buildSearchPathOption('user')).toBe('-c search_path="user"')
+  })
+
+  it('emits a comma-separated chain for multiple schemas', () => {
+    expect(buildSearchPathOption('bbl, public')).toBe('-c search_path="bbl","public"')
+  })
+
+  it('backslash-escapes whitespace, which pg_split_opts would otherwise treat as an argument break', () => {
+    // The server strips the backslashes before the GUC parser sees the value, so this
+    // arrives as search_path="we ird","public".
+    expect(buildSearchPathOption('we ird, public')).toBe('-c search_path="we\\ ird","public"')
+  })
+
+  it('escapes backslashes in the schema name so they are not eaten as escapes', () => {
+    expect(buildSearchPathOption('we\\ird')).toBe('-c search_path="we\\\\ird"')
+  })
+
+  it('doubles embedded quotes so the identifier cannot be terminated early', () => {
+    expect(buildSearchPathOption('we"ird')).toBe('-c search_path="we""ird"')
+  })
+})
+
+describe('buildClientConfig', () => {
+  it('sets startup options when a default schema is configured', () => {
+    expect(buildClientConfig(makeConfig({ schema: 'bbl' })).options).toBe('-c search_path="bbl"')
+  })
+
+  it('omits options entirely when no schema is configured', () => {
+    expect(buildClientConfig(makeConfig()).options).toBeUndefined()
+    expect(buildClientConfig(makeConfig({ schema: '' })).options).toBeUndefined()
+  })
+
+  it('keeps the search_path when the connection is tunnelled through SSH', () => {
+    const config = buildClientConfig(makeConfig({ schema: 'bbl' }), {
+      host: '127.0.0.1',
+      port: 54320
+    })
+    expect(config.host).toBe('127.0.0.1')
+    expect(config.port).toBe(54320)
+    expect(config.options).toBe('-c search_path="bbl"')
+  })
+})

--- a/apps/desktop/src/main/__tests__/pg-pool-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/pg-pool-manager.test.ts
@@ -79,6 +79,25 @@ describe('withPgClient', () => {
     expect(PoolCtor).toHaveBeenCalledTimes(2)
   })
 
+  it('passes the configured default schema through as startup options', async () => {
+    await withPgClient(makeConfig({ schema: 'bbl' }), async () => {})
+
+    expect(PoolCtor).toHaveBeenCalledWith(
+      expect.objectContaining({ options: '-c search_path="bbl"' })
+    )
+  })
+
+  it('does not share a pool between unsaved configs that differ only by schema', async () => {
+    // search_path is baked into each connection's startup options, so reusing a pool
+    // across schemas would silently keep the first one's search_path.
+    const base = { ...makeConfig(), id: '' }
+
+    await withPgClient({ ...base, schema: 'bbl' }, async () => {})
+    await withPgClient({ ...base, schema: 'fel' }, async () => {})
+
+    expect(PoolCtor).toHaveBeenCalledTimes(2)
+  })
+
   it('survives double-release without throwing', async () => {
     mockClient.release.mockImplementationOnce(() => {
       throw new Error('Release called on client which has already been released')

--- a/apps/desktop/src/main/adapters/pg-client-config.ts
+++ b/apps/desktop/src/main/adapters/pg-client-config.ts
@@ -3,6 +3,40 @@ import type { ClientConfig } from 'pg'
 import type { ConnectionConfig } from '@shared/index'
 
 /**
+ * Split a user-entered default schema into individual schema names.
+ *
+ * A comma-separated value sets a fallback chain, mirroring how `search_path`
+ * itself works, so `"bbl, public"` resolves unqualified names against `bbl`
+ * first and `public` second.
+ */
+export function parseSchemaList(schema: string | undefined): string[] {
+  if (!schema) return []
+  return schema
+    .split(',')
+    .map((name) => name.trim())
+    .filter(Boolean)
+}
+
+/**
+ * Build the `options` startup parameter that pins `search_path` to `schema`.
+ *
+ * Each name is double-quoted so mixed-case schemas and reserved words survive the
+ * GUC's identifier parsing. The result is then backslash-escaped because the server
+ * splits `options` on unescaped whitespace (`pg_split_opts`) and strips backslashes
+ * before the value ever reaches the GUC parser — quotes themselves pass through
+ * untouched, which is what makes the two layers compose.
+ *
+ * Returns undefined when no schema is configured, leaving the server default in place.
+ */
+export function buildSearchPathOption(schema: string | undefined): string | undefined {
+  const names = parseSchemaList(schema)
+  if (names.length === 0) return undefined
+
+  const searchPath = names.map((name) => `"${name.replace(/"/g, '""')}"`).join(',')
+  return `-c search_path=${searchPath.replace(/[\\\s]/g, '\\$&')}`
+}
+
+/**
  * Build pg ClientConfig from a ConnectionConfig.
  *
  * Handles SSL options for cloud databases (AWS RDS, Supabase, Neon, DigitalOcean) and
@@ -18,6 +52,14 @@ export function buildClientConfig(
     database: config.database,
     user: config.user,
     password: config.password
+  }
+
+  // Applied at connection startup rather than via a follow-up SET, so every physical
+  // connection a pool opens is already on the right search_path before it hands out
+  // its first client.
+  const searchPathOption = buildSearchPathOption(config.schema)
+  if (searchPathOption) {
+    clientConfig.options = searchPathOption
   }
 
   if (config.ssl) {

--- a/apps/desktop/src/main/adapters/pg-client-config.ts
+++ b/apps/desktop/src/main/adapters/pg-client-config.ts
@@ -11,10 +11,16 @@ import type { ConnectionConfig } from '@shared/index'
  */
 export function parseSchemaList(schema: string | undefined): string[] {
   if (!schema) return []
-  return schema
-    .split(',')
-    .map((name) => name.trim())
-    .filter(Boolean)
+  return (
+    schema
+      .split(',')
+      .map((name) => name.trim())
+      // `SHOW search_path` reports quoted identifiers, so a value pasted straight from psql
+      // arrives as `"bbl","public"`. Unwrap it rather than re-quoting into `"""bbl"""`.
+      .map((name) => name.replace(/^"(.*)"$/, '$1'))
+      .map((name) => name.trim())
+      .filter(Boolean)
+  )
 }
 
 /**

--- a/apps/desktop/src/main/adapters/pg-pool-manager.ts
+++ b/apps/desktop/src/main/adapters/pg-pool-manager.ts
@@ -38,12 +38,16 @@ let teardownInFlight: Promise<void> | null = null
 
 function getPoolKey(config: ConnectionConfig): string {
   if (config.id) return `pg:${config.id}`
-  // Unsaved configs (test-connect before save) hash the auth+tunnel+ssl shape so
+  // Unsaved configs (test-connect before save) hash the auth+tunnel+ssl+schema shape so
   // two attempts to the same host with different credentials/keys can't share a pool.
+  // schema is part of the fingerprint because it is baked into each connection's
+  // startup options — reusing a pool across schemas would silently keep the old
+  // search_path.
   const fingerprint = createHash('sha256')
     .update(
       JSON.stringify({
         password: config.password ?? '',
+        schema: config.schema ?? '',
         ssh: config.ssh ? (config.sshConfig ?? null) : null,
         ssl: config.ssl ? (config.sslOptions ?? null) : null
       })

--- a/apps/desktop/src/main/pg-notification-listener.ts
+++ b/apps/desktop/src/main/pg-notification-listener.ts
@@ -12,6 +12,7 @@ import type {
   PgNotificationConnectionState
 } from '@shared/index'
 import { createTunnel, closeTunnel, TunnelSession } from './ssh-tunnel-service'
+import { buildSearchPathOption } from './adapters/pg-client-config'
 import { createLogger } from './lib/logger'
 
 const log = createLogger('pg-notification-listener')
@@ -29,6 +30,11 @@ function buildClientConfig(
     database: config.database,
     user: config.user,
     password: config.password
+  }
+
+  const searchPathOption = buildSearchPathOption(config.schema)
+  if (searchPathOption) {
+    clientConfig.options = searchPathOption
   }
 
   if (config.ssl) {

--- a/apps/desktop/src/main/step-session.ts
+++ b/apps/desktop/src/main/step-session.ts
@@ -13,6 +13,7 @@ import type {
   RetryStepResponse,
   StopStepResponse
 } from '@shared/index'
+import { buildSearchPathOption } from './adapters/pg-client-config'
 import { STEP_SESSION_IDLE_TIMEOUT_MS, STEP_SESSION_CLEANUP_INTERVAL_MS } from '@shared/index'
 import { parseStatementsWithLines } from './lib/parse-statements'
 import { createLogger } from './lib/logger'
@@ -354,6 +355,7 @@ function defaultClientFactory(config: ConnectionConfig): MinimalDbClient {
     database: config.database,
     user: config.user,
     password: config.password,
+    options: buildSearchPathOption(config.schema),
     ssl: config.ssl ? { rejectUnauthorized: false } : undefined
   })
   return {

--- a/apps/desktop/src/renderer/src/components/add-connection-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/add-connection-dialog.tsx
@@ -62,6 +62,7 @@ export function AddConnectionDialog({
   const [host, setHost] = useState('localhost')
   const [port, setPort] = useState('5432')
   const [database, setDatabase] = useState('')
+  const [schema, setSchema] = useState('')
   const [user, setUser] = useState('postgres')
   const [password, setPassword] = useState('')
   const [ssl, setSsl] = useState(false)
@@ -109,6 +110,7 @@ export function AddConnectionDialog({
       setHost(editConnection.host)
       setPort(String(editConnection.port))
       setDatabase(editConnection.database)
+      setSchema(editConnection.schema || '')
       setUser(editConnection.user || '')
       setPassword(editConnection.password || '')
       setSsl(editConnection.ssl || false)
@@ -176,6 +178,10 @@ export function AddConnectionDialog({
     if (newType !== 'mssql') {
       setMssqlOptions(undefined)
     }
+    // Default schema is a PostgreSQL-only concept
+    if (newType !== 'postgresql') {
+      setSchema('')
+    }
     // SQLite doesn't support SSH/SSL, and doesn't use connection strings
     if (newType === 'sqlite') {
       setSsh(false)
@@ -203,6 +209,7 @@ export function AddConnectionDialog({
       setHost(parsed.host)
       setPort(parsed.port)
       setDatabase(parsed.database)
+      setSchema(parsed.schema || '')
       setUser(parsed.user)
       setPassword(parsed.password)
       setSsl(parsed.ssl)
@@ -234,6 +241,7 @@ export function AddConnectionDialog({
     setHost('localhost')
     setPort('5432')
     setDatabase('')
+    setSchema('')
     setUser('postgres')
     setPassword('')
     setSsl(false)
@@ -285,6 +293,7 @@ export function AddConnectionDialog({
       host,
       port: parseInt(port, 10) || 0,
       database,
+      ...(dbType === 'postgresql' && schema.trim() && { schema: schema.trim() }),
       user: isActiveDirectoryIntegrated ? undefined : user,
       password: isActiveDirectoryIntegrated ? undefined : password || undefined,
       ssl,
@@ -788,6 +797,29 @@ export function AddConnectionDialog({
                   onChange={(e) => setDatabase(e.target.value)}
                 />
               </div>
+
+              {dbType === 'postgresql' && (
+                <div className="flex flex-col gap-2">
+                  <label htmlFor="schema" className="text-sm font-medium">
+                    Default Schema
+                    <span className="text-xs text-muted-foreground font-normal ml-1">
+                      (optional)
+                    </span>
+                  </label>
+                  <Input
+                    id="schema"
+                    placeholder="public"
+                    value={schema}
+                    onChange={(e) => setSchema(e.target.value)}
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Sets <code className="font-mono">search_path</code> so unqualified table names
+                    resolve here, and focuses the sidebar on this schema. Comma-separate for a
+                    fallback chain (e.g. <code className="font-mono">bbl, public</code>). Leave
+                    empty to use the server default.
+                  </p>
+                </div>
+              )}
 
               <div className="flex flex-col gap-2">
                 <label htmlFor="user" className="text-sm font-medium">

--- a/apps/desktop/src/renderer/src/components/schema-explorer.tsx
+++ b/apps/desktop/src/renderer/src/components/schema-explorer.tsx
@@ -689,6 +689,9 @@ export function SchemaExplorer() {
   const isLoadingSchema = useConnectionStore((s) => s.isLoadingSchema)
   const schemaError = useConnectionStore((s) => s.schemaError)
   const activeConnectionId = useConnectionStore((s) => s.activeConnectionId)
+  const defaultSchema = useConnectionStore(
+    (s) => s.connections.find((c) => c.id === s.activeConnectionId)?.schema
+  )
   const getActiveConnection = useConnectionStore((s) => s.getActiveConnection)
   const fetchSchemas = useConnectionStore((s) => s.fetchSchemas)
   const schemaFromCache = useConnectionStore((s) => s.schemaFromCache)
@@ -784,6 +787,20 @@ export function SchemaExplorer() {
       setFocusedSchema(null)
     }
   }, [schemas, focusedSchema])
+
+  // Pre-focus the connection's default schema once its schema list arrives. Keyed by
+  // connection id so switching connections re-applies the default, while a manual
+  // change to the focus dropdown sticks for the rest of the connection's session.
+  const appliedDefaultFocusRef = React.useRef<string | null>(null)
+  React.useEffect(() => {
+    if (!activeConnectionId || schemas.length === 0) return
+    if (appliedDefaultFocusRef.current === activeConnectionId) return
+    appliedDefaultFocusRef.current = activeConnectionId
+
+    // search_path can list several schemas; the first one is the effective default.
+    const primary = defaultSchema?.split(',')[0]?.trim()
+    setFocusedSchema(primary && schemas.some((s) => s.name === primary) ? primary : null)
+  }, [activeConnectionId, defaultSchema, schemas])
 
   const toggleSchema = (schemaName: string) => {
     setExpandedSchemas((prev) => {

--- a/apps/desktop/src/renderer/src/lib/__tests__/connection-string-parser.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/connection-string-parser.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import { parseConnectionString } from '../connection-string-parser'
+
+describe('parseConnectionString — default schema', () => {
+  it('picks up Prisma-style ?schema=', () => {
+    const parsed = parseConnectionString(
+      'postgresql://u:p@host:5432/blocktree?schema=bbl',
+      'postgresql'
+    )
+    expect(parsed?.schema).toBe('bbl')
+    expect(parsed?.database).toBe('blocktree')
+  })
+
+  it('picks up ?search_path=, including a fallback chain', () => {
+    expect(
+      parseConnectionString('postgresql://u:p@host:5432/db?search_path=bbl,public', 'postgresql')
+        ?.schema
+    ).toBe('bbl,public')
+  })
+
+  it('picks up the libpq ?options=-c search_path= form', () => {
+    expect(
+      parseConnectionString(
+        'postgresql://u:p@host:5432/db?options=-c%20search_path%3Dbbl',
+        'postgresql'
+      )?.schema
+    ).toBe('bbl')
+  })
+
+  it('unwraps quotes and escapes from the libpq form so the field shows plain text', () => {
+    expect(
+      parseConnectionString(
+        'postgresql://u:p@host:5432/db?options=-c%20search_path%3D%22bbl%22%2C%22public%22',
+        'postgresql'
+      )?.schema
+    ).toBe('bbl,public')
+  })
+
+  it('leaves schema undefined when the URL does not specify one', () => {
+    expect(
+      parseConnectionString('postgresql://u:p@host:5432/db', 'postgresql')?.schema
+    ).toBeUndefined()
+  })
+
+  it('ignores a blank schema param rather than pinning an empty search_path', () => {
+    expect(
+      parseConnectionString('postgresql://u:p@host:5432/db?schema=', 'postgresql')?.schema
+    ).toBeUndefined()
+  })
+
+  it('ignores ?schema= for MySQL, where schema and database are the same thing', () => {
+    const parsed = parseConnectionString('mysql://u:p@host:3306/appdb?schema=other', 'mysql')
+    expect(parsed?.database).toBe('appdb')
+    expect(parsed?.schema).toBeUndefined()
+  })
+
+  it('still parses the rest of the URL alongside the schema', () => {
+    const parsed = parseConnectionString(
+      'postgresql://svc:pw@db.example.com/blocktree?schema=bbl&sslmode=no-verify',
+      'postgresql'
+    )
+    expect(parsed).toMatchObject({
+      host: 'db.example.com',
+      port: '5432',
+      database: 'blocktree',
+      user: 'svc',
+      password: 'pw',
+      ssl: true,
+      schema: 'bbl'
+    })
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/__tests__/connection-string-parser.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/connection-string-parser.test.ts
@@ -47,6 +47,26 @@ describe('parseConnectionString — default schema', () => {
     ).toBe('my schema,public')
   })
 
+  it('preserves a doubled quote as one literal quote in the schema name', () => {
+    // `"we""ird"` is the identifier we"ird. Stripping every quote in one pass would
+    // yield `weird` and point search_path at a different schema entirely.
+    expect(
+      parseConnectionString(
+        'postgresql://u:p@host:5432/db?options=-c%20search_path%3D%22we%22%22ird%22%2C%22public%22',
+        'postgresql'
+      )?.schema
+    ).toBe('we"ird,public')
+  })
+
+  it('handles a name carrying both an escaped space and a doubled quote', () => {
+    expect(
+      parseConnectionString(
+        'postgresql://u:p@host:5432/db?options=-c%20search_path%3D%22my%5C%20%22%22quoted%22%22%5C%20schema%22',
+        'postgresql'
+      )?.schema
+    ).toBe('my "quoted" schema')
+  })
+
   it('stops at the next unescaped option rather than swallowing it', () => {
     expect(
       parseConnectionString(

--- a/apps/desktop/src/renderer/src/lib/__tests__/connection-string-parser.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/connection-string-parser.test.ts
@@ -36,6 +36,26 @@ describe('parseConnectionString — default schema', () => {
     ).toBe('bbl,public')
   })
 
+  it('keeps a backslash-escaped space in the libpq form instead of truncating at it', () => {
+    // The server splits `options` on unescaped whitespace only, so `\ ` is part of the
+    // value. A naive \S+ would capture just `"my\` and silently drop `,"public"`.
+    expect(
+      parseConnectionString(
+        'postgresql://u:p@host:5432/db?options=-c%20search_path%3D%22my%5C%20schema%22%2C%22public%22',
+        'postgresql'
+      )?.schema
+    ).toBe('my schema,public')
+  })
+
+  it('stops at the next unescaped option rather than swallowing it', () => {
+    expect(
+      parseConnectionString(
+        'postgresql://u:p@host:5432/db?options=-c%20search_path%3Dbbl%20-c%20statement_timeout%3D5s',
+        'postgresql'
+      )?.schema
+    ).toBe('bbl')
+  })
+
   it('leaves schema undefined when the URL does not specify one', () => {
     expect(
       parseConnectionString('postgresql://u:p@host:5432/db', 'postgresql')?.schema

--- a/apps/desktop/src/renderer/src/lib/connection-string-parser.ts
+++ b/apps/desktop/src/renderer/src/lib/connection-string-parser.ts
@@ -39,7 +39,10 @@ function parseSchemaParam(url: URL): string | undefined {
   if (direct?.trim()) return direct.trim()
 
   const options = url.searchParams.get('options')
-  const fromOptions = options?.match(/-c\s+search_path=(\S+)/)?.[1]
+  // `\\.` before `\S` so a backslash-escaped space stays part of the value — the server
+  // splits `options` on *unescaped* whitespace only, and `\S+` alone would truncate
+  // `search_path="my\ schema","public"` to `"my\`.
+  const fromOptions = options?.match(/-c\s+search_path=((?:\\.|\S)+)/)?.[1]
   if (!fromOptions) return undefined
 
   const unescaped = fromOptions.replace(/\\(.)/g, '$1').replace(/"/g, '')

--- a/apps/desktop/src/renderer/src/lib/connection-string-parser.ts
+++ b/apps/desktop/src/renderer/src/lib/connection-string-parser.ts
@@ -21,7 +21,29 @@ export interface ParsedConnectionConfig {
   user: string
   password: string
   ssl: boolean
+  /** Default schema, from `?schema=`/`?search_path=`/`?options=-c search_path=` (PostgreSQL) */
+  schema?: string
   mssqlOptions?: MSSQLConnectionOptions
+}
+
+/**
+ * Pull the default schema out of a PostgreSQL URL's query string.
+ *
+ * Three spellings are in the wild: `?schema=` (Prisma), `?search_path=` (SQLAlchemy,
+ * JDBC-style tooling) and `?options=-c search_path=...` (libpq passthrough). Quotes
+ * and backslash escapes are stripped from the libpq form so the value round-trips
+ * back into the plain text the schema field expects.
+ */
+function parseSchemaParam(url: URL): string | undefined {
+  const direct = url.searchParams.get('schema') || url.searchParams.get('search_path')
+  if (direct?.trim()) return direct.trim()
+
+  const options = url.searchParams.get('options')
+  const fromOptions = options?.match(/-c\s+search_path=(\S+)/)?.[1]
+  if (!fromOptions) return undefined
+
+  const unescaped = fromOptions.replace(/\\(.)/g, '$1').replace(/"/g, '')
+  return unescaped.trim() || undefined
 }
 
 /**
@@ -218,7 +240,11 @@ export function parseConnectionString(
     const sslParam = url.searchParams.get('sslmode') || url.searchParams.get('ssl')
     const ssl = sslParam ? !['disable', 'false', '0'].includes(sslParam.toLowerCase()) : false
 
-    return { host, port, database, user, password, ssl }
+    // MySQL has no schema-vs-database distinction and SQLite has no schemas at all,
+    // so the default schema is only meaningful for PostgreSQL.
+    const schema = dbType === 'postgresql' ? parseSchemaParam(url) : undefined
+
+    return { host, port, database, user, password, ssl, schema }
   } catch {
     return null
   }

--- a/apps/desktop/src/renderer/src/lib/connection-string-parser.ts
+++ b/apps/desktop/src/renderer/src/lib/connection-string-parser.ts
@@ -45,7 +45,18 @@ function parseSchemaParam(url: URL): string | undefined {
   const fromOptions = options?.match(/-c\s+search_path=((?:\\.|\S)+)/)?.[1]
   if (!fromOptions) return undefined
 
-  const unescaped = fromOptions.replace(/\\(.)/g, '$1').replace(/"/g, '')
+  // Two quote levels to undo: `""` is one literal quote inside an identifier, while a
+  // lone `"` is the identifier delimiter. Park the doubled pairs on NUL — which cannot
+  // occur in a Postgres identifier or survive a URL — so stripping the delimiters can't
+  // eat them, then restore. Stripping all quotes in one pass would turn `we""ird` into
+  // `weird` and silently point search_path at a different schema.
+  const NUL = '\u0000'
+  const unescaped = fromOptions
+    .replace(/\\(.)/g, '$1')
+    .replace(/""/g, NUL)
+    .replace(/"/g, '')
+    .split(NUL)
+    .join('"')
   return unescaped.trim() || undefined
 }
 

--- a/apps/desktop/src/renderer/src/stores/connection-store.ts
+++ b/apps/desktop/src/renderer/src/stores/connection-store.ts
@@ -30,6 +30,8 @@ export interface Connection {
   host: string
   port: number
   database: string
+  /** Default schema (PostgreSQL only) — pins search_path and pre-focuses the explorer */
+  schema?: string
   user?: string // Optional for MSSQL with Azure AD authentication
   password?: string
   ssl?: boolean

--- a/docs/features.md
+++ b/docs/features.md
@@ -70,7 +70,8 @@ For power users and teams:
 | Feature | Description |
 |---------|-------------|
 | **Quick Connection Setup** | Add connections with host, port, database, user, and password — or paste a connection string |
-| **Connection String Parsing** | Paste any PostgreSQL connection URL and auto-fill all fields |
+| **Connection String Parsing** | Paste any PostgreSQL connection URL and auto-fill all fields, including `?schema=` |
+| **Default Schema** | Pin a PostgreSQL connection's `search_path` so unqualified table names resolve there, and pre-focus the sidebar on that schema. Comma-separate for a fallback chain (`bbl, public`) |
 | **Test Before Save** | Verify connections work before adding them |
 | **Encrypted Storage** | Credentials stored securely with encryption |
 | **SSL Support** | Connect to SSL-enabled databases |

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -665,6 +665,13 @@ export interface ConnectionConfig {
   host: string;
   port: number;
   database: string;
+  /**
+   * Default schema (PostgreSQL only). Pins `search_path` for every connection
+   * in the pool and pre-focuses the schema explorer. Accepts a comma-separated
+   * list to set a fallback chain (e.g. `"bbl, public"`). Empty/absent leaves the
+   * server default (`"$user", public`) untouched.
+   */
+  schema?: string;
   user?: string; // Optional for MSSQL with Azure AD authentication
   password?: string;
   ssl?: boolean;


### PR DESCRIPTION
## Problem

You couldn't pin a schema on a connection. Pasting a URL like:

```
postgresql://user:pw@host/blocktree?schema=bbl&sslmode=no-verify
```

parsed `?schema=bbl` via `new URL()` and then dropped it on the floor — no field to set it manually, no warning that the parameter was ignored. Connections always landed on the server default `search_path`, and the sidebar always opened on all schemas.

## What this adds

An optional **Default Schema** field on PostgreSQL connections:

1. **Pins `search_path`** via the libpq `options` startup parameter rather than a follow-up `SET`, so the path is in place on every physical connection a pool opens — no window where the first query runs unpinned.
2. **Pre-focuses the schema explorer**, reusing the existing focus dropdown. Keyed by connection id, so switching connections re-applies the default while a manual focus change sticks.
3. **Parses `?schema=` from pasted URLs** — plus `?search_path=` and the libpq `?options=-c search_path=` form.

Comma-separate for a fallback chain (`bbl, public`). Empty leaves the server default untouched.

## Escaping

The fiddly part. Two parsers stack: the server splits `options` on unescaped whitespace (`pg_split_opts` — backslash escapes only, quotes pass straight through), then parses the result as a `search_path` quoted identifier list. So `buildSearchPathOption` double-quotes each name, then backslash-escapes whitespace and backslashes.

Confirmed against a live PG 18 that `-c search_path="we\ ird","public"` arrives as `"we ird","public"`.

## Verified end-to-end

Against a live PostgreSQL 18 instance, through `node-postgres`:

```
schema=undefined         → search_path="$user", public       unqualified lookup: ERR relation does not exist
schema=blocktree         → search_path="blocktree"           unqualified lookup: 3
schema=blocktree, public → search_path="blocktree","public"  unqualified lookup: 3
```

## Notes

- `schema` joins the unsaved-config pool fingerprint in `pg-pool-manager.ts`. It's baked into the startup options, so without this a test-connect against a second schema would silently reuse the first pool's `search_path`.
- `pg-notification-listener.ts` and `step-session.ts` build pg clients independently of `buildClientConfig`; both now route through the same helper.
- PostgreSQL only. MySQL has no schema/database distinction, SQLite has no schemas, and MSSQL's default schema is a per-user server-side property rather than a connection parameter — the field is hidden and the URL param ignored for those.
- The schema cache key is deliberately unchanged: `getSchemas` enumerates all visible schemas regardless of `search_path`.

## Tests

- `pg-client-config.test.ts` (new, 13 cases) — schema list parsing, quoting, whitespace/backslash/quote escaping, SSH-tunnel passthrough
- `connection-string-parser.test.ts` (new, 8 cases) — all three URL spellings, blank params, MySQL exclusion
- `pg-pool-manager.test.ts` (+2) — options passthrough, and that two unsaved configs differing only by schema don't share a pool

Full suite: 1180 passed, typecheck clean.

## Not covered

The sidebar pre-focus is verified by code review only — I didn't start the dev server. Worth a click-through before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional PostgreSQL default-schema configuration for connections.
  * Added schema input support when creating or editing PostgreSQL connections.
  * Supports comma-separated schema fallback paths and PostgreSQL connection URLs with schema settings.
  * Automatically focuses the configured schema in the schema explorer when a connection opens.
* **Documentation**
  * Documented PostgreSQL default-schema and search-path configuration support.
* **Tests**
  * Added coverage for schema parsing, connection options, pool separation, and schema explorer behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->