### PR TITLE
feat(desktop): Antigravity (agy) CLI as a third BYOH harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ A minimal, fast SQL client desktop application with AI-powered querying. Built f
 - **Read-only tools** - `list_connections`, `list_schemas`, `run_query` (500-row cap, rollback-wrapped, Postgres additionally runs `READ ONLY` at the DB level), `explain_query`
 - **Approved writes** - `execute_statement` prompts an in-app Approve/Reject dialog for every write; 60s timeout auto-rejects
 - **One-command setup** - copy the ready-made `claude mcp add` snippet straight from Settings → MCP server
-- **Bring your own agent** - point the AI assistant at your locally installed Claude Code or Codex CLI; it uses your existing subscription and sign-in, and data-peek never stores a key. Claude Code grounds answers against your live database via MCP; Codex grounding follows once headless tool approval lands upstream.
+- **Bring your own agent** - point the AI assistant at your locally installed Claude Code, Codex, or Antigravity (`agy`) CLI; it uses your existing subscription and sign-in, and data-peek never stores a key. Claude Code grounds answers against your live database via MCP; Codex and Antigravity grounding follows once headless tool approval lands upstream.
 
 ### Audit Log
 

--- a/apps/desktop/src/main/__tests__/ai-providers.test.ts
+++ b/apps/desktop/src/main/__tests__/ai-providers.test.ts
@@ -13,7 +13,7 @@
  */
 
 import { describe, expect, it } from 'vitest'
-import { AI_PROVIDERS, type AIConfig, type AIProvider } from '@shared/index'
+import { AI_PROVIDERS, isHarnessProvider, type AIConfig, type AIProvider } from '@shared/index'
 import { createProviderClient } from '../ai-providers'
 
 function configFor(provider: AIProvider): AIConfig {
@@ -25,10 +25,10 @@ function configFor(provider: AIProvider): AIConfig {
   }
 }
 
-// claude-cli and codex-cli are not AI SDK providers — they drive local CLIs via
-// harness-service, so createProviderClient intentionally throws for them (callers
+// BYOH harness providers are not AI SDK providers — they drive local CLIs via
+// harness/service, so createProviderClient intentionally throws for them (callers
 // route them away before reaching the factory).
