### PR TITLE
test(desktop): live e2e coverage for the BYOH harness providers

### DIFF
--- a/apps/desktop/tests/e2e/README.md
+++ b/apps/desktop/tests/e2e/README.md
@@ -86,6 +86,33 @@ Requirements:
 - Existing tests assume the seed file at `seeds/acme_saas_seed.sql` is unchanged. If
   the seed grows or shrinks, update the assertions in `queries.spec.ts`.
 
+## Live BYOH harness checks (opt-in)
+
+`byoh-harness-live.spec.ts` covers the bring-your-own-harness providers end to end:
+CLI detection, grounded vs schema-only chat, the capability refusals, and the
+provider-switch session reset. It spawns the **real** `claude` / `codex` / `agy`
+CLIs, so it is gated and skipped by default:
+
+```bash
+BYOH_LIVE=1 pnpm exec playwright test byoh-harness-live --workers=1
+```
+
+Requirements beyond the usual (Docker + a built bundle):
+
+- All three CLIs installed **and signed in** — the adapters deliberately drop
+  `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GEMINI_API_KEY` from the child env, so an
+  env var is not a substitute for the CLI's own auth.
+- Real model round-trips: budget ~3 minutes and your own subscription quota. Timeouts
+  are raised to 300s per test because agentic turns dwarf the 60s default.
+
+CI never runs it (no CLIs, signed in or otherwise), which is the point of the gate —
+the adapters' deterministic coverage lives in `src/main/harness/__tests__/` and runs
+from captured CLI fixtures instead.
+
+MCP ports are set explicitly per test (`47241`+) rather than using the `4722` default,
+for the same reason `mcp-server.spec.ts` does it: a locally running data-peek usually
+holds 4722, and `mcp.setEnabled(true)` rejects on a busy port instead of falling back.
+
 ## CI
 
 `.github/workflows/e2e.yml` runs the suite on every PR and on `main`. The runner

