### PR TITLE
fix(desktop): key Postgres pools by connection shape, not just id

### DIFF
--- a/apps/desktop/src/main/__tests__/pg-client-config.test.ts
+++ b/apps/desktop/src/main/__tests__/pg-client-config.test.ts
@@ -1,10 +1,16 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { readFileSync } from 'fs'
 import type { ConnectionConfig } from '@shared/index'
 import {
   buildClientConfig,
   buildSearchPathOption,
   parseSchemaList
 } from '../adapters/pg-client-config'
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>()
+  return { ...actual, readFileSync: vi.fn() }
+})
 
 function makeConfig(overrides: Partial<ConnectionConfig> = {}): ConnectionConfig {
   return {
@@ -94,5 +100,66 @@ describe('buildClientConfig', () => {
     expect(config.host).toBe('127.0.0.1')
     expect(config.port).toBe(54320)
     expect(config.options).toBe('-c search_path="bbl"')
+  })
+})
+
+describe('buildClientConfig SSL', () => {
+  beforeEach(() => {
+    vi.mocked(readFileSync).mockReset()
+  })
+
+  it('leaves ssl unset when the connection does not use it', () => {
+    expect(buildClientConfig(makeConfig()).ssl).toBeUndefined()
+    expect(buildClientConfig(makeConfig({ ssl: false })).ssl).toBeUndefined()
+  })
+
+  it('asks pg to initiate TLS whenever "Use SSL" is on', () => {
+    // A truthy ssl object is what makes pg send the SSLRequest — the equivalent of
+    // sslmode=require. Without it the server answers "no pg_hba.conf entry ... no
+    // encryption" (issue #252).
+    expect(buildClientConfig(makeConfig({ ssl: true })).ssl).toEqual({
+      rejectUnauthorized: false
+    })
+    expect(buildClientConfig(makeConfig({ ssl: true, sslOptions: {} })).ssl).toEqual({
+      rejectUnauthorized: false
+    })
+  })
+
+  it('only verifies the server certificate when strict mode is opted into', () => {
+    expect(
+      buildClientConfig(makeConfig({ ssl: true, sslOptions: { rejectUnauthorized: true } })).ssl
+    ).toEqual({ rejectUnauthorized: true })
+    expect(
+      buildClientConfig(makeConfig({ ssl: true, sslOptions: { rejectUnauthorized: false } })).ssl
+    ).toEqual({ rejectUnauthorized: false })
+  })
+
+  it('pins a supplied CA and verifies against it by default', () => {
+    vi.mocked(readFileSync).mockReturnValue('---CA---')
+
+    const config = buildClientConfig(makeConfig({ ssl: true, sslOptions: { ca: '/tmp/ca.pem' } }))
+
+    expect(readFileSync).toHaveBeenCalledWith('/tmp/ca.pem', 'utf-8')
+    expect(config.ssl).toEqual({ rejectUnauthorized: true, ca: '---CA---' })
+  })
+
+  it('keeps a pinned CA while honouring an explicit opt-out of verification', () => {
+    vi.mocked(readFileSync).mockReturnValue('---CA---')
+
+    const config = buildClientConfig(
+      makeConfig({ ssl: true, sslOptions: { ca: '/tmp/ca.pem', rejectUnauthorized: false } })
+    )
+
+    expect(config.ssl).toEqual({ rejectUnauthorized: false, ca: '---CA---' })
+  })
+
+  it('fails loudly rather than silently dropping TLS when the CA file is unreadable', () => {
+    vi.mocked(readFileSync).mockImplementation(() => {
+      throw new Error('ENOENT')
+    })
+
+    expect(() =>
+      buildClientConfig(makeConfig({ ssl: true, sslOptions: { ca: '/nope.pem' } }))
+    ).toThrow('Failed to read CA certificate file: /nope.pem')
   })
 })

--- a/apps/desktop/src/main/__tests__/pg-pool-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/pg-pool-manager.test.ts
@@ -21,7 +21,19 @@ vi.mock('../lib/logger', () => ({
   createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
 }))
 