-const SDK_PROVIDERS = AI_PROVIDERS.filter((p) => p.id !== 'claude-cli' && p.id !== 'codex-cli')
+const SDK_PROVIDERS = AI_PROVIDERS.filter((p) => !isHarnessProvider(p.id))
 
 describe('createProviderClient', () => {
   for (const info of SDK_PROVIDERS) {
@@ -52,6 +52,10 @@ describe('createProviderClient', () => {
 
   it('throws for codex-cli (handled by the harness, not the AI SDK factory)', () => {
     expect(() => createProviderClient(configFor('codex-cli'))).toThrow(/harness/i)
+  })
+
+  it('throws for antigravity-cli (handled by the harness, not the AI SDK factory)', () => {
+    expect(() => createProviderClient(configFor('antigravity-cli'))).toThrow(/harness/i)
   })
 
   it('throws on an unknown provider (defensive)', () => {

--- a/apps/desktop/src/main/ai-providers.ts
+++ b/apps/desktop/src/main/ai-providers.ts
@@ -94,6 +94,12 @@ export function createProviderClient(config: AIConfig) {
       throw new Error('codex-cli is handled by the harness service, not the AI SDK factory')
     }
 
+    case 'antigravity-cli': {
+      // Not an AI SDK provider — it shells out to the local `agy` CLI.
+      // Routed to the harness service before this factory is ever reached.
+      throw new Error('antigravity-cli is handled by the harness service, not the AI SDK factory')
+    }
+
     default: {
       const _exhaustive: never = config.provider
       throw new Error(`Unknown provider: ${String(_exhaustive)}`)

--- a/apps/desktop/src/main/harness/__tests__/antigravity.test.ts
+++ b/apps/desktop/src/main/harness/__tests__/antigravity.test.ts
@@ -1,9 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import {
-  antigravityAdapter,
-  buildAntigravityArgs,
-  toGeminiSchema
-} from '../adapters/antigravity'
+import { antigravityAdapter, buildAntigravityArgs, toGeminiSchema } from '../adapters/antigravity'
 import { RESPONSE_JSON_SCHEMA_STRING } from '../../ai-schema'
 import type { HarnessInput } from '../types'
 
@@ -21,7 +17,10 @@ const input = (over: Partial<HarnessInput> = {}): HarnessInput => ({
 // Real fixtures captured live, 2026-08-06, agy 1.1.8. `--json-schema` only
 // works in stream-json mode (plain json mode returns an empty response), and
 // the validated object arrives on the terminal result event as
-// `structured_output` alongside the raw `response` text.
+// `structured_output` alongside the raw `response` text. STEP_DELTA_EVENT is
+// a mid-run step_update: agent_response steps carry a text_delta (the
+// structured JSON, when a schema is set), delivered per completed step rather
+// than token-by-token.
 const RESULT_EVENT = {
   event: 'result',
   result: {
@@ -96,6 +95,13 @@ describe('buildAntigravityArgs', () => {
     const args = buildAntigravityArgs(input({ resumeSessionId: 'conv-7', userPrompt: 'and now?' }))
     expect(args[args.indexOf('--conversation') + 1]).toBe('conv-7')
     expect(args[1]).toBe('and now?')
+    // Unlike codex's `exec resume`, agy accepts --sandbox on resumed
+    // conversations (verified live, agy 1.1.8) — pin that it stays on.
+    expect(args).toContain('--sandbox')
+  })
+
+  it('stages no temp files (the schema travels inline via --json-schema)', () => {
+    expect(antigravityAdapter.buildRequest(input()).tempFiles).toBeUndefined()
   })
 
   it('drops Google API keys so agy rides its own login', () => {
@@ -171,6 +177,29 @@ describe('antigravity run collector', () => {
     expect(() => run.finish({ code: 1, stderr: '' })).toThrow(/terminated due to error/)
   })
 
+  it('prefers the error field over leftover response text when both are present', () => {
+    const run = antigravityAdapter.createRun()
+    run.onLine({
+      event: 'result',
+      result: {
+        conversation_id: 'x',
+        status: 'ERROR',
+        response: '{"type":"met',
+        error: 'model overloaded'
+      }
+    })
+    expect(() => run.finish({ code: 1, stderr: '' })).toThrow(/model overloaded/)
+  })
+
+  it('falls back to the status when neither response nor error carries detail', () => {
+    const run = antigravityAdapter.createRun()
+    run.onLine({
+      event: 'result',
+      result: { conversation_id: 'x', status: 'CANCELLED', response: '' }
+    })
+    expect(() => run.finish({ code: 1, stderr: '' })).toThrow(/status CANCELLED/)
+  })
+
   it('throws with stderr detail when no result event ever arrived', () => {
     const run = antigravityAdapter.createRun()
     run.onLine(STEP_DELTA_EVENT)
@@ -182,6 +211,9 @@ describe('antigravity run collector', () => {
     expect(run.onLine({ event: 'init', conversation_id: 'c', init: { tools: [] } })).toEqual({})
     expect(run.onLine(null)).toEqual({})
     expect(run.onLine('boom')).toEqual({})
+    // A result event with a malformed result field is noise, not a reply.
+    expect(run.onLine({ event: 'result', result: null })).toEqual({})
+    expect(run.onLine({ event: 'result', result: 'oops' })).toEqual({})
   })
 })
 

--- a/apps/desktop/src/main/harness/__tests__/antigravity.test.ts
+++ b/apps/desktop/src/main/harness/__tests__/antigravity.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect } from 'vitest'
+import {
+  antigravityAdapter,
+  buildAntigravityArgs,
+  toGeminiSchema
+} from '../adapters/antigravity'
+import { RESPONSE_JSON_SCHEMA_STRING } from '../../ai-schema'
+import type { HarnessInput } from '../types'
+
+const input = (over: Partial<HarnessInput> = {}): HarnessInput => ({
+  kind: 'chat',
+  userPrompt: 'how many users?',
+  systemPrompt: 'SYS',
+  model: '',
+  jsonSchema: '{"type":"object"}',
+  stream: false,
+  workDir: '/tmp/run-1',
+  ...over
+})
+
+// Real fixtures captured live, 2026-08-06, agy 1.1.8. `--json-schema` only
+// works in stream-json mode (plain json mode returns an empty response), and
+// the validated object arrives on the terminal result event as
+// `structured_output` alongside the raw `response` text.
+const RESULT_EVENT = {
+  event: 'result',
+  result: {
+    conversation_id: '7cf036dc-b6d8-45cf-8e04-9a66d7706584',
+    status: 'SUCCESS',
+    response: '{"message":"hello","toolAction":"Finishing task","type":"message"}\n',
+    duration_seconds: 2.758459,
+    num_turns: 1,
+    structured_output: { message: 'hello', type: 'message' },
+    usage: { input_tokens: 25039, output_tokens: 556 }
+  }
+}
+
+const STEP_DELTA_EVENT = {
+  event: 'step_update',
+  step_update: {
+    conversation_id: '9aaeb4e8-0ce7-410e-8b93-075995f27d75',
+    step_index: 2,
+    state: 'DONE',
+    step_type: 'agent_response',
+    text_delta: '{"message":"hel',
+    duration_seconds: 1.471092
+  }
+}
+
+describe('buildAntigravityArgs', () => {
+  it('runs print mode with stream-json output (json mode breaks --json-schema)', () => {
+    const args = buildAntigravityArgs(input())
+    expect(args[0]).toBe('-p')
+    expect(args[1]).toBe('## Instructions\nSYS\n\n## Request\nhow many users?')
+    expect(args[args.indexOf('--output-format') + 1]).toBe('stream-json')
+    expect(args).toContain('--sandbox')
+  })
+
+  it('passes the JSON schema inline and omits it when absent', () => {
+    const args = buildAntigravityArgs(input())
+    expect(args[args.indexOf('--json-schema') + 1]).toBe('{"type":"object"}')
+    expect(buildAntigravityArgs(input({ jsonSchema: undefined }))).not.toContain('--json-schema')
+  })
+
+  // Gemini's structured-output dialect rejects null inside enum arrays
+  // (live-bisected on agy 1.1.8: the untouched chat schema errors in ~1s;
+  // stripping enum nulls fixes it, with nullability kept by the type unions).
+  it('strips null enum members from the staged schema', () => {
+    const args = buildAntigravityArgs(input({ jsonSchema: RESPONSE_JSON_SCHEMA_STRING }))
+    const staged = JSON.parse(args[args.indexOf('--json-schema') + 1])
+    const assertNoNullEnums = (node: unknown): void => {
+      if (Array.isArray(node)) return node.forEach(assertNoNullEnums)
+      if (!node || typeof node !== 'object') return
+      const obj = node as Record<string, unknown>
+      if (Array.isArray(obj.enum)) expect(obj.enum).not.toContain(null)
+      Object.values(obj).forEach(assertNoNullEnums)
+    }
+    assertNoNullEnums(staged)
+    expect(staged.properties.chartType.enum).toEqual(['bar', 'line', 'pie', 'area'])
+    expect(staged.properties.chartType.type).toEqual(['string', 'null'])
+  })
+
+  it('toGeminiSchema is identity for enum-free schemas and non-JSON input', () => {
+    expect(toGeminiSchema('{"type":"object"}')).toBe('{"type":"object"}')
+    expect(toGeminiSchema('not json')).toBe('not json')
+  })
+
+  it('omits --model for the CLI-default model and passes explicit models through', () => {
+    expect(buildAntigravityArgs(input({ model: '' }))).not.toContain('--model')
+    expect(buildAntigravityArgs(input({ model: 'default' }))).not.toContain('--model')
+    const args = buildAntigravityArgs(input({ model: 'gemini-3-pro' }))
+    expect(args[args.indexOf('--model') + 1]).toBe('gemini-3-pro')
+  })
+
+  it('resumes via --conversation with only the user prompt', () => {
+    const args = buildAntigravityArgs(input({ resumeSessionId: 'conv-7', userPrompt: 'and now?' }))
+    expect(args[args.indexOf('--conversation') + 1]).toBe('conv-7')
+    expect(args[1]).toBe('and now?')
+  })
+
+  it('drops Google API keys so agy rides its own login', () => {
+    const prevGemini = process.env.GEMINI_API_KEY
+    const prevGoogle = process.env.GOOGLE_API_KEY
+    process.env.GEMINI_API_KEY = 'should-not-leak'
+    process.env.GOOGLE_API_KEY = 'should-not-leak'
+    try {
+      const req = antigravityAdapter.buildRequest(input())
+      expect(req.env.GEMINI_API_KEY).toBeUndefined()
+      expect(req.env.GOOGLE_API_KEY).toBeUndefined()
+    } finally {
+      if (prevGemini === undefined) delete process.env.GEMINI_API_KEY
+      else process.env.GEMINI_API_KEY = prevGemini
+      if (prevGoogle === undefined) delete process.env.GOOGLE_API_KEY
+      else process.env.GOOGLE_API_KEY = prevGoogle
+    }
+  })
+
+  it('runs inside the per-run work dir (agy has no --cd flag)', () => {
+    expect(antigravityAdapter.buildRequest(input()).cwd).toBe('/tmp/run-1')
+  })
+})
+
+describe('antigravity run collector', () => {
+  it('prefers structured_output from the result event and reports the session id', () => {
+    const run = antigravityAdapter.createRun()
+    run.onLine(STEP_DELTA_EVENT)
+    run.onLine(RESULT_EVENT)
+    const res = run.finish({ code: 0, stderr: '' })
+    expect(res.payload).toEqual({ message: 'hello', type: 'message' })
+    expect(res.stats).toEqual({
+      toolRoundTrips: 0,
+      denials: 0,
+      sessionId: '7cf036dc-b6d8-45cf-8e04-9a66d7706584'
+    })
+  })
+
+  it('falls back to the raw response text when structured_output is absent', () => {
+    const run = antigravityAdapter.createRun()
+    const { structured_output: _dropped, ...rest } = RESULT_EVENT.result
+    run.onLine({ event: 'result', result: rest })
+    const res = run.finish({ code: 0, stderr: '' })
+    expect(res.payload).toBe(RESULT_EVENT.result.response)
+  })
+
+  it('surfaces agent_response deltas as json deltas for live message extraction', () => {
+    const run = antigravityAdapter.createRun()
+    expect(run.onLine(STEP_DELTA_EVENT).jsonDelta).toBe('{"message":"hel')
+  })
+
+  it('throws with the response text when the result status is not SUCCESS', () => {
+    const run = antigravityAdapter.createRun()
+    run.onLine({
+      event: 'result',
+      result: { conversation_id: 'x', status: 'ERROR', response: 'quota exceeded' }
+    })
+    expect(() => run.finish({ code: 1, stderr: '' })).toThrow(/quota exceeded/)
+  })
+
+  // Real failure shape captured live: empty response, dedicated error field.
+  it('surfaces the error field when the response is empty', () => {
+    const run = antigravityAdapter.createRun()
+    run.onLine({
+      event: 'result',
+      result: {
+        conversation_id: 'x',
+        status: 'ERROR',
+        response: '',
+        error: 'Agent execution terminated due to error.'
+      }
+    })
+    expect(() => run.finish({ code: 1, stderr: '' })).toThrow(/terminated due to error/)
+  })
+
+  it('throws with stderr detail when no result event ever arrived', () => {
+    const run = antigravityAdapter.createRun()
+    run.onLine(STEP_DELTA_EVENT)
+    expect(() => run.finish({ code: 1, stderr: 'boom' })).toThrow(/boom/)
+  })
+
+  it('ignores noise events safely', () => {
+    const run = antigravityAdapter.createRun()
+    expect(run.onLine({ event: 'init', conversation_id: 'c', init: { tools: [] } })).toEqual({})
+    expect(run.onLine(null)).toEqual({})
+    expect(run.onLine('boom')).toEqual({})
+  })
+})
+
+describe('adapter contract', () => {
+  it('ships chat-only: no agentic grounding or dashboards yet', () => {
+    expect(antigravityAdapter.capabilities).toEqual({
+      streaming: false,
+      resume: true,
+      dashboard: false,
+      agentic: false
+    })
+    expect(antigravityAdapter.id).toBe('antigravity-cli')
+    expect(antigravityAdapter.cliLabel).toBe('Antigravity CLI')
+    expect(antigravityAdapter.notFoundMessage).toMatch(/agy/)
+  })
+})

--- a/apps/desktop/src/main/harness/__tests__/runner.test.ts
+++ b/apps/desktop/src/main/harness/__tests__/runner.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { EventEmitter } from 'events'
-import { mkdtempSync, existsSync, readFileSync } from 'fs'
+import { mkdtempSync, existsSync, readFileSync, rmSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 
@@ -59,6 +59,21 @@ describe('runHarnessProcess', () => {
     child.emit('close', 0)
     await p
     expect(lines).toEqual([{ type: 'result', result: 'ok' }])
+  })
+
+  it('re-diagnoses spawn ENOENT as a missing cwd when the dir vanished after preflight', async () => {
+    // TOCTOU window: the cwd passes the preflight existsSync but disappears
+    // before the OS-level spawn — the ENOENT must still not claim the CLI
+    // is missing.
+    const dir = mkdtempSync(join(tmpdir(), 'runner-toctou-'))
+    const child = fakeChild()
+    spawnMock.mockReturnValue(child)
+    const p = runHarnessProcess(req({ cwd: dir }), opts, () => {})
+    rmSync(dir, { recursive: true, force: true })
+    const err = new Error('spawn fake-cli ENOENT') as NodeJS.ErrnoException
+    err.code = 'ENOENT'
+    child.emit('error', err)
+    await expect(p).rejects.toThrow(/working directory disappeared/)
   })
 
   it('reports a missing cwd distinctly instead of misdiagnosing it as a missing binary', async () => {

--- a/apps/desktop/src/main/harness/__tests__/runner.test.ts
+++ b/apps/desktop/src/main/harness/__tests__/runner.test.ts
@@ -61,14 +61,25 @@ describe('runHarnessProcess', () => {
     expect(lines).toEqual([{ type: 'result', result: 'ok' }])
   })
 
+  it('reports a missing cwd distinctly instead of misdiagnosing it as a missing binary', async () => {
+    // A vanished work dir makes spawn throw the same ENOENT as a missing
+    // binary — without this guard the user is told to reinstall a CLI that
+    // is installed and working.
+    const p = runHarnessProcess(req({ cwd: '/definitely/not/a/real/dir' }), opts, () => {})
+    await expect(p).rejects.toThrow(/working directory disappeared/)
+    await expect(p).rejects.toThrow('/definitely/not/a/real/dir')
+    expect(spawnMock).not.toHaveBeenCalled()
+  })
+
   it('forwards the request cwd to the child (for CLIs without a --cd flag)', async () => {
     const child = fakeChild()
     spawnMock.mockReturnValue(child)
-    const p = runHarnessProcess(req({ cwd: '/tmp/work-1' }), opts, () => {})
+    const workDir = tmpdir()
+    const p = runHarnessProcess(req({ cwd: workDir }), opts, () => {})
     child.emit('close', 0)
     await p
     const spawnOpts = spawnMock.mock.calls[0][2] as { cwd?: string }
-    expect(spawnOpts.cwd).toBe('/tmp/work-1')
+    expect(spawnOpts.cwd).toBe(workDir)
   })
 
   it('closes stdin so CLIs never wait for piped input', async () => {

--- a/apps/desktop/src/main/harness/__tests__/runner.test.ts
+++ b/apps/desktop/src/main/harness/__tests__/runner.test.ts
@@ -61,6 +61,16 @@ describe('runHarnessProcess', () => {
     expect(lines).toEqual([{ type: 'result', result: 'ok' }])
   })
 
+  it('forwards the request cwd to the child (for CLIs without a --cd flag)', async () => {
+    const child = fakeChild()
+    spawnMock.mockReturnValue(child)
+    const p = runHarnessProcess(req({ cwd: '/tmp/work-1' }), opts, () => {})
+    child.emit('close', 0)
+    await p
+    const spawnOpts = spawnMock.mock.calls[0][2] as { cwd?: string }
+    expect(spawnOpts.cwd).toBe('/tmp/work-1')
+  })
+
   it('closes stdin so CLIs never wait for piped input', async () => {
     const child = fakeChild()
     spawnMock.mockReturnValue(child)

--- a/apps/desktop/src/main/harness/__tests__/service.test.ts
+++ b/apps/desktop/src/main/harness/__tests__/service.test.ts
@@ -400,3 +400,112 @@ describe('codex provider routing', () => {
     expect(spawnMock).not.toHaveBeenCalled()
   })
 })
+
+describe('antigravity provider routing', () => {
+  beforeEach(() => {
+    spawnMock.mockReset()
+    getMcpRuntimeInfoMock.mockReturnValue(null)
+  })
+  const agyCfg = { provider: 'antigravity-cli', model: 'default' } as unknown as AIConfig
+  const agyMsgs: AIMessage[] = [{ role: 'user', content: 'how many users?' }]
+
+  const emitAgyReply = (child: ReturnType<typeof fakeChild>): void => {
+    child.stdout.emit(
+      'data',
+      Buffer.from(
+        JSON.stringify({
+          event: 'result',
+          result: {
+            conversation_id: 'conv-1',
+            status: 'SUCCESS',
+            response: '',
+            structured_output: { type: 'message', message: 'hello from agy' },
+            num_turns: 1
+          }
+        }) + '\n'
+      )
+    )
+    child.emit('close', 0)
+  }
+
+  it('runs non-agentically even with MCP up: no MCP wiring, honest meta', async () => {
+    getMcpRuntimeInfoMock.mockReturnValue({
+      port: 4722,
+      token: 'secret-tok',
+      url: 'http://127.0.0.1:4722/mcp'
+    })
+    const child = fakeChild()
+    spawnMock.mockReturnValue(child)
+    const p = generateChatResponseViaHarness(agyCfg, agyMsgs, [], 'postgresql', 'conn-1')
+    emitAgyReply(child)
+    const res = await p
+    expect(res.success).toBe(true)
+    expect(res.data?.message).toBe('hello from agy')
+    expect(res.meta).toMatchObject({ agentic: false, grounded: false, sessionId: 'conv-1' })
+    const [bin, args, opts] = spawnMock.mock.calls.at(-1) as [
+      string,
+      string[],
+      { env: Record<string, string> }
+    ]
+    expect(bin).toContain('agy')
+    expect(args.join(' ')).not.toContain('mcp')
+    expect(args[1]).toMatch(/## No live database access/)
+    expect(opts.env.GEMINI_API_KEY).toBeUndefined()
+  })
+
+  it('surfaces the agy-specific not-found message on ENOENT', async () => {
+    const child = fakeChild()
+    spawnMock.mockReturnValue(child)
+    const p = generateChatResponseViaHarness(agyCfg, agyMsgs, [], 'postgresql')
+    const err = new Error('spawn agy ENOENT') as NodeJS.ErrnoException
+    err.code = 'ENOENT'
+    child.emit('error', err)
+    const res = await p
+    expect(res.success).toBe(false)
+    expect(res.error).toMatch(/Antigravity CLI not found/)
+  })
+
+  it('resumes an agy conversation with only the latest user message', async () => {
+    const child = fakeChild()
+    spawnMock.mockReturnValue(child)
+    const many: AIMessage[] = [
+      { role: 'user', content: 'first' },
+      { role: 'assistant', content: 'reply' },
+      { role: 'user', content: 'and now?' }
+    ]
+    const p = generateChatResponseViaHarnessStream(
+      agyCfg,
+      many,
+      [],
+      'postgresql',
+      undefined,
+      'conv-1',
+      () => {}
+    )
+    emitAgyReply(child)
+    await p
+    const args = spawnMock.mock.calls.at(-1)![1] as string[]
+    expect(args[1]).toBe('and now?')
+    expect(args[args.indexOf('--conversation') + 1]).toBe('conv-1')
+  })
+
+  it('refuses dashboard generation for antigravity without spawning', async () => {
+    getMcpRuntimeInfoMock.mockReturnValue({
+      port: 4722,
+      token: 'secret-tok',
+      url: 'http://127.0.0.1:4722/mcp'
+    })
+    const res = await generateDashboardViaHarness(
+      'antigravity-cli',
+      'overview',
+      [],
+      'postgresql',
+      'conn-1'
+    )
+    expect(res).toEqual({
+      success: false,
+      error: 'Dashboard generation is not supported by this harness yet.'
+    })
+    expect(spawnMock).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/main/harness/__tests__/service.test.ts
+++ b/apps/desktop/src/main/harness/__tests__/service.test.ts
@@ -445,12 +445,15 @@ describe('antigravity provider routing', () => {
     const [bin, args, opts] = spawnMock.mock.calls.at(-1) as [
       string,
       string[],
-      { env: Record<string, string> }
+      { env: Record<string, string>; cwd?: string }
     ]
     expect(bin).toContain('agy')
     expect(args.join(' ')).not.toContain('mcp')
     expect(args[1]).toMatch(/## No live database access/)
     expect(opts.env.GEMINI_API_KEY).toBeUndefined()
+    expect(opts.env.GOOGLE_API_KEY).toBeUndefined()
+    // agy has no --cd flag, so the per-run scratch dir must arrive as cwd.
+    expect(opts.cwd).toMatch(/data-peek-harness-/)
   })
 
   it('surfaces the agy-specific not-found message on ENOENT', async () => {

--- a/apps/desktop/src/main/harness/adapters/antigravity.ts
+++ b/apps/desktop/src/main/harness/adapters/antigravity.ts
@@ -95,10 +95,11 @@ function createAntigravityRun(): HarnessRun {
         )
       }
       if (result.status !== 'SUCCESS') {
-        // Failures carry a dedicated error field with an empty response.
+        // The dedicated error field is the stronger signal — response may hold
+        // a stale partial reply when both are populated.
         const detail =
-          (typeof result.response === 'string' && result.response.trim()) ||
           (typeof result.error === 'string' && result.error.trim()) ||
+          (typeof result.response === 'string' && result.response.trim()) ||
           `status ${String(result.status)}`
         throw new Error(detail)
       }

--- a/apps/desktop/src/main/harness/adapters/antigravity.ts
+++ b/apps/desktop/src/main/harness/adapters/antigravity.ts
@@ -1,0 +1,131 @@
+/**
+ * Google Antigravity CLI (`agy`) adapter. Verified against agy 1.1.8:
+ * `--json-schema` only works with `--output-format stream-json` (plain json
+ * mode returns an empty response), so every run streams. The validated reply
+ * arrives on the terminal result event as `structured_output`, with the raw
+ * `response` text as fallback. There is no --append-system-prompt (we prepend
+ * instructions into the prompt body) and no --cd flag (the runner sets the
+ * child's cwd to the per-run work dir). Resume rides `--conversation <id>`.
+ *
+ * agy has MCP internally (call_mcp_tool) but it is config-file based with a
+ * request-review permission mode and only a blanket
+ * --dangerously-skip-permissions override, so — like codex — agentic grounding
+ * stays off until a safe headless approval path exists.
+ */
+
+import { augmentedPath, detectBinary, resolveBinary } from '../runner'
+import type { HarnessAdapter, HarnessInput, HarnessRun, HarnessStreamInfo } from '../types'
+
+const NOT_FOUND = 'Antigravity CLI not found. Install it and run `agy` once to sign in.'
+
+function composePrompt(systemPrompt: string, userPrompt: string): string {
+  return `## Instructions\n${systemPrompt}\n\n## Request\n${userPrompt}`
+}
+
+/**
+ * Gemini's structured-output dialect rejects null inside enum arrays
+ * (live-bisected on agy 1.1.8: the untouched chat schema errors in ~1s, and
+ * stripping enum nulls is the single change that fixes it). Nullability is
+ * preserved by the fields' type unions (e.g. ["string", "null"]).
+ */
+export function toGeminiSchema(schemaJson: string): string {
+  const strip = (node: unknown): unknown => {
+    if (Array.isArray(node)) return node.map(strip)
+    if (!node || typeof node !== 'object') return node
+    const out: Record<string, unknown> = {}
+    for (const [key, value] of Object.entries(node)) {
+      out[key] =
+        key === 'enum' && Array.isArray(value) ? value.filter((v) => v !== null) : strip(value)
+    }
+    return out
+  }
+  try {
+    return JSON.stringify(strip(JSON.parse(schemaJson)))
+  } catch {
+    return schemaJson
+  }
+}
+
+export function buildAntigravityArgs(input: HarnessInput): string[] {
+  // A resumed conversation already carries the instructions.
+  const prompt = input.resumeSessionId
+    ? input.userPrompt
+    : composePrompt(input.systemPrompt, input.userPrompt)
+  const args = ['-p', prompt, '--output-format', 'stream-json', '--sandbox']
+  if (input.resumeSessionId) args.push('--conversation', input.resumeSessionId)
+  if (input.jsonSchema) args.push('--json-schema', toGeminiSchema(input.jsonSchema))
+  if (input.model && input.model !== 'default') args.push('--model', input.model)
+  return args
+}
+
+function antigravityEnv(): NodeJS.ProcessEnv {
+  // Drop API keys so agy uses its own configured login — the whole point of
+  // BYOH is to ride the local CLI's auth, mirroring the other adapters.
+  const env: Record<string, string | undefined> = { ...process.env, PATH: augmentedPath() }
+  delete env.GEMINI_API_KEY
+  delete env.GOOGLE_API_KEY
+  return env as NodeJS.ProcessEnv
+}
+
+function createAntigravityRun(): HarnessRun {
+  let result: Record<string, unknown> | undefined
+
+  return {
+    onLine(line): HarnessStreamInfo {
+      const info: HarnessStreamInfo = {}
+      if (!line || typeof line !== 'object') return info
+      const evt = line as Record<string, unknown>
+      if (evt.event === 'step_update') {
+        const step = (evt.step_update ?? {}) as Record<string, unknown>
+        if (step.step_type === 'agent_response' && typeof step.text_delta === 'string') {
+          // With --json-schema the reply text IS the structured JSON, so the
+          // service can live-extract the "message" field from the deltas.
+          info.jsonDelta = step.text_delta
+        }
+      }
+      if (evt.event === 'result' && evt.result && typeof evt.result === 'object') {
+        result = evt.result as Record<string, unknown>
+      }
+      return info
+    },
+    finish({ code, stderr }) {
+      if (!result) {
+        throw new Error(
+          `Antigravity CLI returned no result: ${stderr.trim() || `exited with code ${code}`}`
+        )
+      }
+      if (result.status !== 'SUCCESS') {
+        // Failures carry a dedicated error field with an empty response.
+        const detail =
+          (typeof result.response === 'string' && result.response.trim()) ||
+          (typeof result.error === 'string' && result.error.trim()) ||
+          `status ${String(result.status)}`
+        throw new Error(detail)
+      }
+      const sessionId =
+        typeof result.conversation_id === 'string' ? result.conversation_id : undefined
+      const payload =
+        result.structured_output && typeof result.structured_output === 'object'
+          ? result.structured_output
+          : result.response
+      return { payload, stats: { toolRoundTrips: 0, denials: 0, sessionId } }
+    }
+  }
+}
+
+export const antigravityAdapter: HarnessAdapter = {
+  id: 'antigravity-cli',
+  cliLabel: 'Antigravity CLI',
+  notFoundMessage: NOT_FOUND,
+  // Deltas arrive per completed step, not token-by-token, so streaming stays
+  // off; agentic/dashboard wait on a safe headless tool-approval path.
+  capabilities: { streaming: false, resume: true, dashboard: false, agentic: false },
+  detect: () => detectBinary('agy', 'DATA_PEEK_AGY_PATH', NOT_FOUND),
+  buildRequest: (input) => ({
+    binary: resolveBinary('agy', 'DATA_PEEK_AGY_PATH'),
+    args: buildAntigravityArgs(input),
+    env: antigravityEnv(),
+    cwd: input.workDir
+  }),
+  createRun: createAntigravityRun
+}

--- a/apps/desktop/src/main/harness/runner.ts
+++ b/apps/desktop/src/main/harness/runner.ts
@@ -79,6 +79,13 @@ export function runHarnessProcess(
   }
 
   return new Promise((resolve, reject) => {
+    // A missing cwd makes spawn throw the same ENOENT as a missing binary,
+    // which would misdiagnose as "CLI not found" — tell those cases apart.
+    if (request.cwd && !existsSync(request.cwd)) {
+      cleanup()
+      reject(new Error(`${opts.cliLabel} working directory disappeared: ${request.cwd}`))
+      return
+    }
     const child = spawn(request.binary, request.args, {
       env: request.env,
       cwd: request.cwd,

--- a/apps/desktop/src/main/harness/runner.ts
+++ b/apps/desktop/src/main/harness/runner.ts
@@ -81,6 +81,7 @@ export function runHarnessProcess(
   return new Promise((resolve, reject) => {
     const child = spawn(request.binary, request.args, {
       env: request.env,
+      cwd: request.cwd,
       shell: false,
       stdio: ['ignore', 'pipe', 'pipe']
     })

--- a/apps/desktop/src/main/harness/runner.ts
+++ b/apps/desktop/src/main/harness/runner.ts
@@ -120,8 +120,16 @@ export function runHarnessProcess(
     child.on('error', (err) => {
       clearTimeout(timer)
       cleanup()
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+        reject(err)
+        return
+      }
+      // spawn reports a vanished cwd exactly like a missing binary; the
+      // preflight can't cover the window between its check and the spawn.
       reject(
-        (err as NodeJS.ErrnoException).code === 'ENOENT' ? new Error(opts.notFoundMessage) : err
+        request.cwd && !existsSync(request.cwd)
+          ? new Error(`${opts.cliLabel} working directory disappeared: ${request.cwd}`)
+          : new Error(opts.notFoundMessage)
       )
     })
     child.on('close', (code) => {

--- a/apps/desktop/src/main/harness/service.ts
+++ b/apps/desktop/src/main/harness/service.ts
@@ -23,6 +23,7 @@ import type {
 import { DEFAULT_MODELS, isHarnessProvider } from '@shared/index'
 import { claudeCodeAdapter } from './adapters/claude-code'
 import { codexAdapter } from './adapters/codex'
+import { antigravityAdapter } from './adapters/antigravity'
 import { runHarnessProcess } from './runner'
 import { extractPartialMessage } from './partial-json'
 import type {
@@ -54,7 +55,8 @@ const DASHBOARD_TIMEOUT_MS = 300_000
 
 const ADAPTERS: Record<HarnessProviderId, HarnessAdapter> = {
   'claude-cli': claudeCodeAdapter,
-  'codex-cli': codexAdapter
+  'codex-cli': codexAdapter,
+  'antigravity-cli': antigravityAdapter
 }
 
 function adapterFor(provider: AIProvider): HarnessAdapter {

--- a/apps/desktop/src/main/harness/types.ts
+++ b/apps/desktop/src/main/harness/types.ts
@@ -8,7 +8,7 @@
 
 import type { McpRuntimeInfo } from '../mcp-runtime'
 
-export type HarnessProviderId = 'claude-cli' | 'codex-cli'
+export type HarnessProviderId = 'claude-cli' | 'codex-cli' | 'antigravity-cli'
 
 export interface HarnessCapabilities {
   /** Token-level partial messages while generating (vs message-at-completion). */
@@ -54,6 +54,8 @@ export interface HarnessRequest {
   binary: string
   args: string[]
   env: NodeJS.ProcessEnv
+  /** Working directory for the child; for CLIs without a --cd flag. */
+  cwd?: string
   /** Written by the runner before spawn and deleted after the run. */
   tempFiles?: HarnessTempFile[]
 }

--- a/apps/desktop/src/renderer/src/components/ai/ai-settings-modal.tsx
+++ b/apps/desktop/src/renderer/src/components/ai/ai-settings-modal.tsx
@@ -114,7 +114,7 @@ export function AISettingsModal({
     if (!multiProviderConfig?.providers) return false
     const config = multiProviderConfig.providers[providerId]
     if (providerId === 'ollama') return !!config?.baseUrl
-    // BYOH harnesses (claude-cli, codex-cli): no key/url, so an existing entry
+    // BYOH harnesses: no key/url, so an existing entry
     // means it's been configured.
     if (!providerNeedsKey(providerId)) return !!config
     return !!config?.apiKey

--- a/apps/desktop/src/renderer/src/components/ai/ai-settings-modal.tsx
+++ b/apps/desktop/src/renderer/src/components/ai/ai-settings-modal.tsx
@@ -50,6 +50,11 @@ const HARNESS_HINTS: Partial<Record<ProviderId, { detected: string; missing: str
     detected:
       'uses your Codex sign-in via the `codex` CLI — schema-aware answers; live grounding lands when Codex supports headless tool approval',
     missing: 'Install Codex and run `codex login` once to sign in.'
+  },
+  'antigravity-cli': {
+    detected:
+      'uses your Google sign-in via the `agy` CLI — schema-aware answers; live grounding lands when Antigravity supports headless tool approval',
+    missing: 'Install Antigravity and run `agy` once to sign in.'
   }
 }
 

--- a/apps/desktop/src/renderer/src/lib/harness-session-ref.ts
+++ b/apps/desktop/src/renderer/src/lib/harness-session-ref.ts
@@ -2,7 +2,7 @@ import type { AIProvider } from '@data-peek/shared'
 
 /**
  * A CLI session id captured from a BYOH harness turn, tagged with the
- * provider that was active when it arrived. Both harness providers
+ * provider that was active when it arrived. All BYOH harness providers
  * (claude-cli, codex-cli) are resumable, but a session id minted by one is
  * meaningless — and often an outright invalid CLI argument — to the other.
  */

--- a/apps/desktop/src/renderer/src/lib/harness-session-ref.ts
+++ b/apps/desktop/src/renderer/src/lib/harness-session-ref.ts
@@ -2,9 +2,9 @@ import type { AIProvider } from '@data-peek/shared'
 
 /**
  * A CLI session id captured from a BYOH harness turn, tagged with the
- * provider that was active when it arrived. All BYOH harness providers
- * (claude-cli, codex-cli) are resumable, but a session id minted by one is
- * meaningless — and often an outright invalid CLI argument — to the other.
+ * provider that was active when it arrived. All BYOH harness providers are
+ * resumable, but a session id minted by one is meaningless — and often an
+ * outright invalid CLI argument — to the others.
  */
 export interface HarnessSessionRef {
   provider: AIProvider

--- a/apps/desktop/src/renderer/src/stores/__tests__/ai-config-sanitize.test.ts
+++ b/apps/desktop/src/renderer/src/stores/__tests__/ai-config-sanitize.test.ts
@@ -54,11 +54,11 @@ describe('sanitizeMultiConfig', () => {
     expect(sanitizeMultiConfig(config)?.activeProvider).toBe(FIRST)
   })
 
-  it('passes through a keyless harness config (codex-cli) unchanged, like claude-cli', () => {
+  it('passes through keyless harness configs unchanged (claude, codex, antigravity)', () => {
     const config: AIMultiProviderConfig = {
-      providers: { 'codex-cli': {}, 'claude-cli': {} },
-      activeProvider: 'codex-cli',
-      activeModels: { 'codex-cli': 'default' }
+      providers: { 'codex-cli': {}, 'claude-cli': {}, 'antigravity-cli': {} },
+      activeProvider: 'antigravity-cli',
+      activeModels: { 'codex-cli': 'default', 'antigravity-cli': 'default' }
     }
     expect(sanitizeMultiConfig(config)).toEqual(config)
   })

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -85,7 +85,10 @@ export type AIProvider =
   | "claude-cli"
   // Bring-your-own-harness: drives the user's locally installed `codex` CLI,
   // which owns its own auth (ChatGPT sign-in or key). No API key stored by data-peek.
-  | "codex-cli";
+  | "codex-cli"
+  // Bring-your-own-harness: drives the user's locally installed `agy` CLI
+  // (Google Antigravity), which owns its own auth. No API key stored by data-peek.
+  | "antigravity-cli";
 
 /**
  * Configuration for AI service
@@ -388,6 +391,21 @@ export const AI_PROVIDERS: readonly ProviderInfo[] = [
       { id: "gpt-5.1-codex-mini", name: "GPT-5.1 Codex Mini", description: "Fast & cheap" },
     ],
   },
+  {
+    id: "antigravity-cli",
+    name: "Antigravity (local CLI)",
+    description: "Uses your installed `agy` CLI — no API key stored here",
+    keyPrefix: null,
+    keyUrl: "https://antigravity.google",
+    models: [
+      {
+        id: "default",
+        name: "Antigravity CLI default",
+        recommended: true,
+        description: "Whatever your agy config uses",
+      },
+    ],
+  },
 ] as const;
 
 /**
@@ -424,16 +442,18 @@ export const DEFAULT_MODELS: Record<AIProvider, string> = {
   ollama: getRecommendedModel("ollama"),
   "claude-cli": getRecommendedModel("claude-cli"),
   "codex-cli": getRecommendedModel("codex-cli"),
+  "antigravity-cli": getRecommendedModel("antigravity-cli"),
 };
 
 /**
  * Providers that run locally and need no API key stored by data-peek:
- * ollama talks to localhost, claude-cli and codex-cli drive the user's own authed CLIs.
+ * ollama talks to localhost; the BYOH harnesses drive the user's own authed CLIs.
  */
 const KEYLESS_AI_PROVIDERS: ReadonlySet<AIProvider> = new Set([
   "ollama",
   "claude-cli",
   "codex-cli",
+  "antigravity-cli",
 ]);
 
 export function providerNeedsKey(provider: AIProvider): boolean {
@@ -447,6 +467,7 @@ export function providerNeedsKey(provider: AIProvider): boolean {
 const HARNESS_AI_PROVIDERS: ReadonlySet<AIProvider> = new Set([
   "claude-cli",
   "codex-cli",
+  "antigravity-cli",
 ]);
 
 export function isHarnessProvider(provider: AIProvider): boolean {


### PR DESCRIPTION
## Summary

Adds Google Antigravity's `agy` CLI as the third bring-your-own-harness provider, on the adapter seam from #254 — one adapter file, a registry entry, and a settings row. Same BYOH stance: rides the user's own `agy` sign-in, no keys stored (GEMINI_API_KEY/GOOGLE_API_KEY dropped from the child env).

## agy specifics (all live-verified against agy 1.1.8, real captured fixtures in tests)

- `--json-schema` only works with `--output-format stream-json` (plain json mode returns an empty response) — every run streams; the validated reply arrives as `structured_output` on the terminal result event, raw `response` as fallback; failures carry a dedicated `error` field.
- Gemini's structured-output dialect rejects `null` members inside `enum` arrays (live-bisected); `toGeminiSchema` strips them, nullability preserved by the type unions. The OpenAI-strict analogue of #254's `toOpenAiStrictSchema`.
- No `--append-system-prompt` (instructions prepended into the prompt body) and no `--cd` flag — `HarnessRequest` gained an optional `cwd` the runner forwards to spawn.
- Resume via `--conversation <id>` (session id = `conversation_id`).

## Capabilities

Chat-only v1 (`agentic: false`, `dashboard: false`), matching Codex: agy has MCP internally (`call_mcp_tool`) but it's config-file based with a request-review permission mode and only a blanket `--dangerously-skip-permissions` override — same class of upstream limitation as openai/codex#24135, same decision. The no-live-access instruction keeps answers honest: verified live end-to-end, "How many users?" returns `type: metric` with `SELECT COUNT(*) FROM users;` and the metric card shows the real value.

## Verification

1277 tests passing (adapter suite from real fixtures + service routing block mirroring the codex one), node+web typecheck clean. Live end-to-end: one-shot chat, resumed conversation, metric flow with the production schema.

## Manual check before release

Settings → AI → "Antigravity (local CLI)" shows Detected · 1.1.8 → a chat on a seed DB returns a metric/query card (no grounded badge — expected) → provider switch mid-chat starts a fresh conversation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the locally installed Google Antigravity (`agy`) CLI as an AI provider.
  * Added conversation resumption, structured responses, model selection, and local authentication.
  * Added setup guidance, including the `agy` sign-in command.
* **Improvements**
  * Requests now use their configured working directory with clearer errors for invalid locations.
  * Antigravity support reflects unavailable streaming, dashboard, and agentic features.
* **Documentation**
  * Updated the MCP Server feature list to include Antigravity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->