--- a/apps/desktop/tests/e2e/byoh-harness-live.spec.ts
+++ b/apps/desktop/tests/e2e/byoh-harness-live.spec.ts
@@ -1,0 +1,215 @@
+import { test, expect } from './fixtures/electron-app'
+import { startSeededPostgres, type SeededPostgres } from './fixtures/postgres'
+import type { AIProvider, SchemaInfo } from '@data-peek/shared'
+
+/**
+ * Live BYOH harness checks — the manual pre-release checklist from #254 / #255,
+ * automated. Deliberately excluded from the default suite: it spawns the real
+ * `claude` / `codex` / `agy` CLIs and burns the operator's own subscription
+ * quota, so CI (which has none of them, signed in or otherwise) must not run it.
+ *
+ *   pnpm exec playwright test byoh-harness-live --workers=1   # with BYOH_LIVE=1
+ */
+test.skip(!process.env.BYOH_LIVE, 'live harness run — set BYOH_LIVE=1 to opt in')
+
+// Real CLI round-trips, agentic ones especially, dwarf the 60s default.
+test.setTimeout(300_000)
+
+let pg: SeededPostgres
+
+test.beforeAll(async () => {
+  pg = await startSeededPostgres()
+})
+
+test.afterAll(async () => {
+  await pg?.stop()
+})
+
+/** Save the seeded connection, fetch its schema, and select a harness provider. */
+async function prepare(
+  window: import('@playwright/test').Page,
+  provider: AIProvider
+): Promise<SchemaInfo[]> {
+  await window.evaluate((cfg) => window.api.connections.add(cfg), pg.config)
+  await window.evaluate(
+    (p) => window.api.ai.setConfig({ provider: p as AIProvider, model: 'default' }),
+    provider
+  )
+  // db.schemas resolves to DatabaseSchemaResponse — the SchemaInfo[] is under `.schemas`.
+  const schemas = await window.evaluate(
+    (cfg) => window.api.db.schemas(cfg, true).then((r) => r.data?.schemas ?? []),
+    pg.config
+  )
+  expect(schemas.length, 'seeded schema came back empty').toBeGreaterThan(0)
+  return schemas as SchemaInfo[]
+}
+
+/**
+ * Start the embedded MCP server on a port nobody else holds. Ports are unique per
+ * test and off the 4722 default — the operator's own running data-peek usually has
+ * that one, and `setEnabled` rejects rather than falling back when the port is busy.
+ * Same convention as mcp-server.spec.ts, one range up so the two can run together.
+ */
+async function startMcp(window: import('@playwright/test').Page, port: number): Promise<void> {
+  const portResult = await window.evaluate((p) => window.api.mcp.setPort(p), port)
+  expect(portResult.success, `setPort(${port}) failed: ${portResult.error}`).toBe(true)
+  const result = await window.evaluate(() => window.api.mcp.setEnabled(true))
+  expect(result.success, `MCP server failed to start on ${port}: ${result.error}`).toBe(true)
+  expect(result.data?.running, `MCP server reported not running on ${port}`).toBe(true)
+}
+
+async function stopMcp(window: import('@playwright/test').Page): Promise<void> {
+  const result = await window.evaluate(() => window.api.mcp.setEnabled(false))
+  expect(result.success, `MCP server failed to stop: ${result.error}`).toBe(true)
+  expect(result.data?.running).toBe(false)
+}
+
+test('all three harness CLIs are detected with versions', async ({ window }) => {
+  for (const provider of ['claude-cli', 'codex-cli', 'antigravity-cli'] as AIProvider[]) {
+    const detection = await window.evaluate(
+      (p) => window.api.ai.detectHarness(p as AIProvider).then((r) => r.data),
+      provider
+    )
+    expect(detection?.available, `${provider} not detected: ${detection?.error}`).toBe(true)
+    expect(detection?.version, `${provider} reported no version`).toBeTruthy()
+    console.log(`  ${provider} → ${detection?.version} (${detection?.path})`)
+  }
+})
+
+test('claude grounds against the live DB when the MCP server is on', async ({ window }) => {
+  const schemas = await prepare(window, 'claude-cli')
+  await startMcp(window, 47241)
+
+  const res = await window.evaluate(
+    ([s, cfg]) =>
+      window.api.ai.chat(
+        [{ role: 'user', content: 'How many users are in this database?' }],
+        s as SchemaInfo[],
+        'postgresql',
+        (cfg as { id: string }).id
+      ),
+    [schemas, pg.config] as const
+  )
+
+  expect(res.error).toBeUndefined()
+  expect(res.success).toBe(true)
+  expect(res.meta?.agentic).toBe(true)
+  expect(res.meta?.grounded).toBe(true)
+  console.log(`  claude+MCP → grounded=${res.meta?.grounded} turns=${res.meta?.turns}`)
+})
+
+test('claude still answers with runnable SQL when the MCP server is off', async ({ window }) => {
+  const schemas = await prepare(window, 'claude-cli')
+  // Server defaults to off, but stop it explicitly so the assertion can't pass by luck.
+  await stopMcp(window)
+
+  const res = await window.evaluate(
+    ([s, cfg]) =>
+      window.api.ai.chat(
+        [{ role: 'user', content: 'How many users are in this database?' }],
+        s as SchemaInfo[],
+        'postgresql',
+        (cfg as { id: string }).id
+      ),
+    [schemas, pg.config] as const
+  )
+
+  expect(res.error).toBeUndefined()
+  expect(res.success).toBe(true)
+  // The whole point: chat degrades to schema-only instead of refusing to run.
+  expect(res.meta?.agentic).toBe(false)
+  expect(res.meta?.grounded).toBe(false)
+  expect(res.data?.sql, 'expected runnable SQL, not a fabricated prose answer').toBeTruthy()
+  console.log(`  claude−MCP → type=${res.data?.type} sql=${res.data?.sql}`)
+})
+
+for (const [index, provider] of (['codex-cli', 'antigravity-cli'] as AIProvider[]).entries()) {
+  test(`${provider} answers with SQL and claims no grounding`, async ({ window }) => {
+    const schemas = await prepare(window, provider)
+    // MCP up on purpose: these harnesses must stay non-agentic even when it's available.
+    await startMcp(window, 47242 + index)
+
+    const res = await window.evaluate(
+      ([s, cfg]) =>
+        window.api.ai.chat(
+          [{ role: 'user', content: 'How many users are in this database?' }],
+          s as SchemaInfo[],
+          'postgresql',
+          (cfg as { id: string }).id
+        ),
+      [schemas, pg.config] as const
+    )
+
+    expect(res.error).toBeUndefined()
+    expect(res.success).toBe(true)
+    expect(res.meta?.agentic).toBe(false)
+    expect(res.meta?.grounded).toBe(false)
+    expect(res.data?.sql, 'expected runnable SQL, not a fabricated prose answer').toBeTruthy()
+    expect(['query', 'metric', 'chart']).toContain(res.data?.type)
+    console.log(`  ${provider} → type=${res.data?.type} sql=${res.data?.sql}`)
+  })
+}
+
+test('codex dashboard generation is refused with a clear message', async ({ window }) => {
+  const schemas = await prepare(window, 'codex-cli')
+  // MCP up so the refusal is provably the capability gate, not a missing server.
+  await startMcp(window, 47244)
+
+  const res = await window.evaluate(
+    ([s, cfg]) =>
+      window.api.ai.generateDashboard(
+        'Design a useful overview dashboard',
+        s as SchemaInfo[],
+        'postgresql',
+        (cfg as { id: string }).id
+      ),
+    [schemas, pg.config] as const
+  )
+
+  expect(res.success).toBe(false)
+  expect(res.error).toContain('not supported by this harness yet')
+})
+
+test('switching provider mid-conversation starts a fresh CLI session', async ({ window }) => {
+  const schemas = await prepare(window, 'codex-cli')
+  await startMcp(window, 47245)
+
+  const first = await window.evaluate(
+    ([s, cfg]) =>
+      window.api.ai.chatStream(
+        [{ role: 'user', content: 'List the tables you can see.' }],
+        s as SchemaInfo[],
+        'postgresql',
+        (cfg as { id: string }).id,
+        undefined,
+        () => {}
+      ),
+    [schemas, pg.config] as const
+  )
+  expect(first.success, `codex turn failed: ${first.error}`).toBe(true)
+  const codexSession = first.meta?.sessionId
+  expect(codexSession, 'codex returned no session id to carry forward').toBeTruthy()
+
+  // Switch harness. The renderer drops a foreign session ref (resolveHarnessResumeId,
+  // unit-tested); the live assertion is that the next turn succeeds rather than
+  // dying on `--resume <codex-thread-id>`.
+  await window.evaluate(() =>
+    window.api.ai.setConfig({ provider: 'claude-cli' as AIProvider, model: 'default' })
+  )
+
+  const second = await window.evaluate(
+    ([s, cfg]) =>
+      window.api.ai.chatStream(
+        [{ role: 'user', content: 'Now count the rows in the users table.' }],
+        s as SchemaInfo[],
+        'postgresql',
+        (cfg as { id: string }).id,
+        undefined,
+        () => {}
+      ),
+    [schemas, pg.config] as const
+  )
+  expect(second.success, `claude turn after switch failed: ${second.error}`).toBe(true)
+  expect(second.meta?.sessionId).not.toBe(codexSession)
+  console.log(`  codex session ${codexSession} → claude session ${second.meta?.sessionId}`)
+})


