### PR TITLE
fix(desktop): re-land schema focus fixes lost by a stacked-PR base deletion

### DIFF
--- a/apps/desktop/src/renderer/src/components/add-connection-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/add-connection-dialog.tsx
@@ -749,6 +749,12 @@ export function AddConnectionDialog({
                     <span className="font-mono">{port}</span>
                     <span>Database:</span>
                     <span className="font-mono">{database}</span>
+                    {dbType === 'postgresql' && schema && (
+                      <>
+                        <span>Default schema:</span>
+                        <span className="font-mono">{schema}</span>
+                      </>
+                    )}
                     <span>User:</span>
                     <span className="font-mono">{user}</span>
                     <span>Password:</span>

--- a/apps/desktop/src/renderer/src/components/schema-explorer.tsx
+++ b/apps/desktop/src/renderer/src/components/schema-explorer.tsx
@@ -793,13 +793,26 @@ export function SchemaExplorer() {
   // change to the focus dropdown sticks for the rest of the connection's session.
   const appliedDefaultFocusRef = React.useRef<string | null>(null)
   React.useEffect(() => {
-    if (!activeConnectionId || schemas.length === 0) return
+    // Clear the marker when no connection is active so reselecting the same
+    // connection re-applies the default focus.
+    if (!activeConnectionId) {
+      appliedDefaultFocusRef.current = null
+      return
+    }
+    if (schemas.length === 0) return
     if (appliedDefaultFocusRef.current === activeConnectionId) return
-    appliedDefaultFocusRef.current = activeConnectionId
 
     // search_path can list several schemas; the first one is the effective default.
     const primary = defaultSchema?.split(',')[0]?.trim()
-    setFocusedSchema(primary && schemas.some((s) => s.name === primary) ? primary : null)
+    const found = !!primary && schemas.some((s) => s.name === primary)
+
+    // If a default schema is configured but not yet present (e.g. the schema list
+    // came from a stale cache), hold off marking the connection as applied so the
+    // effect retries when the background refresh delivers the full list.
+    if (primary && !found) return
+
+    appliedDefaultFocusRef.current = activeConnectionId
+    setFocusedSchema(found ? primary : null)
   }, [activeConnectionId, defaultSchema, schemas])
 
   const toggleSchema = (schemaName: string) => {


### PR DESCRIPTION
Re-lands #247, which GitHub reports as **MERGED** but which landed nowhere.

## What happened

#247's base was `feat/postgres-default-schema`, not `main`. I deleted that branch when merging #246, so the squash went onto a dead ref:

```
base=feat/postgres-default-schema  state=MERGED  mergeCommit=51f0857
```

`main` never received the change. Verified directly — the reselect fix was absent from `origin/main` after #247 closed as merged.

My mistake: `--delete-branch` on a PR that was the base of an open stacked PR. Recovered the content from the orphaned merge commit; nothing was lost, but it would have been once that commit was GC'd.

## The change itself

Unmodified from #247, authored by @tembo. Both fixes address real defects in the pre-focus effect added in #246:

**`schema-explorer.tsx`** — two holes in the default-schema pre-focus effect:

- It returned early when `activeConnectionId` was `null` without clearing `appliedDefaultFocusRef`. Reselecting the same connection then hit the already-applied guard and skipped the default focus entirely.
- It marked a connection applied even when the configured schema was absent from the list. A schema list served from a stale cache therefore suppressed the focus permanently — when the background refresh delivered the full list, the guard blocked re-application.

**`add-connection-dialog.tsx`** — the parsed-values panel omitted the schema, so pasting `?schema=bbl` gave no visible confirmation the parameter was picked up.

## Verification

The original PR never ran the main CI job — it had 6 checks where mine had 10, and `typecheck · test · lint` and Playwright were not among them. `mergeStateStatus=CLEAN` meant "nothing failing", not "verified". So I ran it locally on top of current `main`:

- `pnpm typecheck` — clean
- `vitest run` — 1202 passed, 56 skipped
- lint — no new errors in either touched file

Net diff against `main` is exactly the intended +22/-3.

## Still outstanding

The pre-focus effect has no test coverage. This is the second change to it without one, and it remains the only part of the default-schema feature with neither a test nor a runtime check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PostgreSQL connection previews now show the configured default schema when available.

* **Bug Fixes**
  * Improved schema navigation so the configured default schema is focused once schemas are loaded.
  * Default-schema focus can retry when schema data is incomplete or refreshed.
  * Prevented stale connection state from blocking default-schema focus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->