-import { withPgClient, withPgTransaction, closeAllPgPools } from '../adapters/pg-pool-manager'
+import {
+  withPgClient,
+  withPgTransaction,
+  closeAllPgPools,
+  closePgPool
+} from '../adapters/pg-pool-manager'
+
+// Each `new Pool()` hands back its own object (delegating to the shared spies) so a test
+// can tell which specific pool was ended when a connection's shape changes.
+interface FakePool {
+  end: ReturnType<typeof vi.fn>
+}
+const createdPools: FakePool[] = []
 
 let counter = 0
 function makeConfig(overrides: Partial<ConnectionConfig> = {}): ConnectionConfig {
@@ -46,8 +58,15 @@ beforeEach(() => {
   mockPool.connect.mockReset().mockResolvedValue(mockClient)
   mockPool.end.mockReset().mockResolvedValue(undefined)
   mockPool.on.mockReset()
+  createdPools.length = 0
   PoolCtor.mockImplementation(function (this: unknown) {
-    return mockPool
+    const instance = {
+      connect: (...args: unknown[]) => mockPool.connect(...args),
+      end: vi.fn((...args: unknown[]) => mockPool.end(...args)),
+      on: (...args: unknown[]) => mockPool.on(...args)
+    }
+    createdPools.push(instance)
+    return instance
   })
 })
 
@@ -98,6 +117,63 @@ describe('withPgClient', () => {
     expect(PoolCtor).toHaveBeenCalledTimes(2)
   })
 
+  it('does not reuse a saved connection pool after its SSL settings change', async () => {
+    // Saved connections have a stable id, so keying on id alone served the pre-edit
+    // pool back to a config that had just turned TLS on (issue #252).
+    const saved = makeConfig()
+
+    await withPgClient(saved, async () => {})
+    await withPgClient(
+      { ...saved, ssl: true, sslOptions: { rejectUnauthorized: false } },
+      async () => {}
+    )
+
+    expect(PoolCtor).toHaveBeenCalledTimes(2)
+    expect(PoolCtor.mock.calls[0][0]).not.toHaveProperty('ssl')
+    expect(PoolCtor.mock.calls[1][0]).toMatchObject({ ssl: { rejectUnauthorized: false } })
+  })
+
+  it('re-dials with TLS after the plaintext attempt was rejected (issue #252)', async () => {
+    const saved = makeConfig()
+    // new Pool() never dials, so a rejected handshake still leaves an entry cached —
+    // the retry has to be given a different pool, not the one that just failed.
+    mockPool.connect.mockRejectedValueOnce(
+      new Error(
+        'no pg_hba.conf entry for host "203.0.113.7", user "u", database "db", no encryption'
+      )
+    )
+
+    await expect(withPgClient(saved, async () => {})).rejects.toThrow('no encryption')
+    await withPgClient(
+      { ...saved, ssl: true, sslOptions: { rejectUnauthorized: false } },
+      async () => {}
+    )
+
+    expect(PoolCtor).toHaveBeenCalledTimes(2)
+    expect(PoolCtor.mock.calls[1][0]).toMatchObject({ ssl: { rejectUnauthorized: false } })
+  })
+
+  it('does not reuse a saved connection pool after host or credentials change', async () => {
+    const saved = makeConfig()
+
+    await withPgClient(saved, async () => {})
+    await withPgClient({ ...saved, host: 'db.example.com' }, async () => {})
+    await withPgClient({ ...saved, host: 'db.example.com', password: 'rotated' }, async () => {})
+
+    expect(PoolCtor).toHaveBeenCalledTimes(3)
+  })
+
+  it('retires the superseded pool so one connection keeps one live pool', async () => {
+    const saved = makeConfig()
+
+    await withPgClient(saved, async () => {})
+    await withPgClient({ ...saved, ssl: true }, async () => {})
+
+    expect(createdPools).toHaveLength(2)
+    expect(createdPools[0].end).toHaveBeenCalledTimes(1)
+    expect(createdPools[1].end).not.toHaveBeenCalled()
+  })
+
   it('survives double-release without throwing', async () => {
     mockClient.release.mockImplementationOnce(() => {
       throw new Error('Release called on client which has already been released')
@@ -146,6 +222,22 @@ describe('withPgTransaction', () => {
     ).rejects.toBe(original)
 
     expect(mockClient.release).toHaveBeenCalledWith(true)
+  })
+})
+
+describe('closePgPool', () => {
+  it('closes the live pool even when handed the pre-edit config', async () => {
+    // connections:update tears down using the *previous* stored config, while a Test
+    // Connection during that edit may already have built a pool from the new shape.
+    const saved = makeConfig()
+    const edited = { ...saved, ssl: true, sslOptions: { rejectUnauthorized: false } }
+    await withPgClient(edited, async () => {})
+
+    await closePgPool(saved)
+
+    expect(createdPools[0].end).toHaveBeenCalledTimes(1)
+    await withPgClient(edited, async () => {})
+    expect(PoolCtor).toHaveBeenCalledTimes(2)
   })
 })
 

--- a/apps/desktop/src/main/__tests__/pg-pool-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/pg-pool-manager.test.ts
@@ -21,6 +21,7 @@ vi.mock('../lib/logger', () => ({
   createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
 }))
 
+import { createTunnel, closeTunnel, type TunnelSession } from '../ssh-tunnel-service'
 import {
   withPgClient,
   withPgTransaction,
@@ -58,6 +59,8 @@ beforeEach(() => {
   mockPool.connect.mockReset().mockResolvedValue(mockClient)
   mockPool.end.mockReset().mockResolvedValue(undefined)
   mockPool.on.mockReset()
+  vi.mocked(createTunnel).mockReset()
+  vi.mocked(closeTunnel).mockReset()
   createdPools.length = 0
   PoolCtor.mockImplementation(function (this: unknown) {
     const instance = {
@@ -172,6 +175,48 @@ describe('withPgClient', () => {
     expect(createdPools).toHaveLength(2)
     expect(createdPools[0].end).toHaveBeenCalledTimes(1)
     expect(createdPools[1].end).not.toHaveBeenCalled()
+  })
+
+  it('disposes a creation that was superseded while it was still dialing', async () => {
+    // evictOtherShapes only sees installed pools, so a slow dial could otherwise install
+    // a second live pool *and* tunnel under one identity after the newer shape landed.
+    // Tunnel setup makes that window wide, so it is the one reproduced here.
+    const saved = makeConfig({
+      ssh: true,
+      sshConfig: {
+        host: 'bastion',
+        port: 22,
+        user: 'x',
+        authMethod: 'Password',
+        privateKeyPath: ''
+      }
+    })
+    const tunnel: TunnelSession = {
+      ssh: null,
+      server: null,
+      localHost: '127.0.0.1',
+      localPort: 54320
+    }
+    let finishDial: (t: TunnelSession) => void = () => {}
+    vi.mocked(createTunnel).mockReturnValueOnce(
+      new Promise<TunnelSession>((resolve) => {
+        finishDial = resolve
+      })
+    )
+
+    const superseded = withPgClient(saved, async () => {})
+    // A newer shape for the same connection is acquired and installed meanwhile.
+    await withPgClient({ ...saved, ssl: true }, async () => {})
+
+    finishDial(tunnel)
+    await expect(superseded).rejects.toThrow('Pool was closed before initialization completed')
+
+    // createdPools[0] is the newer shape: the superseded dial had not reached new Pool()
+    // yet. It must be the one torn down, tunnel included.
+    expect(createdPools).toHaveLength(2)
+    expect(createdPools[0].end).not.toHaveBeenCalled()
+    expect(createdPools[1].end).toHaveBeenCalledTimes(1)
+    expect(closeTunnel).toHaveBeenCalledWith(tunnel)
   })
 
   it('survives double-release without throwing', async () => {

--- a/apps/desktop/src/main/adapters/pg-pool-manager.ts
+++ b/apps/desktop/src/main/adapters/pg-pool-manager.ts
@@ -36,6 +36,9 @@ const POOL_END_TIMEOUT_MS = 2_500
 const pools = new Map<string, PoolEntry>()
 // Tracks in-flight pool creation so concurrent first-use callers share one tunnel/pool.
 const pendingPools = new Map<string, Promise<PoolEntry>>()
+// identity -> most recently requested pool key, so a slow creation can detect that the
+// connection's shape moved on while it was dialing. Entries are dropped on teardown.
+const latestShape = new Map<string, string>()
 
 let shuttingDown = false
 let teardownInFlight: Promise<void> | null = null
@@ -142,6 +145,12 @@ async function createPoolEntry(config: ConnectionConfig, key: string): Promise<P
  * app shutdown. `pool.end()` drains its own checked-out clients, so a query still
  * running on the outgoing pool finishes; we don't wait for it because the caller is
  * waiting on a different pool entirely.
+ *
+ * Two shapes of one connection being used *concurrently* — a Test Connection on an
+ * edited config while the saved one is being queried — therefore retire each other in
+ * turn. That is accepted: both callers still talk to a pool matching their own config,
+ * and a Test Connection is one `SELECT 1`, so the churn is a pool rebuild or two rather
+ * than a sustained thrash.
  */
 function evictOtherShapes(identity: string, keepKey: string): void {
   for (const [key, entry] of pools) {
@@ -160,7 +169,13 @@ export async function getOrCreatePool(config: ConnectionConfig): Promise<PoolEnt
     throw new Error('Pool manager is shutting down')
   }
   const key = getPoolKey(config)
-  evictOtherShapes(identityOf(key), key)
+  const identity = identityOf(key)
+  // Recorded before dialing so a creation that is still in flight can tell it has been
+  // superseded: evictOtherShapes only sees installed pools, so without this a slow dial
+  // (SSH tunnel setup widens the window considerably) would install a second live pool
+  // and tunnel under one identity after a newer shape had already been installed.
+  latestShape.set(identity, key)
+  evictOtherShapes(identity, key)
 
   const existing = pools.get(key)
   if (existing) return existing
@@ -170,8 +185,9 @@ export async function getOrCreatePool(config: ConnectionConfig): Promise<PoolEnt
 
   const promise = createPoolEntry(config, key)
     .then((entry) => {
-      // Don't install the entry if a closePgPool/shutdown raced and decided to drop it.
-      if (shuttingDown || pendingPools.get(key) !== promise) {
+      // Don't install the entry if a closePgPool/shutdown raced and decided to drop it,
+      // or if a newer shape for this connection was acquired while we were dialing.
+      if (shuttingDown || pendingPools.get(key) !== promise || latestShape.get(identity) !== key) {
         entry.pool.end().catch(() => {})
         closeTunnel(entry.tunnel)
         throw new Error('Pool was closed before initialization completed')
@@ -271,6 +287,9 @@ export async function closePgPool(config: ConnectionConfig): Promise<void> {
   // the caller passes the *pre-edit* config, while a Test Connection during that edit
   // may already have built a pool from the new shape.
   const identity = getPoolIdentity(config)
+  // Also makes any in-flight creation for this connection self-dispose instead of
+  // installing itself after we have finished tearing down.
+  latestShape.delete(identity)
 
   for (const [key, promise] of pendingPools) {
     if (identityOf(key) !== identity) continue
@@ -339,6 +358,7 @@ export async function closeAllPgPools(): Promise<void> {
       await Promise.allSettled(Array.from(pendingPools.values()))
       const entries = Array.from(pools.values())
       pools.clear()
+      latestShape.clear()
       await Promise.all(
         entries.map(async (entry) => {
           try {

--- a/apps/desktop/src/main/adapters/pg-pool-manager.ts
+++ b/apps/desktop/src/main/adapters/pg-pool-manager.ts
@@ -13,6 +13,10 @@ const log = createLogger('pg-pool')
  * Each saved connection gets one pg.Pool plus (optionally) one SSH tunnel that
  * the pool's clients share. Pools are created lazily on first use and torn
  * down via `closePgPool` when the connection is edited/deleted.
+ *
+ * A pool is keyed by *both* the connection it belongs to and the shape it was built
+ * from, so a config that has been edited — new credentials, TLS settings, schema,
+ * tunnel — always gets a fresh socket rather than a pool that predates the change.
  */
 
 interface PoolEntry {
@@ -36,25 +40,52 @@ const pendingPools = new Map<string, Promise<PoolEntry>>()
 let shuttingDown = false
 let teardownInFlight: Promise<void> | null = null
 
-function getPoolKey(config: ConnectionConfig): string {
-  if (config.id) return `pg:${config.id}`
-  // Unsaved configs (test-connect before save) hash the auth+tunnel+ssl+schema shape so
-  // two attempts to the same host with different credentials/keys can't share a pool.
-  // schema is part of the fingerprint because it is baked into each connection's
-  // startup options — reusing a pool across schemas would silently keep the old
-  // search_path.
-  const fingerprint = createHash('sha256')
+/**
+ * Hash the fields that decide what a physical connection *is*.
+ *
+ * Everything here is baked into the socket at startup — the TLS handshake, the
+ * credentials, the `search_path` startup option, the tunnel it rides through — so a
+ * pool built from one shape can never be handed to a caller asking for another. That
+ * used to be exactly what happened when a *saved* connection was edited: pools keyed
+ * on `config.id` alone meant ticking "Use SSL" and hitting Test Connection reused the
+ * cached plaintext pool, and the server kept answering `no pg_hba.conf entry for host
+ * ... no encryption` with the box checked (issue #252).
+ */
+function getShapeFingerprint(config: ConnectionConfig): string {
+  return createHash('sha256')
     .update(
       JSON.stringify({
+        host: config.host,
+        port: config.port,
+        database: config.database,
+        user: config.user ?? '',
         password: config.password ?? '',
         schema: config.schema ?? '',
-        ssh: config.ssh ? (config.sshConfig ?? null) : null,
-        ssl: config.ssl ? (config.sslOptions ?? null) : null
+        ssl: config.ssl ? (config.sslOptions ?? {}) : false,
+        ssh: config.ssh ? (config.sshConfig ?? null) : null
       })
     )
     .digest('hex')
     .slice(0, 16)
-  return `pg:${config.host}:${config.port}:${config.database}:${config.user ?? 'default'}:${fingerprint}`
+}
+
+/**
+ * Which connection a pool belongs to, independent of its current shape: the saved
+ * connection's id, or the target itself for an ad-hoc config that was never saved.
+ * Shape variants under one identity are collapsed to a single live pool.
+ */
+function getPoolIdentity(config: ConnectionConfig): string {
+  if (config.id) return `pg:id:${config.id}`
+  return `pg:adhoc:${config.host}:${config.port}:${config.database}:${config.user ?? 'default'}`
+}
+
+function getPoolKey(config: ConnectionConfig): string {
+  return `${getPoolIdentity(config)}#${getShapeFingerprint(config)}`
+}
+
+/** Recover the identity half of a pool key. Fingerprints never contain `#`. */
+function identityOf(key: string): string {
+  return key.slice(0, key.lastIndexOf('#'))
 }
 
 async function createPoolEntry(config: ConnectionConfig, key: string): Promise<PoolEntry> {
@@ -103,11 +134,34 @@ async function createPoolEntry(config: ConnectionConfig, key: string): Promise<P
   }
 }
 
+/**
+ * Retire pools that share `identity` but were built from a different shape.
+ *
+ * Runs on every acquisition, which is what keeps a connection down to one live pool
+ * as its shape changes — otherwise each edited-and-tested variant would linger until
+ * app shutdown. `pool.end()` drains its own checked-out clients, so a query still
+ * running on the outgoing pool finishes; we don't wait for it because the caller is
+ * waiting on a different pool entirely.
+ */
+function evictOtherShapes(identity: string, keepKey: string): void {
+  for (const [key, entry] of pools) {
+    if (key === keepKey || identityOf(key) !== identity) continue
+    pools.delete(key)
+    log.debug('retiring pool built from a superseded connection shape')
+    entry.pool.end().catch((err) => {
+      log.warn('error ending superseded pool:', (err as Error).message)
+    })
+    closeTunnel(entry.tunnel)
+  }
+}
+
 export async function getOrCreatePool(config: ConnectionConfig): Promise<PoolEntry> {
   if (shuttingDown) {
     throw new Error('Pool manager is shutting down')
   }
   const key = getPoolKey(config)
+  evictOtherShapes(identityOf(key), key)
+
   const existing = pools.get(key)
   if (existing) return existing
 
@@ -213,21 +267,31 @@ function evictPoolEntry(key: string): PoolEntry | undefined {
  * appears after this returns.
  */
 export async function closePgPool(config: ConnectionConfig): Promise<void> {
-  const key = getPoolKey(config)
-  const inflight = pendingPools.get(key)
-  if (inflight) {
+  // Every shape variant goes, not just the one matching the config we were handed:
+  // the caller passes the *pre-edit* config, while a Test Connection during that edit
+  // may already have built a pool from the new shape.
+  const identity = getPoolIdentity(config)
+
+  for (const [key, promise] of pendingPools) {
+    if (identityOf(key) !== identity) continue
     pendingPools.delete(key)
     // The .then in getOrCreatePool checks pendingPools identity and self-disposes.
-    await inflight.catch(() => {})
+    await promise.catch(() => {})
   }
-  const entry = evictPoolEntry(key)
-  if (!entry) return
-  try {
-    await entry.pool.end()
-  } catch (err) {
-    log.warn('error ending pool:', (err as Error).message)
+
+  const entries = Array.from(pools.keys())
+    .filter((key) => identityOf(key) === identity)
+    .map((key) => evictPoolEntry(key))
+
+  for (const entry of entries) {
+    if (!entry) continue
+    try {
+      await entry.pool.end()
+    } catch (err) {
+      log.warn('error ending pool:', (err as Error).message)
+    }
+    closeTunnel(entry.tunnel)
   }
-  closeTunnel(entry.tunnel)
 }
 
 /**

--- a/apps/desktop/src/renderer/src/components/add-connection-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/add-connection-dialog.tsx
@@ -1034,6 +1034,9 @@ export function AddConnectionDialog({
           {testResult && (
             <div
               ref={testResultRef}
+              data-testid="connection-dialog-test-result"
+              // A failure is worth interrupting a screen reader for; a success is not.
+              role={testResult === 'success' ? 'status' : 'alert'}
               className={`flex items-center gap-2 rounded-md p-3 text-sm ${
                 testResult === 'success'
                   ? 'bg-green-500/10 text-green-500'

--- a/apps/desktop/src/renderer/src/components/add-connection-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/add-connection-dialog.tsx
@@ -53,6 +53,14 @@ export function AddConnectionDialog({
   const setConnectionStatus = useConnectionStore((s) => s.setConnectionStatus)
   const isEditMode = !!editConnection
 
+  // One id per dialog session rather than one per getConnectionConfig() call. The main
+  // process pools by connection id, so minting a fresh id on every Test Connection click
+  // left an orphaned pool behind each time.
+  const draftIdRef = useRef(crypto.randomUUID())
+  useEffect(() => {
+    if (open && !editConnection) draftIdRef.current = crypto.randomUUID()
+  }, [open, editConnection])
+
   const [dbType, setDbType] = useState<DatabaseType>('postgresql')
   const [inputMode, setInputMode] = useState<InputMode>('manual')
   const [connectionString, setConnectionString] = useState('')
@@ -245,7 +253,9 @@ export function AddConnectionDialog({
     setUser('postgres')
     setPassword('')
     setSsl(false)
-    setSslOptions({ rejectUnauthorized: true })
+    // Matches the initial state and the edit-mode fallback: strict verification is
+    // opt-in, because most managed Postgres serves a private-CA cert that fails it.
+    setSslOptions({ rejectUnauthorized: false })
     setSsh(false)
     setSshConfig({
       host: '',
@@ -288,7 +298,7 @@ export function AddConnectionDialog({
       : undefined
 
     return {
-      id: editConnection?.id || crypto.randomUUID(),
+      id: editConnection?.id || draftIdRef.current,
       name: name || (dbType === 'sqlite' ? database : `${host}/${database}`),
       host,
       port: parseInt(port, 10) || 0,

--- a/apps/desktop/tests/e2e/connection-form.spec.ts
+++ b/apps/desktop/tests/e2e/connection-form.spec.ts
@@ -122,8 +122,9 @@ test('fill, test-connection, save → connection appears in connections.list', a
   // Click the Test Connection button (targeted by visible label text)
   await dialog(window).getByRole('button', { name: 'Test Connection' }).click()
 
-  // Expect a success banner to appear inside the sheet
-  await expect(dialog(window).getByText(/connection successful|connected|success/i)).toBeVisible({
+  // Expect a success banner to appear inside the sheet. Scoped to the banner itself
+  // rather than any matching text in the sheet — see the note on the error assertion below.
+  await expect(dialog(window).getByRole('status')).toContainText(/connection successful/i, {
     timeout: 10000
   })
 
@@ -161,9 +162,14 @@ test('wrong password → test connection shows an error', async ({ window }) => 
   // Click Test and expect an error banner inside the sheet
   await dialog(window).getByRole('button', { name: 'Test Connection' }).click()
 
-  await expect(
-    dialog(window).getByText(/authentication failed|password|connection failed|error/i)
-  ).toBeVisible({ timeout: 10000 })
+  // Scoped to the result banner. The previous sheet-wide getByText matched the
+  // always-present "Password" field label, so it passed the moment the dialog rendered
+  // and never actually observed the error — then hit a strict-mode violation (2 matches)
+  // whenever the error banner won the race and appeared before the assertion ran.
+  await expect(dialog(window).getByRole('alert')).toContainText(
+    /authentication failed|password authentication|connection failed|error/i,
+    { timeout: 10000 }
+  )
 
   // Do NOT save — the fixture tears down the Electron app after this test.
 })


### PR DESCRIPTION
Fixes #252.

## What was happening

Ticking **Use SSL** on a saved Postgres connection and hitting **Test Connection** kept failing with `no pg_hba.conf entry for host "...", no encryption` — the server saying the client never sent an SSLRequest — with the box visibly checked.

`buildClientConfig` was fine. It sets `ssl: { rejectUnauthorized: false }` whenever `config.ssl` is true, which is exactly what makes `pg` initiate TLS (the equivalent of `sslmode=require`). The pool manager just never asked it: `getPoolKey` returned `pg:${config.id}` for any config with an id, ignoring host, port, credentials, schema, and SSL. An edited config got the pool built *before* the edit. The shape-fingerprint branch underneath only ran for id-less configs, which the dialog never produces.

Two details stopped it from self-correcting:

- `new Pool()` never dials, so `createPoolEntry` caches an entry even when every subsequent handshake is rejected — the failed plaintext pool stayed installed.
- Only `connections:update` tears a pool down, and the user never gets there, because Test Connection is the thing failing.

So the same error repeated for every attempt until app restart, which is what made it look like an SSL bug.

## The fix

Pools are keyed on **identity** (the saved connection, or the target for an ad-hoc config) **plus a fingerprint** of every field baked into the socket at startup — host, port, database, user, password, schema, ssl/sslOptions, ssh/sshConfig.

Each acquisition retires other shapes under the same identity, so a connection still keeps at most one live pool rather than accumulating one per edit. `closePgPool` now closes every variant for the connection: it is handed the *pre-edit* config, so keying off that alone could leave behind a pool a concurrent Test Connection had just built.

## Two adjacent bugs in the same path

- `resetForm` reset `sslOptions` to `{ rejectUnauthorized: true }`, while the initial state and the edit-mode fallback both use `false`. Closing the dialog via Cancel and reopening it silently flipped new connections to strict certificate verification — contradicting the "Off by default" copy right under the checkbox and the opt-in design from v0.21.3 (#95).
- `getConnectionConfig` minted a fresh UUID per call, so every Test Connection click on a new connection orphaned a pool that lived until app shutdown. The draft id is now stable per dialog session.

## Tests

The SSL branch of `buildClientConfig` had **no coverage at all**, and `pg-pool-manager` only checked shape isolation for id-less configs. Added:

- `buildClientConfig`: require, strict opt-in, pinned CA (verified by default, explicit opt-out honoured), and unreadable CA failing loudly instead of silently dropping TLS.
- `pg-pool-manager`: SSL / host / credential changes on a *saved* connection each get a new pool; the plaintext-rejected-then-TLS-retry sequence from the issue; one live pool per connection (superseded pool ended, current one not); `closePgPool` closing the live pool when handed the pre-edit config.

1213 tests pass, typecheck clean, ESLint clean on the touched files.

## Not verified

I have no Azure Flexible Server to reproduce against — the diagnosis is from the code path, and the reporter's symptom matches it exactly. Worth asking them to confirm on the next build.

MySQL and MSSQL are unaffected; neither adapter pools.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection handling when host, credentials, SSL, or SSH settings change.
  * Ensured outdated connections are retired and replaced cleanly.
  * Improved retry behavior when an initial connection attempt fails.
  * Fixed connection tests and saves to consistently use the same connection identity.
  * Prevented connection cleanup issues after configuration changes.

* **Improvements**
  * SSL certificate verification is now disabled by default for new connections.
  * Improved support for custom certificate authorities and TLS settings.
  * Connection test results now display clearer success and error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->