### PR DESCRIPTION
## Summary

#254 and #255 both shipped with a hand-written *"manual checklist before release"* because the BYOH harness had no end-to-end coverage — the adapters are well tested against captured CLI fixtures, but nothing exercised them through the app against a real database. Ran that checklist manually against v0.29.0 (all green), then automated it so the next harness release doesn't need a human with three CLIs and a seed DB.

## What it checks

Seven checks over the real `claude` / `codex` / `agy` CLIs and a seeded Postgres container:

| Check | Asserts |
|---|---|
| CLI detection ×3 | each provider `available` with a version string |
| claude + MCP **on** | `agentic: true`, `grounded: true` |
| claude + MCP **off** | succeeds, `grounded: false`, still returns runnable SQL |
| codex / agy (MCP **on**) | non-agentic regardless, SQL present, type is query/metric/chart |
| codex dashboard | refused with "not supported by this harness yet" |
| provider switch mid-chat | claude turn after a codex turn succeeds with a new session id |

The MCP-off case is the one worth having: without it, nothing stopped a regression that made grounding a hard requirement for chat instead of an upgrade to it.

## Gating

`test.skip(!process.env.BYOH_LIVE)` — CI skips all seven (verified locally: `7 skipped`). The runners have none of the CLIs, signed in or otherwise, and a real run burns subscription quota. The adapters' deterministic coverage stays in `src/main/harness/__tests__/`, from captured fixtures.

```bash
BYOH_LIVE=1 pnpm exec playwright test byoh-harness-live --workers=1
```

## Notes on fidelity

- Drives the **IPC surface** (`window.api.ai.chat` / `chatStream` / `detectHarness`), not the chat UI — so it asserts the `meta.grounded` flag the badge renders from, not the pixels. Same for the Settings → AI detection row.
- The provider-switch check asserts the positive path; the guard itself (`resolveHarnessResumeId`) already has unit coverage in `harness-session-ref.test.ts`.
- MCP ports are set per test (`47241`+) instead of the `4722` default, same convention as `mcp-server.spec.ts`. A locally running data-peek usually holds 4722 and `mcp.setEnabled(true)` rejects on a busy port rather than falling back — which is exactly how an earlier iteration of this spec failed.

## Verification

`7 passed (2.9m)` against claude 2.1.224, codex-cli 0.146.0, and agy **1.1.10** — a bump from the 1.1.8 #255 verified against, so the newer `agy` is now covered. Observed live: claude grounded in 4 turns; codex returned `SELECT COUNT(*) AS user_count FROM public.users AS u` with no live access; agy returned a metric with `SELECT COUNT(*) FROM users`. eslint + prettier clean.

https://claude.ai/code/session_014BfHTX6G2tfWNq8cmwCRbU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added an opt-in live end-to-end test suite covering AI provider responses, tool-assisted grounding, SQL fallback behavior, authentication detection, dashboard safeguards, and session switching.
  * Added coverage for consistent behavior across supported AI integrations and configurations.

* **Documentation**
  * Documented how to run the live test harness, including authentication, timing, port configuration, and CI limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->