### PR TITLE
fix(desktop): harden connection lifecycle — session pool isolation, MySQL/MSSQL pooling, keepalive

### DIFF
--- a/apps/desktop/src/main/__tests__/connection-handlers.test.ts
+++ b/apps/desktop/src/main/__tests__/connection-handlers.test.ts
@@ -3,11 +3,20 @@ import type { ConnectionConfig } from '@shared/index'
 
 type Handler = (event: unknown, ...args: unknown[]) => unknown
 
-const { handlers, closePgPool, invalidateSchemaCache, broadcastToAll } = vi.hoisted(() => ({
+const {
+  handlers,
+  closePgPool,
+  invalidateSchemaCache,
+  broadcastToAll,
+  drainSessions,
+  getAdapterByType
+} = vi.hoisted(() => ({
   handlers: new Map<string, Handler>(),
   closePgPool: vi.fn(),
   invalidateSchemaCache: vi.fn(),
-  broadcastToAll: vi.fn()
+  broadcastToAll: vi.fn(),
+  drainSessions: vi.fn(),
+  getAdapterByType: vi.fn()
 }))
 
 vi.mock('electron', () => ({
@@ -18,6 +27,7 @@ vi.mock('electron', () => ({
   }
 }))
 vi.mock('../adapters/pg-pool-manager', () => ({ closePgPool }))
+vi.mock('../db-adapter', () => ({ getAdapterByType }))
 vi.mock('../schema-cache', () => ({ invalidateSchemaCache }))
 vi.mock('../window-manager', () => ({ windowManager: { broadcastToAll } }))
 vi.mock('../lib/logger', () => ({
@@ -54,6 +64,8 @@ beforeEach(() => {
   closePgPool.mockReset().mockResolvedValue(undefined)
   invalidateSchemaCache.mockReset()
   broadcastToAll.mockReset()
+  drainSessions.mockReset().mockResolvedValue(undefined)
+  getAdapterByType.mockReset().mockReturnValue({ drainSessions })
 })
 
 describe('connections:update', () => {
@@ -90,6 +102,37 @@ describe('connections:update', () => {
     expect((result as { success: boolean }).success).toBe(true)
     // Let the teardown promise reject; the .catch handler should swallow it.
     await new Promise((resolve) => setImmediate(resolve))
+  })
+
+  it('drains open transactions before tearing the pool down', async () => {
+    // A parked session client keeps the pool's teardown pending, so the rollback has to
+    // land first or the transaction is left open server-side holding its locks.
+    const order: string[] = []
+    drainSessions.mockImplementationOnce(async () => {
+      order.push('drain')
+    })
+    closePgPool.mockImplementationOnce(async () => {
+      order.push('close')
+    })
+    registerConnectionHandlers(makeStore([{ ...previous }]))
+
+    handlers.get('connections:update')!(null, { ...previous, host: 'new-host' })
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(order).toEqual(['drain', 'close'])
+    expect(drainSessions).toHaveBeenCalledWith(
+      expect.objectContaining({ host: 'old-host.example.com' })
+    )
+  })
+
+  it('still tears the pool down when the drain fails', async () => {
+    drainSessions.mockRejectedValueOnce(new Error('rollback blew up'))
+    registerConnectionHandlers(makeStore([{ ...previous }]))
+
+    handlers.get('connections:update')!(null, { ...previous, host: 'new-host' })
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(closePgPool).toHaveBeenCalledTimes(1)
   })
 
   it('broadcasts to renderers before scheduling teardown', () => {

--- a/apps/desktop/src/main/__tests__/connection-handlers.test.ts
+++ b/apps/desktop/src/main/__tests__/connection-handlers.test.ts
@@ -9,14 +9,18 @@ const {
   invalidateSchemaCache,
   broadcastToAll,
   drainSessions,
-  getAdapterByType
+  getAdapterByType,
+  closeMySQLPool,
+  closeMSSQLPool
 } = vi.hoisted(() => ({
   handlers: new Map<string, Handler>(),
   closePgPool: vi.fn(),
   invalidateSchemaCache: vi.fn(),
   broadcastToAll: vi.fn(),
   drainSessions: vi.fn(),
-  getAdapterByType: vi.fn()
+  getAdapterByType: vi.fn(),
+  closeMySQLPool: vi.fn(),
+  closeMSSQLPool: vi.fn()
 }))
 
 vi.mock('electron', () => ({
@@ -28,6 +32,8 @@ vi.mock('electron', () => ({
 }))
 vi.mock('../adapters/pg-pool-manager', () => ({ closePgPool }))
 vi.mock('../db-adapter', () => ({ getAdapterByType }))
+vi.mock('../adapters/mysql-pool-manager', () => ({ closeMySQLPool }))
+vi.mock('../adapters/mssql-pool-manager', () => ({ closeMSSQLPool }))
 vi.mock('../schema-cache', () => ({ invalidateSchemaCache }))
 vi.mock('../window-manager', () => ({ windowManager: { broadcastToAll } }))
 vi.mock('../lib/logger', () => ({
@@ -66,6 +72,8 @@ beforeEach(() => {
   broadcastToAll.mockReset()
   drainSessions.mockReset().mockResolvedValue(undefined)
   getAdapterByType.mockReset().mockReturnValue({ drainSessions })
+  closeMySQLPool.mockReset().mockResolvedValue(undefined)
+  closeMSSQLPool.mockReset().mockResolvedValue(undefined)
 })
 
 describe('connections:update', () => {
@@ -143,6 +151,52 @@ describe('connections:update', () => {
 
     // broadcast should run synchronously inside the handler, before the await tick.
     expect(broadcastToAll).toHaveBeenCalledWith('connections:updated')
+  })
+})
+
+describe('teardown dispatch by driver', () => {
+  // Every pooled driver has to be routed to its own closer and drained through its own
+  // adapter — a connection whose pool is never closed keeps its sockets and, over SSH,
+  // its tunnel for the rest of the session.
+  it.each([
+    ['mysql' as const, () => closeMySQLPool, () => [closePgPool, closeMSSQLPool]],
+    ['mssql' as const, () => closeMSSQLPool, () => [closePgPool, closeMySQLPool]],
+    ['postgresql' as const, () => closePgPool, () => [closeMySQLPool, closeMSSQLPool]]
+  ])('routes %s teardown to its own pool closer', async (dbType, expected, others) => {
+    registerConnectionHandlers(makeStore([{ ...previous, dbType }]))
+
+    handlers.get('connections:delete')!(null, 'conn-1')
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(expected()).toHaveBeenCalledWith(expect.objectContaining({ id: 'conn-1', dbType }))
+    for (const other of others()) expect(other).not.toHaveBeenCalled()
+    expect(getAdapterByType).toHaveBeenCalledWith(dbType)
+    expect(drainSessions).toHaveBeenCalledWith(expect.objectContaining({ dbType }))
+  })
+
+  it('tears the pool down for an adapter that has no drainSessions hook', async () => {
+    // Only Postgres parks clients today; the others must not be skipped for lacking it.
+    getAdapterByType.mockReturnValue({})
+    registerConnectionHandlers(makeStore([{ ...previous, dbType: 'mysql' }]))
+
+    handlers.get('connections:delete')!(null, 'conn-1')
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(closeMySQLPool).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not attempt a pool teardown for SQLite', async () => {
+    // SQLite opens the file per call and holds no pool or tunnel.
+    registerConnectionHandlers(makeStore([{ ...previous, dbType: 'sqlite' }]))
+
+    handlers.get('connections:delete')!(null, 'conn-1')
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(closePgPool).not.toHaveBeenCalled()
+    expect(closeMySQLPool).not.toHaveBeenCalled()
+    expect(closeMSSQLPool).not.toHaveBeenCalled()
+    // The cache is still connection-scoped, so it must be invalidated regardless.
+    expect(invalidateSchemaCache).toHaveBeenCalledWith(expect.objectContaining({ id: 'conn-1' }))
   })
 })
 

--- a/apps/desktop/src/main/__tests__/pg-pool-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/pg-pool-manager.test.ts
@@ -25,14 +25,19 @@ import { createTunnel, closeTunnel, type TunnelSession } from '../ssh-tunnel-ser
 import {
   withPgClient,
   withPgTransaction,
+  acquirePgSessionClient,
   closeAllPgPools,
-  closePgPool
+  closePgPool,
+  type PgSessionLease
 } from '../adapters/pg-pool-manager'
 
 // Each `new Pool()` hands back its own object (delegating to the shared spies) so a test
 // can tell which specific pool was ended when a connection's shape changes.
 interface FakePool {
   end: ReturnType<typeof vi.fn>
+  // Per-instance so a test can tell *which* pool a client was checked out of — the
+  // point of the session pool is that its clients don't come from the query pool.
+  connect: ReturnType<typeof vi.fn>
 }
 const createdPools: FakePool[] = []
 
@@ -64,7 +69,7 @@ beforeEach(() => {
   createdPools.length = 0
   PoolCtor.mockImplementation(function (this: unknown) {
     const instance = {
-      connect: (...args: unknown[]) => mockPool.connect(...args),
+      connect: vi.fn((...args: unknown[]) => mockPool.connect(...args)),
       end: vi.fn((...args: unknown[]) => mockPool.end(...args)),
       on: (...args: unknown[]) => mockPool.on(...args)
     }
@@ -194,6 +199,7 @@ describe('withPgClient', () => {
     const tunnel: TunnelSession = {
       ssh: null,
       server: null,
+      sockets: new Set(),
       localHost: '127.0.0.1',
       localPort: 54320
     }
@@ -267,6 +273,118 @@ describe('withPgTransaction', () => {
     ).rejects.toBe(original)
 
     expect(mockClient.release).toHaveBeenCalledWith(true)
+  })
+})
+
+describe('acquirePgSessionClient', () => {
+  // A manual transaction holds its client until the user commits. Serving those from the
+  // query pool meant POOL_MAX open transactions consumed every slot, after which ordinary
+  // queries blocked on pool.connect() and failed with pg's generic connection timeout.
+  const SESSION_POOL_MAX = 4
+
+  it('checks out session clients from a pool separate from the query pool', async () => {
+    const cfg = makeConfig()
+    await withPgClient(cfg, async () => {})
+    expect(createdPools).toHaveLength(1)
+
+    await acquirePgSessionClient(cfg)
+
+    expect(createdPools).toHaveLength(2)
+    const [queryPool, sessionPool] = createdPools
+    // The query pool served only the withPgClient call, not the session checkout.
+    expect(queryPool.connect).toHaveBeenCalledTimes(1)
+    expect(sessionPool.connect).toHaveBeenCalledTimes(1)
+  })
+
+  it('leaves the query pool untouched when every session slot is parked', async () => {
+    const cfg = makeConfig()
+    for (let i = 0; i < SESSION_POOL_MAX; i++) {
+      await acquirePgSessionClient(cfg)
+    }
+
+    await withPgClient(cfg, async () => {})
+
+    const [queryPool, sessionPool] = createdPools
+    expect(sessionPool.connect).toHaveBeenCalledTimes(SESSION_POOL_MAX)
+    expect(queryPool.connect).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects the overflowing session with an actionable message, not a connect timeout', async () => {
+    const cfg = makeConfig()
+    for (let i = 0; i < SESSION_POOL_MAX; i++) {
+      await acquirePgSessionClient(cfg)
+    }
+
+    await expect(acquirePgSessionClient(cfg)).rejects.toThrow(
+      /already has 4 open transactions.*Commit or roll one back/s
+    )
+    // It must fail without even trying to queue behind the parked clients.
+    expect(createdPools[1].connect).toHaveBeenCalledTimes(SESSION_POOL_MAX)
+  })
+
+  it('frees the slot on release', async () => {
+    const cfg = makeConfig()
+    const leases: PgSessionLease[] = []
+    for (let i = 0; i < SESSION_POOL_MAX; i++) {
+      leases.push(await acquirePgSessionClient(cfg))
+    }
+
+    leases[0].release()
+
+    await expect(acquirePgSessionClient(cfg)).resolves.toBeDefined()
+    expect(mockClient.release).toHaveBeenCalledTimes(1)
+  })
+
+  it('frees the slot when the checkout itself fails', async () => {
+    const cfg = makeConfig()
+    await acquirePgSessionClient(cfg)
+    mockPool.connect.mockRejectedValueOnce(new Error('server refused'))
+
+    await expect(acquirePgSessionClient(cfg)).rejects.toThrow('server refused')
+
+    // The failed attempt must not have burned a slot permanently.
+    for (let i = 0; i < SESSION_POOL_MAX - 1; i++) {
+      await expect(acquirePgSessionClient(cfg)).resolves.toBeDefined()
+    }
+    await expect(acquirePgSessionClient(cfg)).rejects.toThrow(/open transactions/)
+  })
+
+  it('is idempotent on release, so a cancellation path cannot free a slot twice', async () => {
+    const cfg = makeConfig()
+    const lease = await acquirePgSessionClient(cfg)
+
+    lease.release(true)
+    lease.release()
+    lease.release()
+
+    expect(mockClient.release).toHaveBeenCalledTimes(1)
+    expect(mockClient.release).toHaveBeenCalledWith(true)
+
+    // Exactly one slot came back, not three.
+    for (let i = 0; i < SESSION_POOL_MAX; i++) {
+      await expect(acquirePgSessionClient(cfg)).resolves.toBeDefined()
+    }
+    await expect(acquirePgSessionClient(cfg)).rejects.toThrow(/open transactions/)
+  })
+
+  it('ends the session pool alongside the query pool on teardown', async () => {
+    const cfg = makeConfig()
+    await acquirePgSessionClient(cfg)
+
+    await closeAllPgPools()
+
+    expect(createdPools).toHaveLength(2)
+    expect(createdPools[0].end).toHaveBeenCalledTimes(1)
+    expect(createdPools[1].end).toHaveBeenCalledTimes(1)
+  })
+
+  it('ends the session pool when a single connection is closed', async () => {
+    const cfg = makeConfig()
+    await acquirePgSessionClient(cfg)
+
+    await closePgPool(cfg)
+
+    expect(createdPools[1].end).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/apps/desktop/src/main/__tests__/pool-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/pool-registry.test.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { ConnectionConfig } from '@shared/index'
+
+vi.mock('../ssh-tunnel-service', () => ({
+  createTunnel: vi.fn(),
+  closeTunnel: vi.fn()
+}))
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}))
+
+import { createTunnel, closeTunnel, type TunnelSession } from '../ssh-tunnel-service'
+import { PoolRegistry, type PoolRegistryOptions } from '../adapters/pool-registry'
+
+/**
+ * The registry is shared by every driver, so these cover the lifecycle guarantees the
+ * adapters rely on rather than any one driver's pool type.
+ */
+
+interface FakePool {
+  id: number
+  destroyed: boolean
+}
+
+let nextPoolId = 0
+let created: FakePool[] = []
+let destroy: ReturnType<typeof vi.fn<(pool: FakePool) => Promise<void>>>
+
+function newFakePool(): FakePool {
+  const pool = { id: nextPoolId++, destroyed: false }
+  created.push(pool)
+  return pool
+}
+
+function makeRegistry(overrides: Partial<PoolRegistryOptions<FakePool>> = {}) {
+  return new PoolRegistry<FakePool>({
+    driver: 'fake',
+    create: newFakePool,
+    destroy,
+    ...overrides
+  })
+}
+
+let counter = 0
+function makeConfig(overrides: Partial<ConnectionConfig> = {}): ConnectionConfig {
+  return {
+    id: `cfg-${++counter}`,
+    name: 'test',
+    host: 'localhost',
+    port: 5432,
+    database: 'db',
+    user: 'u',
+    password: 'p',
+    dbType: 'postgresql',
+    dstPort: 5432,
+    ...overrides
+  }
+}
+
+function makeTunnel(port = 54320): TunnelSession {
+  return {
+    ssh: null,
+    server: null,
+    sockets: new Set(),
+    localHost: '127.0.0.1',
+    localPort: port
+  }
+}
+
+beforeEach(() => {
+  nextPoolId = 0
+  created = []
+  destroy = vi.fn(async (pool: FakePool) => {
+    pool.destroyed = true
+  })
+  vi.mocked(createTunnel).mockReset()
+  vi.mocked(closeTunnel).mockReset()
+})
+
+describe('PoolRegistry', () => {
+  it('shares one pool across concurrent first-use callers', async () => {
+    const registry = makeRegistry()
+    const cfg = makeConfig()
+
+    const entries = await Promise.all(Array.from({ length: 5 }, () => registry.getOrCreate(cfg)))
+
+    expect(created).toHaveLength(1)
+    expect(new Set(entries.map((e) => e.pool.id)).size).toBe(1)
+  })
+
+  it('reuses one pool across sequential acquisitions', async () => {
+    const registry = makeRegistry()
+    const cfg = makeConfig()
+
+    await registry.getOrCreate(cfg)
+    await registry.getOrCreate(cfg)
+
+    expect(created).toHaveLength(1)
+  })
+
+  it('builds a new pool when the connection shape changes, and retires the old one', async () => {
+    // Ticking "Use SSL" on a saved connection must not reuse the plaintext pool.
+    const registry = makeRegistry()
+    const saved = makeConfig()
+    await registry.getOrCreate(saved)
+
+    await registry.getOrCreate({ ...saved, ssl: true })
+
+    expect(created).toHaveLength(2)
+    expect(created[0].destroyed).toBe(true)
+    expect(created[1].destroyed).toBe(false)
+  })
+
+  it('keys driver-specific config through fingerprintExtras', async () => {
+    const registry = makeRegistry({
+      fingerprintExtras: (config: ConnectionConfig) => ({ schema: config.schema ?? '' })
+    })
+    const base = makeConfig()
+
+    await registry.getOrCreate({ ...base, schema: 'bbl' })
+    await registry.getOrCreate({ ...base, schema: 'fel' })
+
+    expect(created).toHaveLength(2)
+  })
+
+  it('does not collide across drivers sharing one connection id', async () => {
+    const a = makeRegistry()
+    const b = new PoolRegistry<FakePool>({ driver: 'other', create: newFakePool, destroy })
+    const cfg = makeConfig()
+
+    await a.getOrCreate(cfg)
+    await b.getOrCreate(cfg)
+
+    expect(created).toHaveLength(2)
+  })
+
+  it('closes a connection built from a newer shape when handed the pre-edit config', async () => {
+    // connections:update tears down using the *previous* stored config, while a Test
+    // Connection during that edit may already have built a pool from the new shape.
+    const registry = makeRegistry()
+    const saved = makeConfig()
+    const edited = { ...saved, ssl: true }
+    await registry.getOrCreate(edited)
+
+    await registry.close(saved)
+
+    expect(created[0].destroyed).toBe(true)
+    await registry.getOrCreate(edited)
+    expect(created).toHaveLength(2)
+  })
+
+  it('disposes a pool whose creation finished after it was superseded', async () => {
+    // SSH tunnel setup widens this window considerably.
+    const registry = makeRegistry()
+    const cfg = makeConfig({
+      ssh: true,
+      sshConfig: {
+        host: 'bastion',
+        port: 22,
+        user: 'x',
+        authMethod: 'Password',
+        privateKeyPath: ''
+      }
+    })
+
+    let finishSlowDial: (t: TunnelSession) => void = () => {}
+    vi.mocked(createTunnel).mockReturnValueOnce(
+      new Promise<TunnelSession>((resolve) => {
+        finishSlowDial = resolve
+      })
+    )
+    const slow = registry.getOrCreate(cfg)
+
+    // A newer shape lands and installs while the first is still dialing.
+    vi.mocked(createTunnel).mockResolvedValueOnce(makeTunnel(54321))
+    await registry.getOrCreate({ ...cfg, ssl: true })
+
+    finishSlowDial(makeTunnel())
+    await expect(slow).rejects.toThrow(/closed before initialization/)
+
+    // The slow dial builds its pool last, when its tunnel finally resolves. It must tear
+    // itself down rather than linger as a second live pool under one identity, while the
+    // newer shape that won the race stays up.
+    expect(created).toHaveLength(2)
+    expect(created[0].destroyed).toBe(false)
+    expect(created[1].destroyed).toBe(true)
+  })
+
+  it('leaves the registry reusable after closeAll (guard is transient, not latched)', async () => {
+    // On macOS the process routinely outlives a cleanup pass.
+    const registry = makeRegistry()
+    await registry.getOrCreate(makeConfig())
+
+    await registry.closeAll()
+
+    await expect(registry.getOrCreate(makeConfig())).resolves.toBeDefined()
+  })
+
+  it('does not wedge when a destroy() hangs', async () => {
+    vi.useFakeTimers()
+    try {
+      const registry = makeRegistry()
+      await registry.getOrCreate(makeConfig())
+      destroy.mockReturnValueOnce(new Promise<void>(() => {}))
+
+      const closed = registry.closeAll()
+      await vi.advanceTimersByTimeAsync(2_500)
+      await expect(closed).resolves.toBeUndefined()
+
+      await expect(registry.getOrCreate(makeConfig())).resolves.toBeDefined()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('coalesces concurrent closeAll calls without wedging the guard', async () => {
+    const registry = makeRegistry()
+    await registry.getOrCreate(makeConfig())
+
+    await Promise.all([registry.closeAll(), registry.closeAll()])
+
+    await expect(registry.getOrCreate(makeConfig())).resolves.toBeDefined()
+  })
+
+  it('closes the tunnel when pool creation throws', async () => {
+    const tunnel = makeTunnel()
+    vi.mocked(createTunnel).mockResolvedValueOnce(tunnel)
+    const registry = makeRegistry({
+      create: () => {
+        throw new Error('handshake rejected')
+      }
+    })
+
+    await expect(
+      registry.getOrCreate(
+        makeConfig({
+          ssh: true,
+          sshConfig: {
+            host: 'bastion',
+            port: 22,
+            user: 'x',
+            authMethod: 'Password',
+            privateKeyPath: ''
+          }
+        })
+      )
+    ).rejects.toThrow('handshake rejected')
+
+    expect(closeTunnel).toHaveBeenCalledWith(tunnel)
+  })
+
+  it('passes the tunnel endpoint to create() as host/port overrides', async () => {
+    const create = vi.fn(newFakePool)
+    vi.mocked(createTunnel).mockResolvedValueOnce(makeTunnel(54999))
+    const registry = makeRegistry({ create })
+
+    await registry.getOrCreate(
+      makeConfig({
+        ssh: true,
+        sshConfig: {
+          host: 'bastion',
+          port: 22,
+          user: 'x',
+          authMethod: 'Password',
+          privateKeyPath: ''
+        }
+      })
+    )
+
+    expect(create).toHaveBeenCalledWith(expect.anything(), { host: '127.0.0.1', port: 54999 })
+  })
+
+  it('passes no overrides when the connection does not use SSH', async () => {
+    const create = vi.fn(newFakePool)
+    const registry = makeRegistry({ create })
+
+    await registry.getOrCreate(makeConfig())
+
+    expect(create).toHaveBeenCalledWith(expect.anything(), undefined)
+    expect(createTunnel).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/main/__tests__/pool-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/pool-registry.test.ts
@@ -186,6 +186,37 @@ describe('PoolRegistry', () => {
     expect(created[1].destroyed).toBe(true)
   })
 
+  it('still closes the tunnel when close() hits a hanging destroy()', async () => {
+    // closeTunnel runs after the destroy, so an unbounded destroy that never settles
+    // would strand the SSH tunnel and its bound local port for the rest of the session.
+    vi.useFakeTimers()
+    try {
+      const tunnel = makeTunnel()
+      vi.mocked(createTunnel).mockResolvedValueOnce(tunnel)
+      const registry = makeRegistry()
+      const cfg = makeConfig({
+        ssh: true,
+        sshConfig: {
+          host: 'bastion',
+          port: 22,
+          user: 'x',
+          authMethod: 'Password',
+          privateKeyPath: ''
+        }
+      })
+      await registry.getOrCreate(cfg)
+      destroy.mockReturnValueOnce(new Promise<void>(() => {}))
+
+      const closed = registry.close(cfg)
+      await vi.advanceTimersByTimeAsync(2_500)
+      await expect(closed).resolves.toBeUndefined()
+
+      expect(closeTunnel).toHaveBeenCalledWith(tunnel)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('leaves the registry reusable after closeAll (guard is transient, not latched)', async () => {
     // On macOS the process routinely outlives a cleanup pass.
     const registry = makeRegistry()

--- a/apps/desktop/src/main/adapters/mssql-adapter.ts
+++ b/apps/desktop/src/main/adapters/mssql-adapter.ts
@@ -36,9 +36,18 @@ import type {
   QueryOptions
 } from '../db-adapter'
 import { registerQuery, unregisterQuery } from '../query-tracker'
-import { closeTunnel, createTunnel, TunnelSession } from '../ssh-tunnel-service'
+import { toMSSQLConfig } from './mssql-client-config'
+import {
+  withMSSQLPool,
+  withMSSQLTransaction,
+  withDedicatedMSSQLConnection
+} from './mssql-pool-manager'
 import { splitStatements } from '../lib/sql-parser'
 import { telemetryCollector, TELEMETRY_PHASES } from '../telemetry-collector'
+
+// Re-exported because it was part of this module's surface before it moved out to break
+// an import cycle with the pool manager.
+export { toMSSQLConfig }
 
 /** Split SQL into statements for MSSQL */
 const splitMssqlStatements = (sqlText: string) => splitStatements(sqlText, 'mssql')
@@ -128,93 +137,6 @@ function bindParameter(request: sql.Request, paramName: string, value: unknown):
 }
 
 /**
- * Create MSSQL connection config from our ConnectionConfig
- */
-export function toMSSQLConfig(
-  config: ConnectionConfig,
-  overrides?: { host: string; port: number }
-): sql.config {
-  const mssqlOptions = config.mssqlOptions || {}
-
-  // Handle authentication methods first to determine what options are needed
-  const authentication = mssqlOptions.authentication
-  const isAzureAD = authentication === 'ActiveDirectoryIntegrated'
-
-  // Build options object - for Azure AD, keep it minimal
-  const defaultSsl = config.ssl ?? false
-  const options: sql.config['options'] = {}
-
-  // Always set encrypt if specified
-  if (mssqlOptions.encrypt !== undefined) {
-    options.encrypt = mssqlOptions.encrypt
-  } else if (defaultSsl) {
-    options.encrypt = true
-  }
-
-  // For Azure AD, don't set trustServerCertificate or enableArithAbort
-  // These can interfere with Azure AD authentication
-  if (!isAzureAD) {
-    if (mssqlOptions.trustServerCertificate !== undefined) {
-      options.trustServerCertificate = mssqlOptions.trustServerCertificate
-    } else if (!defaultSsl) {
-      options.trustServerCertificate = true
-    }
-    options.enableArithAbort = mssqlOptions.enableArithAbort ?? true
-  }
-
-  // Add connection timeout if specified
-  if (mssqlOptions.connectionTimeout !== undefined) {
-    options.connectTimeout = mssqlOptions.connectionTimeout
-  }
-
-  // Set request timeout (default to 0 = no timeout to allow long-running queries)
-  // The mssql library defaults to 15000ms which is too short for complex queries
-  options.requestTimeout = mssqlOptions.requestTimeout ?? 0
-
-  // Build base config
-  const sqlConfig: sql.config = {
-    server: overrides?.host ?? config.host,
-    database: config.database,
-    options
-  }
-
-  // Include port if provided (optional in mssql config)
-  if (overrides?.port) {
-    sqlConfig.port = overrides.port
-  } else if (config.port) {
-    sqlConfig.port = config.port
-  }
-
-  // Handle authentication methods
-  if (authentication === 'ActiveDirectoryIntegrated') {
-    // Azure AD Integrated Authentication - uses azure-active-directory-default
-    sqlConfig.authentication = {
-      type: 'azure-active-directory-default',
-      options: {}
-    }
-    // Explicitly don't set user/password for Azure AD authentication
-    // Even if they exist in config, we should not include them
-  } else if (authentication === 'ActiveDirectoryPassword') {
-    // Azure AD Password Authentication
-    // Note: This requires clientId and tenantId which aren't in our config yet
-    // For now, use SQL Server auth as fallback
-    if (config.user) sqlConfig.user = config.user
-    if (config.password) sqlConfig.password = config.password
-  } else if (authentication === 'ActiveDirectoryServicePrincipal') {
-    // Azure AD Service Principal - would need clientId and clientSecret
-    // For now, fall back to SQL Server auth
-    if (config.user) sqlConfig.user = config.user
-    if (config.password) sqlConfig.password = config.password
-  } else {
-    // Default: SQL Server Authentication
-    if (config.user) sqlConfig.user = config.user
-    if (config.password) sqlConfig.password = config.password
-  }
-
-  return sqlConfig
-}
-
-/**
  * Check if a SQL statement is data-returning (SELECT, etc.)
  */
 export function isDataReturningStatement(sqlText: string): boolean {
@@ -235,37 +157,15 @@ export class MSSQLAdapter implements DatabaseAdapter {
   readonly dbType = 'mssql' as const
 
   async connect(config: ConnectionConfig): Promise<void> {
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-    const pool = new sql.ConnectionPool(toMSSQLConfig(config, tunnelOverrides))
-    try {
-      await pool.connect()
-      await pool.close()
-    } catch (error) {
-      await pool.close().catch(() => {})
-      throw error
-    } finally {
-      closeTunnel(tunnelSession)
-    }
+    // Warm the pool AND verify the socket end-to-end. Connecting alone can be satisfied
+    // by an already-open pooled connection; SELECT 1 proves it's live.
+    await withMSSQLPool(config, async (pool) => {
+      await pool.request().query('SELECT 1')
+    })
   }
 
   async query(config: ConnectionConfig, sqlQuery: string): Promise<AdapterQueryResult> {
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-    const pool = new sql.ConnectionPool(toMSSQLConfig(config, tunnelOverrides))
-
-    try {
-      await pool.connect()
+    return withMSSQLPool(config, async (pool) => {
       const result = await pool.request().query(sqlQuery)
       const rows = result.recordset as Record<string, unknown>[]
       const fields: QueryField[] = []
@@ -322,10 +222,7 @@ export class MSSQLAdapter implements DatabaseAdapter {
       }
 
       return { rows, fields, rowCount: result.rowsAffected[0] ?? rows.length }
-    } finally {
-      await pool.close().catch(() => {})
-      closeTunnel(tunnelSession)
-    }
+    })
   }
 
   async queryMultiple(
@@ -342,193 +239,179 @@ export class MSSQLAdapter implements DatabaseAdapter {
       telemetryCollector.startPhase(executionId, TELEMETRY_PHASES.TCP_HANDSHAKE)
     }
 
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-
-    const pool = new sql.ConnectionPool(toMSSQLConfig(config, tunnelOverrides))
     const totalStart = Date.now()
     const results: StatementResult[] = []
     let totalRowCount = 0
 
-    try {
-      if (collectTelemetry) {
-        telemetryCollector.endPhase(executionId, TELEMETRY_PHASES.TCP_HANDSHAKE)
-        telemetryCollector.startPhase(executionId, TELEMETRY_PHASES.DB_HANDSHAKE)
-      }
+    return withMSSQLPool(config, async (pool) => {
+      try {
+        if (collectTelemetry) {
+          telemetryCollector.endPhase(executionId, TELEMETRY_PHASES.TCP_HANDSHAKE)
+          telemetryCollector.startPhase(executionId, TELEMETRY_PHASES.DB_HANDSHAKE)
+          telemetryCollector.endPhase(executionId, TELEMETRY_PHASES.DB_HANDSHAKE)
+        }
+        const statements = splitMssqlStatements(sqlQuery)
 
-      await pool.connect()
+        for (let i = 0; i < statements.length; i++) {
+          const statement = statements[i]
+          const stmtStart = Date.now()
 
-      if (collectTelemetry) {
-        telemetryCollector.endPhase(executionId, TELEMETRY_PHASES.DB_HANDSHAKE)
-      }
-      const statements = splitMssqlStatements(sqlQuery)
+          try {
+            const request = pool.request()
 
-      for (let i = 0; i < statements.length; i++) {
-        const statement = statements[i]
-        const stmtStart = Date.now()
+            // Set per-request timeout if specified (overrides connection-level timeout)
+            const queryTimeoutMs = options?.queryTimeoutMs
+            if (
+              queryTimeoutMs !== undefined &&
+              typeof queryTimeoutMs === 'number' &&
+              Number.isFinite(queryTimeoutMs)
+            ) {
+              // The mssql library supports request.timeout at runtime but types don't expose it
+              ;(request as unknown as { timeout: number }).timeout = Math.max(
+                0,
+                Math.floor(queryTimeoutMs)
+              )
+            }
 
-        try {
-          const request = pool.request()
+            // Register the current request for cancellation support
+            if (options?.executionId) {
+              registerQuery(options.executionId, { type: 'mssql', request })
+            }
 
-          // Set per-request timeout if specified (overrides connection-level timeout)
-          const queryTimeoutMs = options?.queryTimeoutMs
-          if (
-            queryTimeoutMs !== undefined &&
-            typeof queryTimeoutMs === 'number' &&
-            Number.isFinite(queryTimeoutMs)
-          ) {
-            // The mssql library supports request.timeout at runtime but types don't expose it
-            ;(request as unknown as { timeout: number }).timeout = Math.max(
-              0,
-              Math.floor(queryTimeoutMs)
-            )
-          }
+            // Start execution phase timing
+            if (collectTelemetry) {
+              telemetryCollector.startPhase(executionId, TELEMETRY_PHASES.EXECUTION)
+            }
 
-          // Register the current request for cancellation support
-          if (options?.executionId) {
-            registerQuery(options.executionId, { type: 'mssql', request })
-          }
+            const result = await request.query(statement)
 
-          // Start execution phase timing
-          if (collectTelemetry) {
-            telemetryCollector.startPhase(executionId, TELEMETRY_PHASES.EXECUTION)
-          }
+            if (collectTelemetry) {
+              telemetryCollector.endPhase(executionId, TELEMETRY_PHASES.EXECUTION)
+              telemetryCollector.startPhase(executionId, TELEMETRY_PHASES.PARSE)
+            }
 
-          const result = await request.query(statement)
+            const stmtDuration = Date.now() - stmtStart
 
-          if (collectTelemetry) {
-            telemetryCollector.endPhase(executionId, TELEMETRY_PHASES.EXECUTION)
-            telemetryCollector.startPhase(executionId, TELEMETRY_PHASES.PARSE)
-          }
+            const rows = (result.recordset || []) as Record<string, unknown>[]
+            const fields: QueryField[] = []
 
-          const stmtDuration = Date.now() - stmtStart
+            if (result.recordset?.columns) {
+              let colIndex = 0
+              for (const col of Object.values(result.recordset.columns)) {
+                const meta = col as { name: string; type?: { id?: number; name?: string } }
+                let dataTypeID: number | undefined
+                let dataType: string
 
-          const rows = (result.recordset || []) as Record<string, unknown>[]
-          const fields: QueryField[] = []
+                // MSSQL returns empty string for unnamed columns (e.g., COUNT(*), SUM(), etc.)
+                // Generate a fallback name and remap the row data
+                const originalName = meta.name
+                const columnName = originalName || `column_${colIndex + 1}`
 
-          if (result.recordset?.columns) {
-            let colIndex = 0
-            for (const col of Object.values(result.recordset.columns)) {
-              const meta = col as { name: string; type?: { id?: number; name?: string } }
-              let dataTypeID: number | undefined
-              let dataType: string
-
-              // MSSQL returns empty string for unnamed columns (e.g., COUNT(*), SUM(), etc.)
-              // Generate a fallback name and remap the row data
-              const originalName = meta.name
-              const columnName = originalName || `column_${colIndex + 1}`
-
-              // If column name was empty, remap the row data to use the generated name
-              if (!originalName && rows.length > 0) {
-                for (const row of rows) {
-                  if (originalName in row) {
-                    row[columnName] = row[originalName]
-                    delete row[originalName]
+                // If column name was empty, remap the row data to use the generated name
+                if (!originalName && rows.length > 0) {
+                  for (const row of rows) {
+                    if (originalName in row) {
+                      row[columnName] = row[originalName]
+                      delete row[originalName]
+                    }
                   }
                 }
+
+                if (meta.type?.id) {
+                  dataTypeID = meta.type.id
+                  dataType = resolveMSSQLType(dataTypeID)
+                } else if (meta.type?.name) {
+                  dataType = meta.type.name.toLowerCase()
+                  const match = Object.entries(MSSQL_TYPE_MAP).find(
+                    ([, name]) => name.toLowerCase() === dataType
+                  )
+                  dataTypeID = match ? Number(match[0]) : undefined
+                } else {
+                  const inferred = inferTypeFromValue(rows[0]?.[columnName])
+                  dataType = inferred.dataType
+                  dataTypeID = inferred.dataTypeID
+                }
+
+                fields.push({
+                  name: columnName,
+                  dataType: dataType || 'nvarchar',
+                  dataTypeID: dataTypeID || 231
+                })
+                colIndex++
               }
-
-              if (meta.type?.id) {
-                dataTypeID = meta.type.id
-                dataType = resolveMSSQLType(dataTypeID)
-              } else if (meta.type?.name) {
-                dataType = meta.type.name.toLowerCase()
-                const match = Object.entries(MSSQL_TYPE_MAP).find(
-                  ([, name]) => name.toLowerCase() === dataType
-                )
-                dataTypeID = match ? Number(match[0]) : undefined
-              } else {
-                const inferred = inferTypeFromValue(rows[0]?.[columnName])
-                dataType = inferred.dataType
-                dataTypeID = inferred.dataTypeID
+            } else if (rows.length > 0) {
+              for (const [name, value] of Object.entries(rows[0])) {
+                const inferred = inferTypeFromValue(value)
+                fields.push({ name, ...inferred })
               }
-
-              fields.push({
-                name: columnName,
-                dataType: dataType || 'nvarchar',
-                dataTypeID: dataTypeID || 231
-              })
-              colIndex++
             }
-          } else if (rows.length > 0) {
-            for (const [name, value] of Object.entries(rows[0])) {
-              const inferred = inferTypeFromValue(value)
-              fields.push({ name, ...inferred })
+
+            const isDataReturning = isDataReturningStatement(statement)
+            const rowCount = isDataReturning ? rows.length : (result.rowsAffected[0] ?? 0)
+            totalRowCount += rowCount
+
+            results.push({
+              statement,
+              statementIndex: i,
+              rows,
+              fields,
+              rowCount,
+              durationMs: stmtDuration,
+              isDataReturning
+            })
+
+            if (collectTelemetry) {
+              telemetryCollector.endPhase(executionId, TELEMETRY_PHASES.PARSE)
             }
+
+            // Unregister after each statement completes successfully
+            if (options?.executionId) {
+              unregisterQuery(options.executionId)
+            }
+          } catch (error) {
+            const stmtDuration = Date.now() - stmtStart
+            const errorMessage = error instanceof Error ? error.message : String(error)
+
+            results.push({
+              statement,
+              statementIndex: i,
+              rows: [],
+              fields: [{ name: 'error', dataType: 'nvarchar' }],
+              rowCount: 0,
+              durationMs: stmtDuration,
+              isDataReturning: false
+            })
+
+            // Cancel telemetry on error
+            if (collectTelemetry) {
+              telemetryCollector.cancel(executionId)
+            }
+
+            throw new Error(
+              `Error in statement ${i + 1}: ${errorMessage}\n\nStatement:\n${statement}`
+            )
           }
+        }
 
-          const isDataReturning = isDataReturningStatement(statement)
-          const rowCount = isDataReturning ? rows.length : (result.rowsAffected[0] ?? 0)
-          totalRowCount += rowCount
+        const result: AdapterMultiQueryResult = {
+          results,
+          totalDurationMs: Date.now() - totalStart
+        }
 
-          results.push({
-            statement,
-            statementIndex: i,
-            rows,
-            fields,
-            rowCount,
-            durationMs: stmtDuration,
-            isDataReturning
-          })
+        // Finalize telemetry
+        if (collectTelemetry) {
+          result.telemetry = telemetryCollector.finalize(executionId, totalRowCount)
+        }
 
-          if (collectTelemetry) {
-            telemetryCollector.endPhase(executionId, TELEMETRY_PHASES.PARSE)
-          }
-
-          // Unregister after each statement completes successfully
-          if (options?.executionId) {
-            unregisterQuery(options.executionId)
-          }
-        } catch (error) {
-          const stmtDuration = Date.now() - stmtStart
-          const errorMessage = error instanceof Error ? error.message : String(error)
-
-          results.push({
-            statement,
-            statementIndex: i,
-            rows: [],
-            fields: [{ name: 'error', dataType: 'nvarchar' }],
-            rowCount: 0,
-            durationMs: stmtDuration,
-            isDataReturning: false
-          })
-
-          // Cancel telemetry on error
-          if (collectTelemetry) {
-            telemetryCollector.cancel(executionId)
-          }
-
-          throw new Error(
-            `Error in statement ${i + 1}: ${errorMessage}\n\nStatement:\n${statement}`
-          )
+        return result
+      } finally {
+        // The per-statement unregister above only runs on the success path, so a failed
+        // statement would otherwise leave a stale request registered as cancellable.
+        if (options?.executionId) {
+          unregisterQuery(options.executionId)
         }
       }
-
-      const result: AdapterMultiQueryResult = {
-        results,
-        totalDurationMs: Date.now() - totalStart
-      }
-
-      // Finalize telemetry
-      if (collectTelemetry) {
-        result.telemetry = telemetryCollector.finalize(executionId, totalRowCount)
-      }
-
-      return result
-    } finally {
-      // Unregister from tracker
-      if (options?.executionId) {
-        unregisterQuery(options.executionId)
-      }
-      await pool.close().catch(() => {})
-      closeTunnel(tunnelSession)
-    }
+    })
   }
 
   async execute(
@@ -536,17 +419,7 @@ export class MSSQLAdapter implements DatabaseAdapter {
     sqlQuery: string,
     params: unknown[]
   ): Promise<{ rowCount: number | null }> {
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-    const pool = new sql.ConnectionPool(toMSSQLConfig(config, tunnelOverrides))
-
-    try {
-      await pool.connect()
+    return withMSSQLPool(config, async (pool) => {
       const request = pool.request()
       const hasMSSQLPlaceholders = /@p\d+/.test(sqlQuery)
 
@@ -564,30 +437,14 @@ export class MSSQLAdapter implements DatabaseAdapter {
 
       const result = await request.query(sqlQuery)
       return { rowCount: result.rowsAffected[0] ?? null }
-    } finally {
-      await pool.close().catch(() => {})
-      closeTunnel(tunnelSession)
-    }
+    })
   }
 
   async executeTransaction(
     config: ConnectionConfig,
     statements: Array<{ sql: string; params: unknown[] }>
   ): Promise<{ rowsAffected: number; results: Array<{ rowCount: number | null }> }> {
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-    const pool = new sql.ConnectionPool(toMSSQLConfig(config, tunnelOverrides))
-    let transaction: sql.Transaction | null = null
-
-    try {
-      await pool.connect()
-      transaction = new sql.Transaction(pool)
-      await transaction.begin()
+    return withMSSQLTransaction(config, async (transaction) => {
       const results: Array<{ rowCount: number | null }> = []
       let rowsAffected = 0
 
@@ -614,29 +471,12 @@ export class MSSQLAdapter implements DatabaseAdapter {
         rowsAffected += affected
       }
 
-      await transaction.commit()
       return { rowsAffected, results }
-    } catch (error) {
-      if (transaction) await transaction.rollback().catch(() => {})
-      throw error
-    } finally {
-      await pool.close().catch(() => {})
-      closeTunnel(tunnelSession)
-    }
+    })
   }
 
   async getSchemas(config: ConnectionConfig): Promise<SchemaInfo[]> {
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-    const pool = new sql.ConnectionPool(toMSSQLConfig(config, tunnelOverrides))
-
-    try {
-      await pool.connect()
+    return withMSSQLPool(config, async (pool) => {
       const schemaList = SYSTEM_SCHEMAS.map((s) => `'${s}'`).join(', ')
 
       const [schemasResult, tablesResult] = await Promise.all([
@@ -851,10 +691,7 @@ export class MSSQLAdapter implements DatabaseAdapter {
       }
 
       return Array.from(schemaMap.values())
-    } finally {
-      await pool.close().catch(() => {})
-      closeTunnel(tunnelSession)
-    }
+    })
   }
 
   async explain(
@@ -862,17 +699,9 @@ export class MSSQLAdapter implements DatabaseAdapter {
     sqlQuery: string,
     analyze: boolean
   ): Promise<ExplainResult> {
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-    const pool = new sql.ConnectionPool(toMSSQLConfig(config, tunnelOverrides))
-
-    try {
-      await pool.connect()
+    // Pinned to one connection: the SET below configures the statement that follows it,
+    // and pooled requests are not guaranteed to share a connection.
+    return withDedicatedMSSQLConnection(config, async (pool) => {
       const start = Date.now()
 
       if (analyze) {
@@ -912,10 +741,7 @@ export class MSSQLAdapter implements DatabaseAdapter {
           durationMs: Date.now() - start
         }
       }
-    } finally {
-      await pool.close().catch(() => {})
-      closeTunnel(tunnelSession)
-    }
+    })
   }
 
   async getTableDDL(
@@ -923,17 +749,7 @@ export class MSSQLAdapter implements DatabaseAdapter {
     schema: string,
     table: string
   ): Promise<TableDefinition> {
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-    const pool = new sql.ConnectionPool(toMSSQLConfig(config, tunnelOverrides))
-
-    try {
-      await pool.connect()
+    return withMSSQLPool(config, async (pool) => {
       // Query columns with full metadata
       const columnsResult = await pool
         .request()
@@ -1150,10 +966,7 @@ export class MSSQLAdapter implements DatabaseAdapter {
         indexes,
         comment: tableCommentResult.recordset[0]?.comment || undefined
       }
-    } finally {
-      await pool.close().catch(() => {})
-      closeTunnel(tunnelSession)
-    }
+    })
   }
 
   async getSequences(): Promise<SequenceInfo[]> {
@@ -1163,17 +976,7 @@ export class MSSQLAdapter implements DatabaseAdapter {
   }
 
   async getTypes(config: ConnectionConfig): Promise<CustomTypeInfo[]> {
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-    const pool = new sql.ConnectionPool(toMSSQLConfig(config, tunnelOverrides))
-
-    try {
-      await pool.connect()
+    return withMSSQLPool(config, async (pool) => {
       // Get user-defined types from sys.types
       const typesResult = await pool.request().query(`
         SELECT
@@ -1195,10 +998,7 @@ export class MSSQLAdapter implements DatabaseAdapter {
         name: row.type_name,
         type: 'composite' as const // Treat as composite for now
       }))
-    } finally {
-      await pool.close().catch(() => {})
-      closeTunnel(tunnelSession)
-    }
+    })
   }
 
   private classifyColumnType(dataType: string): ColumnStatsType {
@@ -1239,18 +1039,7 @@ export class MSSQLAdapter implements DatabaseAdapter {
     column: string,
     dataType: string
   ): Promise<ColumnStats> {
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-    const pool = new sql.ConnectionPool(toMSSQLConfig(config, tunnelOverrides))
-
-    try {
-      await pool.connect()
-
+    return withMSSQLPool(config, async (pool) => {
       const statsType = this.classifyColumnType(dataType)
       const quoteIdent = (name: string) => '[' + name.replace(/\]/g, ']]') + ']'
       const quotedTable = `${quoteIdent(schema)}.${quoteIdent(table)}`
@@ -1409,25 +1198,11 @@ export class MSSQLAdapter implements DatabaseAdapter {
       }
 
       return stats
-    } finally {
-      await pool.close().catch(() => {})
-      closeTunnel(tunnelSession)
-    }
+    })
   }
 
   async getActiveQueries(config: ConnectionConfig): Promise<ActiveQuery[]> {
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-    const pool = new sql.ConnectionPool(toMSSQLConfig(config, tunnelOverrides))
-
-    try {
-      await pool.connect()
-
+    return withMSSQLPool(config, async (pool) => {
       const result = await pool.request().query(`
         SELECT
           r.session_id AS pid,
@@ -1456,28 +1231,14 @@ export class MSSQLAdapter implements DatabaseAdapter {
         query: String(row.query ?? ''),
         waitEvent: row.wait_event ? String(row.wait_event) : undefined
       }))
-    } finally {
-      await pool.close().catch(() => {})
-      closeTunnel(tunnelSession)
-    }
+    })
   }
 
   async getTableSizes(
     config: ConnectionConfig,
     schema?: string
   ): Promise<{ dbSize: DatabaseSizeInfo; tables: TableSizeInfo[] }> {
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-    const pool = new sql.ConnectionPool(toMSSQLConfig(config, tunnelOverrides))
-
-    try {
-      await pool.connect()
-
+    return withMSSQLPool(config, async (pool) => {
       const dbSizeResult = await pool.request().query(`
         SELECT
           SUM(size * 8 * 1024) AS total_size_bytes
@@ -1538,25 +1299,11 @@ export class MSSQLAdapter implements DatabaseAdapter {
       })
 
       return { dbSize, tables }
-    } finally {
-      await pool.close().catch(() => {})
-      closeTunnel(tunnelSession)
-    }
+    })
   }
 
   async getCacheStats(config: ConnectionConfig): Promise<CacheStats> {
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-    const pool = new sql.ConnectionPool(toMSSQLConfig(config, tunnelOverrides))
-
-    try {
-      await pool.connect()
-
+    return withMSSQLPool(config, async (pool) => {
       const cacheResult = await pool.request().query(`
         SELECT
           CASE WHEN SUM(CAST(page_count AS BIGINT)) = 0 THEN 0
@@ -1593,25 +1340,11 @@ export class MSSQLAdapter implements DatabaseAdapter {
         bufferCacheHitRatio,
         indexHitRatio
       }
-    } finally {
-      await pool.close().catch(() => {})
-      closeTunnel(tunnelSession)
-    }
+    })
   }
 
   async getLocks(config: ConnectionConfig): Promise<LockInfo[]> {
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-    const pool = new sql.ConnectionPool(toMSSQLConfig(config, tunnelOverrides))
-
-    try {
-      await pool.connect()
-
+    return withMSSQLPool(config, async (pool) => {
       const result = await pool.request().query(`
         SELECT
           blocked.request_session_id AS blocked_pid,
@@ -1656,34 +1389,20 @@ export class MSSQLAdapter implements DatabaseAdapter {
         waitDuration: String(row.wait_duration ?? '0s'),
         waitDurationMs: Number(row.wait_duration_ms ?? 0)
       }))
-    } finally {
-      await pool.close().catch(() => {})
-      closeTunnel(tunnelSession)
-    }
+    })
   }
 
   async killQuery(
     config: ConnectionConfig,
     pid: number
   ): Promise<{ success: boolean; error?: string }> {
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-    const pool = new sql.ConnectionPool(toMSSQLConfig(config, tunnelOverrides))
-
     try {
-      await pool.connect()
-      await pool.request().query(`KILL ${Number(pid)}`)
-      return { success: true }
+      return await withMSSQLPool(config, async (pool) => {
+        await pool.request().query(`KILL ${Number(pid)}`)
+        return { success: true }
+      })
     } catch (err) {
       return { success: false, error: String(err) }
-    } finally {
-      await pool.close().catch(() => {})
-      closeTunnel(tunnelSession)
     }
   }
 
@@ -1691,22 +1410,9 @@ export class MSSQLAdapter implements DatabaseAdapter {
     config: ConnectionConfig,
     checks?: SchemaIntelCheckId[]
   ): Promise<SchemaIntelReport> {
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-    const pool = new sql.ConnectionPool(toMSSQLConfig(config, tunnelOverrides))
-
-    try {
-      await pool.connect()
+    return withMSSQLPool(config, async (pool) => {
       return await runMssqlSchemaIntel(pool, checks)
-    } finally {
-      await pool.close().catch(() => {})
-      closeTunnel(tunnelSession)
-    }
+    })
   }
 
   private formatBytes(bytes: number): string {

--- a/apps/desktop/src/main/adapters/mssql-adapter.ts
+++ b/apps/desktop/src/main/adapters/mssql-adapter.ts
@@ -243,15 +243,24 @@ export class MSSQLAdapter implements DatabaseAdapter {
     const results: StatementResult[] = []
     let totalRowCount = 0
 
-    return withMSSQLPool(config, async (pool) => {
-      try {
-        if (collectTelemetry) {
-          telemetryCollector.endPhase(executionId, TELEMETRY_PHASES.TCP_HANDSHAKE)
-          telemetryCollector.startPhase(executionId, TELEMETRY_PHASES.DB_HANDSHAKE)
-          telemetryCollector.endPhase(executionId, TELEMETRY_PHASES.DB_HANDSHAKE)
-        }
-        const statements = splitMssqlStatements(sqlQuery)
+    const statements = splitMssqlStatements(sqlQuery)
 
+    // A multi-statement script may carry session state between its statements — a temp
+    // table, SET, DECLARE, SET IDENTITY_INSERT — and `pool.request()` can route each
+    // statement to a different pooled connection, which would break all of those. Pin
+    // the whole loop to one connection when there is more than one statement; a lone
+    // statement has nothing to inherit, so it keeps the pooled fast path.
+    const run = statements.length > 1 ? withDedicatedMSSQLConnection : withMSSQLPool
+
+    return run(config, async (pool) => {
+      // Closes over the pool acquisition, which is the only connection-level cost left
+      // now that pooling amortises the handshake — and the one worth seeing, since it
+      // spikes when the pool saturates. There is no per-query DB handshake to report.
+      if (collectTelemetry) {
+        telemetryCollector.endPhase(executionId, TELEMETRY_PHASES.TCP_HANDSHAKE)
+      }
+
+      try {
         for (let i = 0; i < statements.length; i++) {
           const statement = statements[i]
           const stmtStart = Date.now()

--- a/apps/desktop/src/main/adapters/mssql-client-config.ts
+++ b/apps/desktop/src/main/adapters/mssql-client-config.ts
@@ -1,0 +1,92 @@
+import sql from 'mssql'
+import type { ConnectionConfig } from '@shared/index'
+
+/**
+ * Create MSSQL connection config from our ConnectionConfig.
+ *
+ * Lives apart from the adapter so the pool manager can build a config without importing
+ * the adapter that consumes the pool.
+ */
+export function toMSSQLConfig(
+  config: ConnectionConfig,
+  overrides?: { host: string; port: number }
+): sql.config {
+  const mssqlOptions = config.mssqlOptions || {}
+
+  // Handle authentication methods first to determine what options are needed
+  const authentication = mssqlOptions.authentication
+  const isAzureAD = authentication === 'ActiveDirectoryIntegrated'
+
+  // Build options object - for Azure AD, keep it minimal
+  const defaultSsl = config.ssl ?? false
+  const options: sql.config['options'] = {}
+
+  // Always set encrypt if specified
+  if (mssqlOptions.encrypt !== undefined) {
+    options.encrypt = mssqlOptions.encrypt
+  } else if (defaultSsl) {
+    options.encrypt = true
+  }
+
+  // For Azure AD, don't set trustServerCertificate or enableArithAbort
+  // These can interfere with Azure AD authentication
+  if (!isAzureAD) {
+    if (mssqlOptions.trustServerCertificate !== undefined) {
+      options.trustServerCertificate = mssqlOptions.trustServerCertificate
+    } else if (!defaultSsl) {
+      options.trustServerCertificate = true
+    }
+    options.enableArithAbort = mssqlOptions.enableArithAbort ?? true
+  }
+
+  // Add connection timeout if specified
+  if (mssqlOptions.connectionTimeout !== undefined) {
+    options.connectTimeout = mssqlOptions.connectionTimeout
+  }
+
+  // Set request timeout (default to 0 = no timeout to allow long-running queries)
+  // The mssql library defaults to 15000ms which is too short for complex queries
+  options.requestTimeout = mssqlOptions.requestTimeout ?? 0
+
+  // Build base config
+  const sqlConfig: sql.config = {
+    server: overrides?.host ?? config.host,
+    database: config.database,
+    options
+  }
+
+  // Include port if provided (optional in mssql config)
+  if (overrides?.port) {
+    sqlConfig.port = overrides.port
+  } else if (config.port) {
+    sqlConfig.port = config.port
+  }
+
+  // Handle authentication methods
+  if (authentication === 'ActiveDirectoryIntegrated') {
+    // Azure AD Integrated Authentication - uses azure-active-directory-default
+    sqlConfig.authentication = {
+      type: 'azure-active-directory-default',
+      options: {}
+    }
+    // Explicitly don't set user/password for Azure AD authentication
+    // Even if they exist in config, we should not include them
+  } else if (authentication === 'ActiveDirectoryPassword') {
+    // Azure AD Password Authentication
+    // Note: This requires clientId and tenantId which aren't in our config yet
+    // For now, use SQL Server auth as fallback
+    if (config.user) sqlConfig.user = config.user
+    if (config.password) sqlConfig.password = config.password
+  } else if (authentication === 'ActiveDirectoryServicePrincipal') {
+    // Azure AD Service Principal - would need clientId and clientSecret
+    // For now, fall back to SQL Server auth
+    if (config.user) sqlConfig.user = config.user
+    if (config.password) sqlConfig.password = config.password
+  } else {
+    // Default: SQL Server Authentication
+    if (config.user) sqlConfig.user = config.user
+    if (config.password) sqlConfig.password = config.password
+  }
+
+  return sqlConfig
+}

--- a/apps/desktop/src/main/adapters/mssql-pool-manager.ts
+++ b/apps/desktop/src/main/adapters/mssql-pool-manager.ts
@@ -1,7 +1,10 @@
 import sql from 'mssql'
 import type { ConnectionConfig } from '@shared/index'
+import { createLogger } from '../lib/logger'
 import { toMSSQLConfig } from './mssql-client-config'
 import { PoolRegistry } from './pool-registry'
+
+const log = createLogger('mssql-pool')
 
 /**
  * Connection pooling for SQL Server.
@@ -26,9 +29,12 @@ const registry = new PoolRegistry<sql.ConnectionPool>({
       ...toMSSQLConfig(config, overrides),
       pool: { max: POOL_MAX, min: POOL_MIN, idleTimeoutMillis: IDLE_TIMEOUT_MS }
     })
-    // Without a listener, a pool-level error (a socket dying while idle) is an
-    // unhandled 'error' event and takes the process down.
-    pool.on('error', () => {})
+    // Without a listener, a pool-level error (a socket dying while idle) is an unhandled
+    // 'error' event and takes the process down. Log it rather than swallowing: it's the
+    // only trace of why a later query on this connection failed or hung.
+    pool.on('error', (err: Error) => {
+      log.warn('idle pool error:', err.message)
+    })
     await pool.connect()
     return pool
   },
@@ -104,7 +110,9 @@ export async function withDedicatedMSSQLConnection<T>(
     ...toMSSQLConfig(config, overrides),
     pool: { max: 1, min: 0, idleTimeoutMillis: 1_000 }
   })
-  pool.on('error', () => {})
+  pool.on('error', (err: Error) => {
+    log.warn('dedicated connection error:', err.message)
+  })
   await pool.connect()
   try {
     return await fn(pool)

--- a/apps/desktop/src/main/adapters/mssql-pool-manager.ts
+++ b/apps/desktop/src/main/adapters/mssql-pool-manager.ts
@@ -113,8 +113,10 @@ export async function withDedicatedMSSQLConnection<T>(
   pool.on('error', (err: Error) => {
     log.warn('dedicated connection error:', err.message)
   })
-  await pool.connect()
+  // connect() inside the try: a rejected connection would otherwise skip the finally
+  // and leak the pool object along with any socket it had already opened.
   try {
+    await pool.connect()
     return await fn(pool)
   } finally {
     await pool.close().catch(() => {})

--- a/apps/desktop/src/main/adapters/mssql-pool-manager.ts
+++ b/apps/desktop/src/main/adapters/mssql-pool-manager.ts
@@ -1,0 +1,124 @@
+import sql from 'mssql'
+import type { ConnectionConfig } from '@shared/index'
+import { toMSSQLConfig } from './mssql-client-config'
+import { PoolRegistry } from './pool-registry'
+
+/**
+ * Connection pooling for SQL Server.
+ *
+ * `mssql.ConnectionPool` already pools internally — the problem was that every adapter
+ * method built, connected and closed a *fresh* one (plus a fresh SSH tunnel) per call,
+ * so the pooling never actually applied. Keeping one connected pool per connection
+ * shape is what makes it real.
+ */
+
+const POOL_MAX = 5
+const POOL_MIN = 0
+const IDLE_TIMEOUT_MS = 30_000
+
+const registry = new PoolRegistry<sql.ConnectionPool>({
+  driver: 'mssql',
+  // Driver flags (encrypt, trustServerCertificate, auth mode) are baked into the
+  // handshake, so changing them has to force a new pool.
+  fingerprintExtras: (config) => config.mssqlOptions ?? null,
+  create: async (config, overrides) => {
+    const pool = new sql.ConnectionPool({
+      ...toMSSQLConfig(config, overrides),
+      pool: { max: POOL_MAX, min: POOL_MIN, idleTimeoutMillis: IDLE_TIMEOUT_MS }
+    })
+    // Without a listener, a pool-level error (a socket dying while idle) is an
+    // unhandled 'error' event and takes the process down.
+    pool.on('error', () => {})
+    await pool.connect()
+    return pool
+  },
+  destroy: (pool) => pool.close()
+})
+
+/**
+ * Run `fn` against the connection's pool.
+ *
+ * Note that `pool.request()` may run on *any* connection in the pool, so consecutive
+ * requests are not guaranteed to share session state. Anything that depends on a `SET`
+ * from a previous statement must use `withMSSQLTransaction`, which pins one connection.
+ */
+export async function withMSSQLPool<T>(
+  config: ConnectionConfig,
+  fn: (pool: sql.ConnectionPool) => Promise<T>
+): Promise<T> {
+  const entry = await registry.getOrCreate(config)
+  return fn(entry.pool)
+}
+
+/**
+ * Run `fn` inside a transaction, which pins every request to one connection.
+ *
+ * This is the only way to make session-scoped `SET` statements (SHOWPLAN_XML,
+ * STATISTICS XML) apply to the statement that follows them, since a bare
+ * `pool.request()` can land on a different connection each time.
+ */
+export async function withMSSQLTransaction<T>(
+  config: ConnectionConfig,
+  fn: (transaction: sql.Transaction) => Promise<T>
+): Promise<T> {
+  const entry = await registry.getOrCreate(config)
+  const transaction = new sql.Transaction(entry.pool)
+  await transaction.begin()
+  let committed = false
+  try {
+    const result = await fn(transaction)
+    await transaction.commit()
+    committed = true
+    return result
+  } finally {
+    if (!committed) {
+      await transaction.rollback().catch(() => {
+        // Already rolled back, or the connection died; either way the pool reclaims it.
+      })
+    }
+  }
+}
+
+/**
+ * Run `fn` against a throwaway pool of exactly one connection, riding the connection's
+ * shared tunnel.
+ *
+ * For the handful of operations that genuinely need consecutive statements to land on
+ * the *same* physical connection because one configures the next — SQL Server's
+ * `SET SHOWPLAN_XML` / `SET STATISTICS XML` are session-scoped, and a bare
+ * `pool.request()` may run on any connection in the pool. A transaction would also pin
+ * one connection, but SHOWPLAN mode compiles rather than executes the statements that
+ * follow it, which is a bad interaction to build a COMMIT on top of.
+ *
+ * The tunnel is still shared, so this costs a TCP+auth handshake, not an SSH one.
+ */
+export async function withDedicatedMSSQLConnection<T>(
+  config: ConnectionConfig,
+  fn: (pool: sql.ConnectionPool) => Promise<T>
+): Promise<T> {
+  const entry = await registry.getOrCreate(config)
+  const overrides = entry.tunnel
+    ? { host: entry.tunnel.localHost, port: entry.tunnel.localPort }
+    : undefined
+  const pool = new sql.ConnectionPool({
+    ...toMSSQLConfig(config, overrides),
+    pool: { max: 1, min: 0, idleTimeoutMillis: 1_000 }
+  })
+  pool.on('error', () => {})
+  await pool.connect()
+  try {
+    return await fn(pool)
+  } finally {
+    await pool.close().catch(() => {})
+  }
+}
+
+/** Close the pool (and tunnel) for a single connection. */
+export async function closeMSSQLPool(config: ConnectionConfig): Promise<void> {
+  return registry.close(config)
+}
+
+/** Close every SQL Server pool. Call on app shutdown. */
+export async function closeAllMSSQLPools(): Promise<void> {
+  return registry.closeAll()
+}

--- a/apps/desktop/src/main/adapters/mysql-adapter.ts
+++ b/apps/desktop/src/main/adapters/mysql-adapter.ts
@@ -1,5 +1,4 @@
 import mysql from 'mysql2/promise'
-import { readFileSync } from 'fs'
 import { randomUUID } from 'crypto'
 import type {
   ConnectionConfig,
@@ -38,12 +37,36 @@ import type {
   QueryOptions
 } from '../db-adapter'
 import { registerQuery, unregisterQuery } from '../query-tracker'
-import { closeTunnel, createTunnel, TunnelSession } from '../ssh-tunnel-service'
 import { splitStatements } from '../lib/sql-parser'
 import { telemetryCollector, TELEMETRY_PHASES } from '../telemetry-collector'
+import { toMySQLConfig } from './mysql-client-config'
+import { withMySQLConnection, withMySQLTransaction } from './mysql-pool-manager'
+
+// Re-exported because it was part of this module's surface before it moved out to break
+// an import cycle with the pool manager.
+export { toMySQLConfig }
 
 /** Split SQL into statements for MySQL */
 const splitMySqlStatements = (sql: string) => splitStatements(sql, 'mysql')
+
+/**
+ * Values mysql2 accepts as prepared-statement parameters.
+ *
+ * Mirrors mysql2's internal `ExecuteValues`, which it doesn't export. `DatabaseAdapter`
+ * hands params down as `unknown[]` because that signature is shared across every driver,
+ * so this is the type at the boundary where those values meet mysql2.
+ */
+type MySQLBindValue =
+  | string
+  | number
+  | bigint
+  | boolean
+  | Date
+  | null
+  | Buffer
+  | Uint8Array
+  | MySQLBindValue[]
+  | { [key: string]: MySQLBindValue }
 
 /**
  * MySQL type codes to type name mapping
@@ -88,50 +111,6 @@ export function resolveMySQLType(typeCode: number): string {
 }
 
 /**
- * Create MySQL connection config from our ConnectionConfig
- * Properly handles SSL options for cloud databases like AWS RDS
- */
-export function toMySQLConfig(
-  config: ConnectionConfig,
-  overrides?: { host: string; port: number }
-): mysql.ConnectionOptions {
-  const mysqlConfig: mysql.ConnectionOptions = {
-    host: overrides?.host ?? config.host,
-    port: overrides?.port ?? config.port,
-    user: config.user,
-    password: config.password,
-    database: config.database
-  }
-
-  if (config.ssl) {
-    const sslOptions = config.sslOptions || {}
-
-    if (sslOptions.ca) {
-      try {
-        mysqlConfig.ssl = {
-          rejectUnauthorized: sslOptions.rejectUnauthorized !== false,
-          ca: readFileSync(sslOptions.ca, 'utf-8')
-        }
-      } catch (err) {
-        console.error(`Failed to read CA certificate from ${sslOptions.ca}:`, err)
-        throw new Error(
-          `Failed to read CA certificate file: ${sslOptions.ca}. Please verify the file exists and is readable.`
-        )
-      }
-    } else {
-      // Default to rejectUnauthorized: false so cloud MySQL (RDS, PlanetScale,
-      // Aiven) with self-signed / private-CA certs works out of the box.
-      // Strict verification is opt-in via the UI.
-      mysqlConfig.ssl = {
-        rejectUnauthorized: sslOptions.rejectUnauthorized === true
-      }
-    }
-  }
-
-  return mysqlConfig
-}
-
-/**
  * Normalize row from MySQL query to lowercase keys
  * MySQL can return column names in different cases depending on configuration
  */
@@ -165,35 +144,15 @@ export class MySQLAdapter implements DatabaseAdapter {
   readonly dbType = 'mysql' as const
 
   async connect(config: ConnectionConfig): Promise<void> {
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-    const connection = await mysql.createConnection(toMySQLConfig(config, tunnelOverrides))
-    try {
-      await connection.end()
-    } catch {
-      // ignore end errors during test connection
-    } finally {
-      closeTunnel(tunnelSession)
-    }
+    // Warm the pool AND verify the socket end-to-end. Checking out a connection alone
+    // can hand back a cached idle one without a round-trip; SELECT 1 proves it's live.
+    await withMySQLConnection(config, async (connection) => {
+      await connection.query('SELECT 1')
+    })
   }
 
   async query(config: ConnectionConfig, sql: string): Promise<AdapterQueryResult> {
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-    let connection: mysql.Connection | null = null
-
-    try {
-      connection = await mysql.createConnection(toMySQLConfig(config, tunnelOverrides))
+    return withMySQLConnection(config, async (connection) => {
       const [rows, fields] = await connection.query(sql)
 
       const queryFields: QueryField[] = (fields as mysql.FieldPacket[]).map((f) => ({
@@ -209,10 +168,7 @@ export class MySQLAdapter implements DatabaseAdapter {
         fields: queryFields,
         rowCount: resultRows.length
       }
-    } finally {
-      if (connection) await connection.end().catch(() => {})
-      closeTunnel(tunnelSession)
-    }
+    })
   }
 
   async queryMultiple(
@@ -229,146 +185,141 @@ export class MySQLAdapter implements DatabaseAdapter {
       telemetryCollector.startPhase(executionId, TELEMETRY_PHASES.TCP_HANDSHAKE)
     }
 
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-
-    let connection: mysql.Connection | null = null
     const totalStart = Date.now()
     const results: StatementResult[] = []
     let totalRowCount = 0
 
-    try {
-      if (collectTelemetry) {
-        telemetryCollector.endPhase(executionId, TELEMETRY_PHASES.TCP_HANDSHAKE)
-        telemetryCollector.startPhase(executionId, TELEMETRY_PHASES.DB_HANDSHAKE)
-      }
+    return withMySQLConnection(config, async (connection) => {
+      // Whether this call set a session-scoped timeout that must be undone before the
+      // connection goes back to the pool.
+      let timeoutWasSet = false
+      try {
+        if (collectTelemetry) {
+          telemetryCollector.endPhase(executionId, TELEMETRY_PHASES.TCP_HANDSHAKE)
+          telemetryCollector.startPhase(executionId, TELEMETRY_PHASES.DB_HANDSHAKE)
+          telemetryCollector.endPhase(executionId, TELEMETRY_PHASES.DB_HANDSHAKE)
+        }
 
-      connection = await mysql.createConnection(toMySQLConfig(config, tunnelOverrides))
+        // Set query timeout if specified (0 = no timeout)
+        // Note: max_execution_time only affects SELECT statements in MySQL 5.7.8+
+        const queryTimeoutMs = options?.queryTimeoutMs
+        if (
+          typeof queryTimeoutMs === 'number' &&
+          Number.isFinite(queryTimeoutMs) &&
+          queryTimeoutMs > 0
+        ) {
+          const safeTimeout = Math.floor(queryTimeoutMs)
+          await connection.query(`SET SESSION max_execution_time = ${safeTimeout}`)
+          timeoutWasSet = true
+        }
 
-      if (collectTelemetry) {
-        telemetryCollector.endPhase(executionId, TELEMETRY_PHASES.DB_HANDSHAKE)
-      }
+        // Register for cancellation support
+        if (options?.executionId) {
+          registerQuery(options.executionId, { type: 'mysql', connection })
+        }
+        const statements = splitMySqlStatements(sql)
 
-      // Set query timeout if specified (0 = no timeout)
-      // Note: max_execution_time only affects SELECT statements in MySQL 5.7.8+
-      const queryTimeoutMs = options?.queryTimeoutMs
-      if (
-        typeof queryTimeoutMs === 'number' &&
-        Number.isFinite(queryTimeoutMs) &&
-        queryTimeoutMs > 0
-      ) {
-        const safeTimeout = Math.floor(queryTimeoutMs)
-        await connection.query(`SET SESSION max_execution_time = ${safeTimeout}`)
-      }
+        for (let i = 0; i < statements.length; i++) {
+          const statement = statements[i]
+          const stmtStart = Date.now()
 
-      // Register for cancellation support
-      if (options?.executionId) {
-        registerQuery(options.executionId, { type: 'mysql', connection })
-      }
-      const statements = splitMySqlStatements(sql)
+          try {
+            // Start execution phase timing
+            if (collectTelemetry) {
+              telemetryCollector.startPhase(executionId, TELEMETRY_PHASES.EXECUTION)
+            }
 
-      for (let i = 0; i < statements.length; i++) {
-        const statement = statements[i]
-        const stmtStart = Date.now()
+            const [rows, fields] = await connection.query(statement)
 
-        try {
-          // Start execution phase timing
-          if (collectTelemetry) {
-            telemetryCollector.startPhase(executionId, TELEMETRY_PHASES.EXECUTION)
+            if (collectTelemetry) {
+              telemetryCollector.endPhase(executionId, TELEMETRY_PHASES.EXECUTION)
+              telemetryCollector.startPhase(executionId, TELEMETRY_PHASES.PARSE)
+            }
+
+            const stmtDuration = Date.now() - stmtStart
+
+            const queryFields: QueryField[] =
+              (fields as mysql.FieldPacket[] | undefined)?.map((f) => ({
+                name: f.name,
+                dataType: resolveMySQLType(f.type ?? 253),
+                dataTypeID: f.type ?? 253
+              })) || []
+
+            const resultRows = Array.isArray(rows) ? rows : []
+            const isDataReturning = isDataReturningStatement(statement)
+
+            // For non-SELECT statements, rowCount is the affected rows
+            let rowCount: number
+            if (isDataReturning) {
+              rowCount = resultRows.length
+            } else {
+              const header = rows as mysql.ResultSetHeader
+              rowCount = header.affectedRows ?? 0
+            }
+            totalRowCount += rowCount
+
+            results.push({
+              statement,
+              statementIndex: i,
+              rows: resultRows as Record<string, unknown>[],
+              fields: queryFields,
+              rowCount,
+              durationMs: stmtDuration,
+              isDataReturning
+            })
+
+            if (collectTelemetry) {
+              telemetryCollector.endPhase(executionId, TELEMETRY_PHASES.PARSE)
+            }
+          } catch (error) {
+            const stmtDuration = Date.now() - stmtStart
+            const errorMessage = error instanceof Error ? error.message : String(error)
+
+            results.push({
+              statement,
+              statementIndex: i,
+              rows: [],
+              fields: [{ name: 'error', dataType: 'text' }],
+              rowCount: 0,
+              durationMs: stmtDuration,
+              isDataReturning: false
+            })
+
+            // Cancel telemetry on error
+            if (collectTelemetry) {
+              telemetryCollector.cancel(executionId)
+            }
+
+            throw new Error(
+              `Error in statement ${i + 1}: ${errorMessage}\n\nStatement:\n${statement}`
+            )
           }
+        }
 
-          const [rows, fields] = await connection.query(statement)
+        const result: AdapterMultiQueryResult = {
+          results,
+          totalDurationMs: Date.now() - totalStart
+        }
 
-          if (collectTelemetry) {
-            telemetryCollector.endPhase(executionId, TELEMETRY_PHASES.EXECUTION)
-            telemetryCollector.startPhase(executionId, TELEMETRY_PHASES.PARSE)
-          }
+        // Finalize telemetry
+        if (collectTelemetry) {
+          result.telemetry = telemetryCollector.finalize(executionId, totalRowCount)
+        }
 
-          const stmtDuration = Date.now() - stmtStart
-
-          const queryFields: QueryField[] =
-            (fields as mysql.FieldPacket[] | undefined)?.map((f) => ({
-              name: f.name,
-              dataType: resolveMySQLType(f.type ?? 253),
-              dataTypeID: f.type ?? 253
-            })) || []
-
-          const resultRows = Array.isArray(rows) ? rows : []
-          const isDataReturning = isDataReturningStatement(statement)
-
-          // For non-SELECT statements, rowCount is the affected rows
-          let rowCount: number
-          if (isDataReturning) {
-            rowCount = resultRows.length
-          } else {
-            const header = rows as mysql.ResultSetHeader
-            rowCount = header.affectedRows ?? 0
-          }
-          totalRowCount += rowCount
-
-          results.push({
-            statement,
-            statementIndex: i,
-            rows: resultRows as Record<string, unknown>[],
-            fields: queryFields,
-            rowCount,
-            durationMs: stmtDuration,
-            isDataReturning
-          })
-
-          if (collectTelemetry) {
-            telemetryCollector.endPhase(executionId, TELEMETRY_PHASES.PARSE)
-          }
-        } catch (error) {
-          const stmtDuration = Date.now() - stmtStart
-          const errorMessage = error instanceof Error ? error.message : String(error)
-
-          results.push({
-            statement,
-            statementIndex: i,
-            rows: [],
-            fields: [{ name: 'error', dataType: 'text' }],
-            rowCount: 0,
-            durationMs: stmtDuration,
-            isDataReturning: false
-          })
-
-          // Cancel telemetry on error
-          if (collectTelemetry) {
-            telemetryCollector.cancel(executionId)
-          }
-
-          throw new Error(
-            `Error in statement ${i + 1}: ${errorMessage}\n\nStatement:\n${statement}`
-          )
+        return result
+      } finally {
+        // Unregister from tracker
+        if (options?.executionId) {
+          unregisterQuery(options.executionId)
+        }
+        // The connection is about to go back to the pool, so undo the session-scoped
+        // timeout — otherwise the next unrelated query on this connection silently
+        // inherits it. Best-effort: a cancelled query already destroyed the socket.
+        if (timeoutWasSet) {
+          await connection.query('SET SESSION max_execution_time = 0').catch(() => {})
         }
       }
-
-      const result: AdapterMultiQueryResult = {
-        results,
-        totalDurationMs: Date.now() - totalStart
-      }
-
-      // Finalize telemetry
-      if (collectTelemetry) {
-        result.telemetry = telemetryCollector.finalize(executionId, totalRowCount)
-      }
-
-      return result
-    } finally {
-      // Unregister from tracker
-      if (options?.executionId) {
-        unregisterQuery(options.executionId)
-      }
-      if (connection) await connection.end().catch(() => {})
-      closeTunnel(tunnelSession)
-    }
+    })
   }
 
   async execute(
@@ -376,76 +327,34 @@ export class MySQLAdapter implements DatabaseAdapter {
     sql: string,
     params: unknown[]
   ): Promise<{ rowCount: number | null }> {
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-    let connection: mysql.Connection | null = null
-
-    try {
-      connection = await mysql.createConnection(toMySQLConfig(config, tunnelOverrides))
-      const [result] = await connection.execute(sql, params as any)
+    return withMySQLConnection(config, async (connection) => {
+      const [result] = await connection.execute(sql, params as MySQLBindValue[])
       const affectedRows = (result as mysql.ResultSetHeader).affectedRows ?? null
       return { rowCount: affectedRows }
-    } finally {
-      if (connection) await connection.end().catch(() => {})
-      closeTunnel(tunnelSession)
-    }
+    })
   }
 
   async executeTransaction(
     config: ConnectionConfig,
     statements: Array<{ sql: string; params: unknown[] }>
   ): Promise<{ rowsAffected: number; results: Array<{ rowCount: number | null }> }> {
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-    let connection: mysql.Connection | null = null
-
-    try {
-      connection = await mysql.createConnection(toMySQLConfig(config, tunnelOverrides))
-      await connection.beginTransaction()
-
+    return withMySQLTransaction(config, async (connection) => {
       const results: Array<{ rowCount: number | null }> = []
       let rowsAffected = 0
 
       for (const stmt of statements) {
-        const [result] = await connection.execute(stmt.sql, stmt.params as any)
+        const [result] = await connection.execute(stmt.sql, stmt.params as MySQLBindValue[])
         const affectedRows = (result as mysql.ResultSetHeader).affectedRows ?? 0
         results.push({ rowCount: affectedRows })
         rowsAffected += affectedRows
       }
 
-      await connection.commit()
       return { rowsAffected, results }
-    } catch (error) {
-      if (connection) await connection.rollback().catch(() => {})
-      throw error
-    } finally {
-      if (connection) await connection.end().catch(() => {})
-      closeTunnel(tunnelSession)
-    }
+    })
   }
 
   async getSchemas(config: ConnectionConfig): Promise<SchemaInfo[]> {
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-    let connection: mysql.Connection | null = null
-
-    try {
-      connection = await mysql.createConnection(toMySQLConfig(config, tunnelOverrides))
+    return withMySQLConnection(config, async (connection) => {
       // In MySQL, "schema" = "database"
       // We'll show all databases as schemas, excluding system databases
       const [schemasRows] = await connection.query(`
@@ -767,24 +676,11 @@ export class MySQLAdapter implements DatabaseAdapter {
       }
 
       return Array.from(schemaMap.values())
-    } finally {
-      if (connection) await connection.end().catch(() => {})
-      closeTunnel(tunnelSession)
-    }
+    })
   }
 
   async explain(config: ConnectionConfig, sql: string, analyze: boolean): Promise<ExplainResult> {
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-    let connection: mysql.Connection | null = null
-
-    try {
-      connection = await mysql.createConnection(toMySQLConfig(config, tunnelOverrides))
+    return withMySQLConnection(config, async (connection) => {
       // MySQL uses EXPLAIN ANALYZE (8.0.18+) or just EXPLAIN
       const explainQuery = analyze ? `EXPLAIN ANALYZE ${sql}` : `EXPLAIN FORMAT=JSON ${sql}`
 
@@ -811,10 +707,7 @@ export class MySQLAdapter implements DatabaseAdapter {
         plan,
         durationMs: duration
       }
-    } finally {
-      if (connection) await connection.end().catch(() => {})
-      closeTunnel(tunnelSession)
-    }
+    })
   }
 
   async getTableDDL(
@@ -822,17 +715,7 @@ export class MySQLAdapter implements DatabaseAdapter {
     schema: string,
     table: string
   ): Promise<TableDefinition> {
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-    let connection: mysql.Connection | null = null
-
-    try {
-      connection = await mysql.createConnection(toMySQLConfig(config, tunnelOverrides))
+    return withMySQLConnection(config, async (connection) => {
       // Get columns with full metadata
       const [columnsRows] = await connection.query(
         `
@@ -1072,10 +955,7 @@ export class MySQLAdapter implements DatabaseAdapter {
         indexes,
         comment: tableCommentResult[0]?.table_comment || undefined
       }
-    } finally {
-      if (connection) await connection.end().catch(() => {})
-      closeTunnel(tunnelSession)
-    }
+    })
   }
 
   async getSequences(_config: ConnectionConfig): Promise<SequenceInfo[]> {
@@ -1085,18 +965,7 @@ export class MySQLAdapter implements DatabaseAdapter {
   }
 
   async getTypes(config: ConnectionConfig): Promise<CustomTypeInfo[]> {
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-    let connection: mysql.Connection | null = null
-
-    try {
-      // Get MySQL ENUM types from columns
-      connection = await mysql.createConnection(toMySQLConfig(config, tunnelOverrides))
+    return withMySQLConnection(config, async (connection) => {
       // MySQL doesn't have standalone enum types, they're defined per column
       // We'll extract unique enum definitions from columns
       const [enumRows] = await connection.query(`
@@ -1131,10 +1000,7 @@ export class MySQLAdapter implements DatabaseAdapter {
       }
 
       return types
-    } finally {
-      if (connection) await connection.end().catch(() => {})
-      closeTunnel(tunnelSession)
-    }
+    })
   }
 
   private classifyColumnType(dataType: string): ColumnStatsType {
@@ -1175,18 +1041,7 @@ export class MySQLAdapter implements DatabaseAdapter {
     column: string,
     dataType: string
   ): Promise<ColumnStats> {
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-    let connection: mysql.Connection | null = null
-
-    try {
-      connection = await mysql.createConnection(toMySQLConfig(config, tunnelOverrides))
-
+    return withMySQLConnection(config, async (connection) => {
       const statsType = this.classifyColumnType(dataType)
       const quoteIdent = (name: string) => '`' + name.replace(/`/g, '``') + '`'
       const quotedTable = `${quoteIdent(schema)}.${quoteIdent(table)}`
@@ -1346,25 +1201,11 @@ export class MySQLAdapter implements DatabaseAdapter {
       }
 
       return stats
-    } finally {
-      if (connection) await connection.end().catch(() => {})
-      closeTunnel(tunnelSession)
-    }
+    })
   }
 
   async getActiveQueries(config: ConnectionConfig): Promise<ActiveQuery[]> {
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-    let connection: mysql.Connection | null = null
-
-    try {
-      connection = await mysql.createConnection(toMySQLConfig(config, tunnelOverrides))
-
+    return withMySQLConnection(config, async (connection) => {
       const [rows] = await connection.query(`
         SELECT
           ID AS pid,
@@ -1390,28 +1231,14 @@ export class MySQLAdapter implements DatabaseAdapter {
         durationMs: Number(row.time_sec ?? 0) * 1000,
         query: String(row.query ?? '')
       }))
-    } finally {
-      if (connection) await connection.end().catch(() => {})
-      closeTunnel(tunnelSession)
-    }
+    })
   }
 
   async getTableSizes(
     config: ConnectionConfig,
     schema?: string
   ): Promise<{ dbSize: DatabaseSizeInfo; tables: TableSizeInfo[] }> {
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-    let connection: mysql.Connection | null = null
-
-    try {
-      connection = await mysql.createConnection(toMySQLConfig(config, tunnelOverrides))
-
+    return withMySQLConnection(config, async (connection) => {
       const dbName = schema || config.database || ''
 
       const [dbSizeRows] = await connection.query(
@@ -1466,25 +1293,11 @@ export class MySQLAdapter implements DatabaseAdapter {
       })
 
       return { dbSize, tables }
-    } finally {
-      if (connection) await connection.end().catch(() => {})
-      closeTunnel(tunnelSession)
-    }
+    })
   }
 
   async getCacheStats(config: ConnectionConfig): Promise<CacheStats> {
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-    let connection: mysql.Connection | null = null
-
-    try {
-      connection = await mysql.createConnection(toMySQLConfig(config, tunnelOverrides))
-
+    return withMySQLConnection(config, async (connection) => {
       const [rows] = await connection.query(`
         SHOW STATUS LIKE 'Innodb_buffer_pool_read%'
       `)
@@ -1503,25 +1316,11 @@ export class MySQLAdapter implements DatabaseAdapter {
         bufferCacheHitRatio,
         indexHitRatio: bufferCacheHitRatio
       }
-    } finally {
-      if (connection) await connection.end().catch(() => {})
-      closeTunnel(tunnelSession)
-    }
+    })
   }
 
   async getLocks(config: ConnectionConfig): Promise<LockInfo[]> {
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-    let connection: mysql.Connection | null = null
-
-    try {
-      connection = await mysql.createConnection(toMySQLConfig(config, tunnelOverrides))
-
+    return withMySQLConnection(config, async (connection) => {
       // Let query failures (e.g. missing performance_schema grants) propagate so the
       // db:locks handler surfaces a real error instead of an empty "no locks" result.
       const [rows] = await connection.query(`
@@ -1559,34 +1358,20 @@ export class MySQLAdapter implements DatabaseAdapter {
           waitDurationMs: waitSec * 1000
         }
       })
-    } finally {
-      if (connection) await connection.end().catch(() => {})
-      closeTunnel(tunnelSession)
-    }
+    })
   }
 
   async killQuery(
     config: ConnectionConfig,
     pid: number
   ): Promise<{ success: boolean; error?: string }> {
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-    let connection: mysql.Connection | null = null
-
     try {
-      connection = await mysql.createConnection(toMySQLConfig(config, tunnelOverrides))
-      await connection.query(`KILL QUERY ${Number(pid)}`)
-      return { success: true }
+      return await withMySQLConnection(config, async (connection) => {
+        await connection.query(`KILL QUERY ${Number(pid)}`)
+        return { success: true }
+      })
     } catch (err) {
       return { success: false, error: String(err) }
-    } finally {
-      if (connection) await connection.end().catch(() => {})
-      closeTunnel(tunnelSession)
     }
   }
 
@@ -1594,22 +1379,9 @@ export class MySQLAdapter implements DatabaseAdapter {
     config: ConnectionConfig,
     checks?: SchemaIntelCheckId[]
   ): Promise<SchemaIntelReport> {
-    let tunnelSession: TunnelSession | null = null
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-    const tunnelOverrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-    let connection: mysql.Connection | null = null
-
-    try {
-      connection = await mysql.createConnection(toMySQLConfig(config, tunnelOverrides))
+    return withMySQLConnection(config, async (connection) => {
       return await runMysqlSchemaIntel(connection, config.database, checks)
-    } finally {
-      if (connection) await connection.end().catch(() => {})
-      closeTunnel(tunnelSession)
-    }
+    })
   }
 
   private formatBytes(bytes: number): string {

--- a/apps/desktop/src/main/adapters/mysql-adapter.ts
+++ b/apps/desktop/src/main/adapters/mysql-adapter.ts
@@ -190,16 +190,17 @@ export class MySQLAdapter implements DatabaseAdapter {
     let totalRowCount = 0
 
     return withMySQLConnection(config, async (connection) => {
+      // Closes over the pool acquisition, which is the only connection-level cost left
+      // now that pooling amortises the handshake — and the one worth seeing, since it
+      // spikes when the pool saturates. There is no per-query DB handshake to report.
+      if (collectTelemetry) {
+        telemetryCollector.endPhase(executionId, TELEMETRY_PHASES.TCP_HANDSHAKE)
+      }
+
       // Whether this call set a session-scoped timeout that must be undone before the
       // connection goes back to the pool.
       let timeoutWasSet = false
       try {
-        if (collectTelemetry) {
-          telemetryCollector.endPhase(executionId, TELEMETRY_PHASES.TCP_HANDSHAKE)
-          telemetryCollector.startPhase(executionId, TELEMETRY_PHASES.DB_HANDSHAKE)
-          telemetryCollector.endPhase(executionId, TELEMETRY_PHASES.DB_HANDSHAKE)
-        }
-
         // Set query timeout if specified (0 = no timeout)
         // Note: max_execution_time only affects SELECT statements in MySQL 5.7.8+
         const queryTimeoutMs = options?.queryTimeoutMs
@@ -314,9 +315,16 @@ export class MySQLAdapter implements DatabaseAdapter {
         }
         // The connection is about to go back to the pool, so undo the session-scoped
         // timeout — otherwise the next unrelated query on this connection silently
-        // inherits it. Best-effort: a cancelled query already destroyed the socket.
+        // inherits it. If the reset itself fails the session state is unknown, so
+        // destroy the connection rather than let the pool hand it to someone else;
+        // mysql2 replaces it on the next checkout. (A cancelled query has already
+        // destroyed the socket, which is why the reset can fail at all.)
         if (timeoutWasSet) {
-          await connection.query('SET SESSION max_execution_time = 0').catch(() => {})
+          try {
+            await connection.query('SET SESSION max_execution_time = 0')
+          } catch {
+            connection.destroy()
+          }
         }
       }
     })

--- a/apps/desktop/src/main/adapters/mysql-client-config.ts
+++ b/apps/desktop/src/main/adapters/mysql-client-config.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from 'fs'
+import type mysql from 'mysql2/promise'
+import type { ConnectionConfig } from '@shared/index'
+
+/**
+ * Create MySQL connection config from our ConnectionConfig.
+ * Properly handles SSL options for cloud databases like AWS RDS.
+ *
+ * Lives apart from the adapter so the pool manager can build a config without importing
+ * the adapter that consumes the pool.
+ */
+export function toMySQLConfig(
+  config: ConnectionConfig,
+  overrides?: { host: string; port: number }
+): mysql.ConnectionOptions {
+  const mysqlConfig: mysql.ConnectionOptions = {
+    host: overrides?.host ?? config.host,
+    port: overrides?.port ?? config.port,
+    user: config.user,
+    password: config.password,
+    database: config.database
+  }
+
+  if (config.ssl) {
+    const sslOptions = config.sslOptions || {}
+
+    if (sslOptions.ca) {
+      try {
+        mysqlConfig.ssl = {
+          rejectUnauthorized: sslOptions.rejectUnauthorized !== false,
+          ca: readFileSync(sslOptions.ca, 'utf-8')
+        }
+      } catch (err) {
+        console.error(`Failed to read CA certificate from ${sslOptions.ca}:`, err)
+        throw new Error(
+          `Failed to read CA certificate file: ${sslOptions.ca}. Please verify the file exists and is readable.`
+        )
+      }
+    } else {
+      // Default to rejectUnauthorized: false so cloud MySQL (RDS, PlanetScale,
+      // Aiven) with self-signed / private-CA certs works out of the box.
+      // Strict verification is opt-in via the UI.
+      mysqlConfig.ssl = {
+        rejectUnauthorized: sslOptions.rejectUnauthorized === true
+      }
+    }
+  }
+
+  return mysqlConfig
+}

--- a/apps/desktop/src/main/adapters/mysql-pool-manager.ts
+++ b/apps/desktop/src/main/adapters/mysql-pool-manager.ts
@@ -1,0 +1,101 @@
+import mysql from 'mysql2/promise'
+import type { ConnectionConfig } from '@shared/index'
+import { createLogger } from '../lib/logger'
+import { toMySQLConfig } from './mysql-client-config'
+import { PoolRegistry } from './pool-registry'
+
+const log = createLogger('mysql-pool')
+
+/**
+ * Connection pooling for MySQL.
+ *
+ * Every adapter method used to open its own connection — and, for SSH connections, its
+ * own tunnel — then tear both down again. That meant a full SSH handshake plus a MySQL
+ * auth handshake for every schema refresh, every autocomplete lookup, every query.
+ * Pooling collapses that to one tunnel and a handful of reused sockets per connection.
+ */
+
+const POOL_MAX = 5
+const IDLE_TIMEOUT_MS = 30_000
+const CONNECT_TIMEOUT_MS = 15_000
+
+const registry = new PoolRegistry<mysql.Pool>({
+  driver: 'mysql',
+  create: (config, overrides) =>
+    mysql.createPool({
+      ...toMySQLConfig(config, overrides),
+      waitForConnections: true,
+      connectionLimit: POOL_MAX,
+      idleTimeout: IDLE_TIMEOUT_MS,
+      connectTimeout: CONNECT_TIMEOUT_MS,
+      // Bound the queue instead of letting it grow without limit: a wedged server
+      // should surface as an error, not an ever-growing backlog of pending callers.
+      queueLimit: 100,
+      // TCP keepalive so a socket killed while idle (laptop sleep, NAT reap, server
+      // restart) is detected rather than handed to a caller that then hangs.
+      enableKeepAlive: true,
+      keepAliveInitialDelay: 10_000
+    }),
+  destroy: (pool) => pool.end()
+})
+
+/**
+ * Acquire a pooled connection, run `fn`, and release it.
+ *
+ * Session state set inside `fn` outlives the call — the connection goes back to the
+ * pool as-is — so anything that runs `SET SESSION` must reset it. `withMySQLConnection`
+ * itself deliberately doesn't blanket-reset, since that would cost a round trip on
+ * every query for a case only one caller needs.
+ */
+export async function withMySQLConnection<T>(
+  config: ConnectionConfig,
+  fn: (connection: mysql.PoolConnection) => Promise<T>
+): Promise<T> {
+  const entry = await registry.getOrCreate(config)
+  const connection = await entry.pool.getConnection()
+  try {
+    return await fn(connection)
+  } finally {
+    // Always safe: a cancelled query destroys its connection out from under us (see
+    // query-tracker), and mysql2's PoolConnection#destroy nulls `_pool`, which makes
+    // this release a no-op rather than a double-release.
+    connection.release()
+  }
+}
+
+/**
+ * Acquire a pooled connection, BEGIN, run `fn`, then COMMIT (or ROLLBACK on failure).
+ */
+export async function withMySQLTransaction<T>(
+  config: ConnectionConfig,
+  fn: (connection: mysql.PoolConnection) => Promise<T>
+): Promise<T> {
+  return withMySQLConnection(config, async (connection) => {
+    await connection.beginTransaction()
+    try {
+      const result = await fn(connection)
+      await connection.commit()
+      return result
+    } catch (error) {
+      try {
+        await connection.rollback()
+      } catch (rollbackErr) {
+        // The connection's transaction state is now unknown; destroying it keeps the
+        // pool from handing the next caller a connection mid-transaction.
+        log.warn('rollback failed:', (rollbackErr as Error).message)
+        connection.destroy()
+      }
+      throw error
+    }
+  })
+}
+
+/** Close the pool (and tunnel) for a single connection. */
+export async function closeMySQLPool(config: ConnectionConfig): Promise<void> {
+  return registry.close(config)
+}
+
+/** Close every MySQL pool. Call on app shutdown. */
+export async function closeAllMySQLPools(): Promise<void> {
+  return registry.closeAll()
+}

--- a/apps/desktop/src/main/adapters/pg-client-config.ts
+++ b/apps/desktop/src/main/adapters/pg-client-config.ts
@@ -57,7 +57,14 @@ export function buildClientConfig(
     port: overrides?.port ?? config.port,
     database: config.database,
     user: config.user,
-    password: config.password
+    password: config.password,
+    // pg leaves TCP keepalive off by default, which makes a pooled socket that died
+    // while idle — laptop sleep, a NAT/firewall idle reap, a server restart — look
+    // healthy until a query is handed to it and hangs instead of erroring. Keepalive
+    // probes surface the death on the socket, so pg.Pool can evict the client via its
+    // 'error' handler before a caller ever gets it.
+    keepAlive: true,
+    keepAliveInitialDelayMillis: 10_000
   }
 
   // Applied at connection startup rather than via a follow-up SET, so every physical

--- a/apps/desktop/src/main/adapters/pg-pool-manager.ts
+++ b/apps/desktop/src/main/adapters/pg-pool-manager.ts
@@ -2,7 +2,7 @@ import { types as pgTypes, Pool, type ClientConfig, type PoolClient } from 'pg'
 import type { ConnectionConfig } from '@shared/index'
 import { createLogger } from '../lib/logger'
 import { buildClientConfig } from './pg-client-config'
-import { PoolRegistry } from './pool-registry'
+import { PoolRegistry, poolIdentity } from './pool-registry'
 
 const log = createLogger('pg-pool')
 
@@ -89,11 +89,6 @@ function ensureSessionPool(pools: PgPools): Pool {
   return sessionPool
 }
 
-export async function getOrCreatePool(config: ConnectionConfig): Promise<{ pool: Pool }> {
-  const entry = await registry.getOrCreate(config)
-  return { pool: entry.pool.pool }
-}
-
 /**
  * Acquire a pooled client, run `fn`, and release the client.
  *
@@ -118,6 +113,14 @@ export async function withPgClient<T>(
       // already released
     }
   }
+}
+
+/**
+ * Which connection a pool belongs to, for callers bucketing their own per-connection
+ * state (parked transaction sessions) the same way the registry buckets pools.
+ */
+export function pgPoolIdentity(config: ConnectionConfig): string {
+  return poolIdentity('pg', config)
 }
 
 /**

--- a/apps/desktop/src/main/adapters/pg-pool-manager.ts
+++ b/apps/desktop/src/main/adapters/pg-pool-manager.ts
@@ -1,105 +1,47 @@
-import { createHash } from 'crypto'
-import { types as pgTypes, Pool, type PoolClient } from 'pg'
+import { types as pgTypes, Pool, type ClientConfig, type PoolClient } from 'pg'
 import type { ConnectionConfig } from '@shared/index'
-import { closeTunnel, createTunnel, type TunnelSession } from '../ssh-tunnel-service'
 import { createLogger } from '../lib/logger'
 import { buildClientConfig } from './pg-client-config'
+import { PoolRegistry } from './pool-registry'
 
 const log = createLogger('pg-pool')
 
 /**
  * Connection pooling for Postgres.
  *
- * Each saved connection gets one pg.Pool plus (optionally) one SSH tunnel that
- * the pool's clients share. Pools are created lazily on first use and torn
- * down via `closePgPool` when the connection is edited/deleted.
- *
- * A pool is keyed by *both* the connection it belongs to and the shape it was built
- * from, so a config that has been edited — new credentials, TLS settings, schema,
- * tunnel — always gets a fresh socket rather than a pool that predates the change.
+ * Each saved connection gets one pg.Pool plus (optionally) one SSH tunnel that the
+ * pool's clients share, plus a second pool built lazily for manual transactions. The
+ * keying, tunnel sharing, shape-change rebuild and teardown all come from
+ * `PoolRegistry`, which the MySQL and SQL Server managers share.
  */
-
-interface PoolEntry {
-  pool: Pool
-  tunnel: TunnelSession | null
-}
 
 const POOL_MAX = 5
+// Manual transactions get their own budget rather than eating into POOL_MAX.
+const SESSION_POOL_MAX = 4
 const IDLE_TIMEOUT_MS = 30_000
 const CONNECT_TIMEOUT_MS = 15_000
-// pool.end() blocks until every checked-out client is released, so an ad-hoc query
-// stuck on a server-side lock (or a dead socket) would otherwise hang teardown
-// indefinitely — leaving `shuttingDown` latched and every later acquisition failing
-// with "Pool manager is shutting down". Bound each end() so teardown always completes.
-const POOL_END_TIMEOUT_MS = 2_500
 
-const pools = new Map<string, PoolEntry>()
-// Tracks in-flight pool creation so concurrent first-use callers share one tunnel/pool.
-const pendingPools = new Map<string, Promise<PoolEntry>>()
-// identity -> most recently requested pool key, so a slow creation can detect that the
-// connection's shape moved on while it was dialing. Entries are dropped on teardown.
-const latestShape = new Map<string, string>()
-
-let shuttingDown = false
-let teardownInFlight: Promise<void> | null = null
-
-/**
- * Hash the fields that decide what a physical connection *is*.
- *
- * Everything here is baked into the socket at startup — the TLS handshake, the
- * credentials, the `search_path` startup option, the tunnel it rides through — so a
- * pool built from one shape can never be handed to a caller asking for another. That
- * used to be exactly what happened when a *saved* connection was edited: pools keyed
- * on `config.id` alone meant ticking "Use SSL" and hitting Test Connection reused the
- * cached plaintext pool, and the server kept answering `no pg_hba.conf entry for host
- * ... no encryption` with the box checked (issue #252).
- */
-function getShapeFingerprint(config: ConnectionConfig): string {
-  return createHash('sha256')
-    .update(
-      JSON.stringify({
-        host: config.host,
-        port: config.port,
-        database: config.database,
-        user: config.user ?? '',
-        password: config.password ?? '',
-        schema: config.schema ?? '',
-        ssl: config.ssl ? (config.sslOptions ?? {}) : false,
-        ssh: config.ssh ? (config.sshConfig ?? null) : null
-      })
-    )
-    .digest('hex')
-    .slice(0, 16)
+interface PgPools {
+  pool: Pool
+  /**
+   * Second pool, built lazily from the same client config and riding the same tunnel,
+   * that serves only manual (`BEGIN`-and-hold) transaction sessions. See
+   * `acquirePgSessionClient` for why these can't come out of `pool`.
+   */
+  sessionPool: Pool | null
+  /** Client config `sessionPool` is built from, kept so creation stays synchronous. */
+  clientConfig: ClientConfig
+  /** Session clients currently checked out of `sessionPool` and held open. */
+  parkedSessions: number
 }
 
-/**
- * Which connection a pool belongs to, independent of its current shape: the saved
- * connection's id, or the target itself for an ad-hoc config that was never saved.
- * Shape variants under one identity are collapsed to a single live pool.
- */
-function getPoolIdentity(config: ConnectionConfig): string {
-  if (config.id) return `pg:id:${config.id}`
-  return `pg:adhoc:${config.host}:${config.port}:${config.database}:${config.user ?? 'default'}`
-}
-
-function getPoolKey(config: ConnectionConfig): string {
-  return `${getPoolIdentity(config)}#${getShapeFingerprint(config)}`
-}
-
-/** Recover the identity half of a pool key. Fingerprints never contain `#`. */
-function identityOf(key: string): string {
-  return key.slice(0, key.lastIndexOf('#'))
-}
-
-async function createPoolEntry(config: ConnectionConfig, key: string): Promise<PoolEntry> {
-  let tunnel: TunnelSession | null = null
-  if (config.ssh) {
-    tunnel = await createTunnel(config)
-  }
-  try {
-    const overrides = tunnel ? { host: tunnel.localHost, port: tunnel.localPort } : undefined
+const registry = new PoolRegistry<PgPools>({
+  driver: 'pg',
+  // search_path is pinned via startup options, so a pool built for one schema can never
+  // be handed to a caller asking for another.
+  fingerprintExtras: (config) => ({ schema: config.schema ?? '' }),
+  create: (config, overrides) => {
     const clientConfig = buildClientConfig(config, overrides)
-
     const pool = new Pool({
       ...clientConfig,
       max: POOL_MAX,
@@ -107,8 +49,8 @@ async function createPoolEntry(config: ConnectionConfig, key: string): Promise<P
       connectionTimeoutMillis: CONNECT_TIMEOUT_MS
     })
 
-    // Return timestamp (without tz) values as raw ISO strings so JavaScript's
-    // Date auto-conversion doesn't shift UTC-stored timestamps to local time.
+    // Return timestamp (without tz) values as raw ISO strings so JavaScript's Date
+    // auto-conversion doesn't shift UTC-stored timestamps to local time.
     // OID 1114 = timestamp, 1184 = timestamptz (timestamptz SHOULD be shifted).
     pgTypes.setTypeParser(1114, (val: string) => val)
 
@@ -118,106 +60,53 @@ async function createPoolEntry(config: ConnectionConfig, key: string): Promise<P
       log.warn('idle client error:', err.message)
     })
 
-    // If the SSH tunnel dies (server restart, network blip), evict the pool entry
-    // so the next withPgClient call rebuilds tunnel+pool instead of dialing a dead port.
-    if (tunnel?.ssh) {
-      tunnel.ssh.once('close', () => {
-        const current = pools.get(key)
-        if (current && current.tunnel === tunnel) {
-          pools.delete(key)
-          current.pool.end().catch(() => {})
-        }
-      })
-    }
-
-    return { pool, tunnel }
-  } catch (err) {
-    closeTunnel(tunnel)
-    throw err
+    return { pool, sessionPool: null, clientConfig, parkedSessions: 0 }
+  },
+  destroy: async (pools) => {
+    await Promise.all([pools.pool.end(), pools.sessionPool ? pools.sessionPool.end() : undefined])
   }
-}
+})
 
 /**
- * Retire pools that share `identity` but were built from a different shape.
+ * Build (once) the pool that backs manual transaction sessions.
  *
- * Runs on every acquisition, which is what keeps a connection down to one live pool
- * as its shape changes — otherwise each edited-and-tested variant would linger until
- * app shutdown. `pool.end()` drains its own checked-out clients, so a query still
- * running on the outgoing pool finishes; we don't wait for it because the caller is
- * waiting on a different pool entirely.
- *
- * Two shapes of one connection being used *concurrently* — a Test Connection on an
- * edited config while the saved one is being queried — therefore retire each other in
- * turn. That is accepted: both callers still talk to a pool matching their own config,
- * and a Test Connection is one `SELECT 1`, so the churn is a pool rebuild or two rather
- * than a sustained thrash.
+ * `new Pool()` doesn't dial — pg connects lazily on first checkout — so this stays
+ * synchronous and two concurrent `beginTransaction` calls can't race into building
+ * two pools.
  */
-function evictOtherShapes(identity: string, keepKey: string): void {
-  for (const [key, entry] of pools) {
-    if (key === keepKey || identityOf(key) !== identity) continue
-    pools.delete(key)
-    log.debug('retiring pool built from a superseded connection shape')
-    entry.pool.end().catch((err) => {
-      log.warn('error ending superseded pool:', (err as Error).message)
-    })
-    closeTunnel(entry.tunnel)
-  }
+function ensureSessionPool(pools: PgPools): Pool {
+  if (pools.sessionPool) return pools.sessionPool
+  const sessionPool = new Pool({
+    ...pools.clientConfig,
+    max: SESSION_POOL_MAX,
+    idleTimeoutMillis: IDLE_TIMEOUT_MS,
+    connectionTimeoutMillis: CONNECT_TIMEOUT_MS
+  })
+  sessionPool.on('error', (err) => {
+    log.warn('idle session client error:', err.message)
+  })
+  pools.sessionPool = sessionPool
+  return sessionPool
 }
 
-export async function getOrCreatePool(config: ConnectionConfig): Promise<PoolEntry> {
-  if (shuttingDown) {
-    throw new Error('Pool manager is shutting down')
-  }
-  const key = getPoolKey(config)
-  const identity = identityOf(key)
-  // Recorded before dialing so a creation that is still in flight can tell it has been
-  // superseded: evictOtherShapes only sees installed pools, so without this a slow dial
-  // (SSH tunnel setup widens the window considerably) would install a second live pool
-  // and tunnel under one identity after a newer shape had already been installed.
-  latestShape.set(identity, key)
-  evictOtherShapes(identity, key)
-
-  const existing = pools.get(key)
-  if (existing) return existing
-
-  const inflight = pendingPools.get(key)
-  if (inflight) return inflight
-
-  const promise = createPoolEntry(config, key)
-    .then((entry) => {
-      // Don't install the entry if a closePgPool/shutdown raced and decided to drop it,
-      // or if a newer shape for this connection was acquired while we were dialing.
-      if (shuttingDown || pendingPools.get(key) !== promise || latestShape.get(identity) !== key) {
-        entry.pool.end().catch(() => {})
-        closeTunnel(entry.tunnel)
-        throw new Error('Pool was closed before initialization completed')
-      }
-      pools.set(key, entry)
-      return entry
-    })
-    .finally(() => {
-      if (pendingPools.get(key) === promise) {
-        pendingPools.delete(key)
-      }
-    })
-
-  pendingPools.set(key, promise)
-  return promise
+export async function getOrCreatePool(config: ConnectionConfig): Promise<{ pool: Pool }> {
+  const entry = await registry.getOrCreate(config)
+  return { pool: entry.pool.pool }
 }
 
 /**
  * Acquire a pooled client, run `fn`, and release the client.
  *
- * The client is always released back to the pool, even if `fn` throws. If the
- * caller needs the connection torn down (e.g. after a cancelled query left it
- * in an unknown state) it can call `client.release(true)` itself.
+ * The client is always released back to the pool, even if `fn` throws. If the caller
+ * needs the connection torn down (e.g. after a cancelled query left it in an unknown
+ * state) it can call `client.release(true)` itself.
  */
 export async function withPgClient<T>(
   config: ConnectionConfig,
   fn: (client: PoolClient) => Promise<T>
 ): Promise<T> {
-  const entry = await getOrCreatePool(config)
-  const client = await entry.pool.connect()
+  const entry = await registry.getOrCreate(config)
+  const client = await entry.pool.pool.connect()
   try {
     return await fn(client)
   } finally {
@@ -232,14 +121,77 @@ export async function withPgClient<T>(
 }
 
 /**
+ * A session client checked out of the session pool, plus the one call that returns it.
+ * `release` is idempotent, so a cancellation path that already destroyed the client
+ * doesn't have to coordinate with the owner.
+ */
+export interface PgSessionLease {
+  client: PoolClient
+  /** Return the client. Pass `true` to destroy it instead of recycling it. */
+  release(destroy?: boolean): void
+}
+
+/**
+ * Check out a client to hold open for a manual (`BEGIN`-and-hold) transaction.
+ *
+ * These come from a *separate* pool. A manual transaction parks its client for as long
+ * as the user leaves the transaction open, so serving them from the main pool meant
+ * POOL_MAX open transactions could consume every slot — after which every ordinary
+ * query on that connection (including background work like schema refresh) blocked on
+ * `pool.connect()` and failed after CONNECT_TIMEOUT_MS with pg's generic
+ * "timeout exceeded when trying to connect".
+ *
+ * Saturating the session pool is now a local failure with an actionable message, and
+ * ad-hoc queries keep all POOL_MAX of their own slots regardless.
+ */
+export async function acquirePgSessionClient(config: ConnectionConfig): Promise<PgSessionLease> {
+  const entry = await registry.getOrCreate(config)
+  const pools = entry.pool
+  // Checked up front rather than letting pool.connect() queue, so the caller gets a
+  // reason instead of a 15-second wait ending in a connection-timeout error.
+  if (pools.parkedSessions >= SESSION_POOL_MAX) {
+    throw new Error(
+      `This connection already has ${SESSION_POOL_MAX} open transactions, which is the maximum. ` +
+        `Commit or roll one back before starting another.`
+    )
+  }
+
+  const sessionPool = ensureSessionPool(pools)
+  // Reserved before the await so concurrent acquisitions can't both pass the check above.
+  pools.parkedSessions++
+  let client: PoolClient
+  try {
+    client = await sessionPool.connect()
+  } catch (err) {
+    pools.parkedSessions--
+    throw err
+  }
+
+  let released = false
+  return {
+    client,
+    release(destroy?: boolean) {
+      if (released) return
+      released = true
+      pools.parkedSessions--
+      try {
+        client.release(destroy)
+      } catch {
+        // Cancellation paths may have already destroyed this client.
+      }
+    }
+  }
+}
+
+/**
  * Acquire a pooled client, BEGIN, run `fn`, then COMMIT (or ROLLBACK on failure).
  */
 export async function withPgTransaction<T>(
   config: ConnectionConfig,
   fn: (client: PoolClient) => Promise<T>
 ): Promise<T> {
-  const entry = await getOrCreatePool(config)
-  const client = await entry.pool.connect()
+  const entry = await registry.getOrCreate(config)
+  const client = await entry.pool.pool.connect()
   let poisoned = false
   try {
     await client.query('BEGIN')
@@ -266,113 +218,14 @@ export async function withPgTransaction<T>(
 }
 
 /**
- * Drop the in-memory pool entry without ending the underlying pg.Pool.
- * Used by callers that have already destroyed the pool out-of-band.
- */
-function evictPoolEntry(key: string): PoolEntry | undefined {
-  const entry = pools.get(key)
-  if (!entry) return undefined
-  pools.delete(key)
-  return entry
-}
-
-/**
- * Close the pool (and its tunnel) for a single connection. Call when the
- * connection is updated or deleted so subsequent queries pick up the new
- * shape. Awaits any in-flight pool creation so we don't leak an entry that
- * appears after this returns.
+ * Close the pool (and its tunnel) for a single connection. Call when the connection is
+ * updated or deleted so subsequent queries pick up the new shape.
  */
 export async function closePgPool(config: ConnectionConfig): Promise<void> {
-  // Every shape variant goes, not just the one matching the config we were handed:
-  // the caller passes the *pre-edit* config, while a Test Connection during that edit
-  // may already have built a pool from the new shape.
-  const identity = getPoolIdentity(config)
-  // Also makes any in-flight creation for this connection self-dispose instead of
-  // installing itself after we have finished tearing down.
-  latestShape.delete(identity)
-
-  for (const [key, promise] of pendingPools) {
-    if (identityOf(key) !== identity) continue
-    pendingPools.delete(key)
-    // The .then in getOrCreatePool checks pendingPools identity and self-disposes.
-    await promise.catch(() => {})
-  }
-
-  const entries = Array.from(pools.keys())
-    .filter((key) => identityOf(key) === identity)
-    .map((key) => evictPoolEntry(key))
-
-  for (const entry of entries) {
-    if (!entry) continue
-    try {
-      await entry.pool.end()
-    } catch (err) {
-      log.warn('error ending pool:', (err as Error).message)
-    }
-    closeTunnel(entry.tunnel)
-  }
+  return registry.close(config)
 }
 
-/**
- * Close every pool. Call on app shutdown.
- *
- * `shuttingDown` is a *transient* guard, not a permanent latch: it blocks new
- * pool creation only while teardown is in flight (so a pool created mid-teardown
- * can't be orphaned by the snapshot below), then clears. This matters on macOS,
- * where the process routinely outlives a cleanup pass — the last window hides
- * instead of quitting, and a raced/aborted quit (e.g. an auto-update
- * `quitAndInstall` whose quit is preventDefault-ed) can run this without the
- * process dying. If the flag stayed latched, every later pool acquisition would
- * fail with "Pool manager is shutting down" until relaunch.
- */
-// Await pool.end() but never longer than POOL_END_TIMEOUT_MS. A stuck client keeps
-// end() pending forever; letting teardown move on unblocks the manager's state reset
-// (the pg socket handle is the OS's to clean up on exit).
-async function endPoolBounded(pool: Pool): Promise<void> {
-  let timer: ReturnType<typeof setTimeout> | undefined
-  try {
-    await Promise.race([
-      pool.end(),
-      new Promise<void>((resolve) => {
-        timer = setTimeout(resolve, POOL_END_TIMEOUT_MS)
-        timer.unref?.()
-      })
-    ])
-  } finally {
-    if (timer) clearTimeout(timer)
-  }
-}
-
+/** Close every Postgres pool. Call on app shutdown. */
 export async function closeAllPgPools(): Promise<void> {
-  // Coalesce concurrent calls onto one teardown, so a second call's `finally`
-  // can't flip `shuttingDown` back to false while the first is still tearing down.
-  if (teardownInFlight) return teardownInFlight
-  shuttingDown = true
-  teardownInFlight = (async () => {
-    try {
-      // Let in-flight pool creations settle first. Each resolves through
-      // getOrCreatePool's post-create check, which ends the pool and closes its
-      // tunnel while `shuttingDown` is true — so awaiting them here tears them
-      // down too instead of leaking a half-created pool + tunnel. New creations
-      // can't start during teardown (the guard above rejects them).
-      await Promise.allSettled(Array.from(pendingPools.values()))
-      const entries = Array.from(pools.values())
-      pools.clear()
-      latestShape.clear()
-      await Promise.all(
-        entries.map(async (entry) => {
-          try {
-            await endPoolBounded(entry.pool)
-          } catch (err) {
-            log.warn('error ending pool:', (err as Error).message)
-          }
-          closeTunnel(entry.tunnel)
-        })
-      )
-    } finally {
-      shuttingDown = false
-      teardownInFlight = null
-    }
-  })()
-  return teardownInFlight
+  return registry.closeAll()
 }

--- a/apps/desktop/src/main/adapters/pool-registry.ts
+++ b/apps/desktop/src/main/adapters/pool-registry.ts
@@ -45,6 +45,19 @@ export interface PoolRegistryOptions<TPool> {
 /** Bound every destroy() so one stuck client can't leave the registry mid-teardown. */
 const POOL_END_TIMEOUT_MS = 2_500
 
+/**
+ * Which connection a pool belongs to, independent of its current shape: the saved
+ * connection's id, or the target itself for an ad-hoc config that was never saved.
+ * Shape variants under one identity are collapsed to a single live pool.
+ *
+ * Exported so callers holding per-connection state of their own — parked transaction
+ * sessions, for instance — can bucket it the same way the registry buckets pools.
+ */
+export function poolIdentity(driver: string, config: ConnectionConfig): string {
+  if (config.id) return `${driver}:id:${config.id}`
+  return `${driver}:adhoc:${config.host}:${config.port}:${config.database}:${config.user ?? 'default'}`
+}
+
 export class PoolRegistry<TPool> {
   private readonly log
   private readonly pools = new Map<string, PoolEntry<TPool>>()
@@ -90,15 +103,8 @@ export class PoolRegistry<TPool> {
       .slice(0, 16)
   }
 
-  /**
-   * Which connection a pool belongs to, independent of its current shape: the saved
-   * connection's id, or the target itself for an ad-hoc config that was never saved.
-   * Shape variants under one identity are collapsed to a single live pool.
-   */
   private identity(config: ConnectionConfig): string {
-    const { driver } = this.options
-    if (config.id) return `${driver}:id:${config.id}`
-    return `${driver}:adhoc:${config.host}:${config.port}:${config.database}:${config.user ?? 'default'}`
+    return poolIdentity(this.options.driver, config)
   }
 
   private key(config: ConnectionConfig): string {

--- a/apps/desktop/src/main/adapters/pool-registry.ts
+++ b/apps/desktop/src/main/adapters/pool-registry.ts
@@ -234,7 +234,11 @@ export class PoolRegistry<TPool> {
 
     for (const entry of entries) {
       try {
-        await this.options.destroy(entry.pool)
+        // Bounded, like closeAll(): closeTunnel below runs *after* this, so an
+        // unbounded destroy that never settles (a checked-out client that never
+        // releases) would strand the SSH tunnel and its bound local port for the rest
+        // of the session.
+        await this.destroyBounded(entry.pool)
       } catch (err) {
         this.log.warn('error ending pool:', (err as Error).message)
       }

--- a/apps/desktop/src/main/adapters/pool-registry.ts
+++ b/apps/desktop/src/main/adapters/pool-registry.ts
@@ -1,0 +1,306 @@
+import { createHash } from 'crypto'
+import type { ConnectionConfig } from '@shared/index'
+import { closeTunnel, createTunnel, type TunnelSession } from '../ssh-tunnel-service'
+import { createLogger } from '../lib/logger'
+
+/**
+ * Driver-agnostic connection-pool lifecycle.
+ *
+ * Every supported database needs the same things around its pool: one pool per saved
+ * connection, an SSH tunnel the pool's sockets share, a rebuild when the connection's
+ * shape changes, and a teardown that can't wedge. That logic was written once for
+ * Postgres; this is it lifted out so MySQL and SQL Server get the same guarantees
+ * instead of their own partial re-derivations.
+ *
+ * `TPool` is whatever handle the driver pools with — a `pg.Pool`, a `mysql2` pool, an
+ * `mssql.ConnectionPool`, or a composite when a driver needs more than one (Postgres
+ * carries a second pool for held-open transactions).
+ */
+
+export interface PoolEntry<TPool> {
+  pool: TPool
+  tunnel: TunnelSession | null
+}
+
+export interface PoolRegistryOptions<TPool> {
+  /** Namespaces pool keys so two drivers can't collide on one connection id. */
+  driver: string
+  /**
+   * Driver-specific config that changes what the physical connection *is* and so must
+   * force a new pool when it changes (TLS options, driver flags, auth mode).
+   */
+  fingerprintExtras?(config: ConnectionConfig): unknown
+  /**
+   * Build the driver's pool. `overrides` carries the local tunnel endpoint when the
+   * connection rides SSH. Never called concurrently for the same key.
+   */
+  create(
+    config: ConnectionConfig,
+    overrides: { host: string; port: number } | undefined
+  ): Promise<TPool> | TPool
+  /** Tear the pool down. Called at most once per created pool. */
+  destroy(pool: TPool): Promise<void>
+}
+
+/** Bound every destroy() so one stuck client can't leave the registry mid-teardown. */
+const POOL_END_TIMEOUT_MS = 2_500
+
+export class PoolRegistry<TPool> {
+  private readonly log
+  private readonly pools = new Map<string, PoolEntry<TPool>>()
+  /** In-flight creation, so concurrent first-use callers share one tunnel and pool. */
+  private readonly pendingPools = new Map<string, Promise<PoolEntry<TPool>>>()
+  /**
+   * identity -> most recently requested key, so a slow dial can detect that the
+   * connection's shape moved on while it was connecting.
+   */
+  private readonly latestShape = new Map<string, string>()
+
+  private shuttingDown = false
+  private teardownInFlight: Promise<void> | null = null
+
+  constructor(private readonly options: PoolRegistryOptions<TPool>) {
+    this.log = createLogger(`${options.driver}-pool`)
+  }
+
+  /**
+   * Hash the fields that decide what a physical connection *is*.
+   *
+   * Everything here is baked into the socket at startup — the TLS handshake, the
+   * credentials, the tunnel it rides through — so a pool built from one shape can never
+   * be handed to a caller asking for another. That used to be exactly what happened when
+   * a *saved* connection was edited: pools keyed on `config.id` alone meant ticking
+   * "Use SSL" and hitting Test Connection reused the cached plaintext pool (issue #252).
+   */
+  private shapeFingerprint(config: ConnectionConfig): string {
+    return createHash('sha256')
+      .update(
+        JSON.stringify({
+          host: config.host,
+          port: config.port,
+          database: config.database,
+          user: config.user ?? '',
+          password: config.password ?? '',
+          ssl: config.ssl ? (config.sslOptions ?? {}) : false,
+          ssh: config.ssh ? (config.sshConfig ?? null) : null,
+          extras: this.options.fingerprintExtras?.(config) ?? null
+        })
+      )
+      .digest('hex')
+      .slice(0, 16)
+  }
+
+  /**
+   * Which connection a pool belongs to, independent of its current shape: the saved
+   * connection's id, or the target itself for an ad-hoc config that was never saved.
+   * Shape variants under one identity are collapsed to a single live pool.
+   */
+  private identity(config: ConnectionConfig): string {
+    const { driver } = this.options
+    if (config.id) return `${driver}:id:${config.id}`
+    return `${driver}:adhoc:${config.host}:${config.port}:${config.database}:${config.user ?? 'default'}`
+  }
+
+  private key(config: ConnectionConfig): string {
+    return `${this.identity(config)}#${this.shapeFingerprint(config)}`
+  }
+
+  /** Recover the identity half of a pool key. Fingerprints never contain `#`. */
+  private identityOf(key: string): string {
+    return key.slice(0, key.lastIndexOf('#'))
+  }
+
+  private async createEntry(config: ConnectionConfig, key: string): Promise<PoolEntry<TPool>> {
+    let tunnel: TunnelSession | null = null
+    if (config.ssh) {
+      tunnel = await createTunnel(config)
+    }
+    try {
+      const overrides = tunnel ? { host: tunnel.localHost, port: tunnel.localPort } : undefined
+      const pool = await this.options.create(config, overrides)
+
+      // If the SSH tunnel dies (server restart, network blip), evict the entry so the
+      // next acquisition rebuilds tunnel+pool instead of dialing a dead local port.
+      if (tunnel?.ssh) {
+        tunnel.ssh.once('close', () => {
+          const current = this.pools.get(key)
+          if (current && current.tunnel === tunnel) {
+            this.pools.delete(key)
+            this.options.destroy(current.pool).catch(() => {})
+          }
+        })
+      }
+
+      return { pool, tunnel }
+    } catch (err) {
+      closeTunnel(tunnel)
+      throw err
+    }
+  }
+
+  /**
+   * Retire pools that share `identity` but were built from a different shape.
+   *
+   * Runs on every acquisition, which is what keeps a connection down to one live pool
+   * as its shape changes — otherwise each edited-and-tested variant would linger until
+   * app shutdown. We don't await the teardown because the caller is waiting on a
+   * different pool entirely; a query still running on the outgoing pool drains itself.
+   */
+  private evictOtherShapes(identity: string, keepKey: string): void {
+    for (const [key, entry] of this.pools) {
+      if (key === keepKey || this.identityOf(key) !== identity) continue
+      this.pools.delete(key)
+      this.log.debug('retiring pool built from a superseded connection shape')
+      this.options.destroy(entry.pool).catch((err) => {
+        this.log.warn('error ending superseded pool:', (err as Error).message)
+      })
+      closeTunnel(entry.tunnel)
+    }
+  }
+
+  async getOrCreate(config: ConnectionConfig): Promise<PoolEntry<TPool>> {
+    if (this.shuttingDown) {
+      throw new Error('Pool manager is shutting down')
+    }
+    const key = this.key(config)
+    const identity = this.identityOf(key)
+    // Recorded before dialing so a creation still in flight can tell it has been
+    // superseded: evictOtherShapes only sees installed pools, so without this a slow
+    // dial (SSH tunnel setup widens the window considerably) would install a second
+    // live pool and tunnel under one identity after a newer shape was already in place.
+    this.latestShape.set(identity, key)
+    this.evictOtherShapes(identity, key)
+
+    const existing = this.pools.get(key)
+    if (existing) return existing
+
+    const inflight = this.pendingPools.get(key)
+    if (inflight) return inflight
+
+    const promise = this.createEntry(config, key)
+      .then((entry) => {
+        // Don't install if a close()/closeAll() raced and decided to drop this, or if a
+        // newer shape for this connection was acquired while we were dialing.
+        if (
+          this.shuttingDown ||
+          this.pendingPools.get(key) !== promise ||
+          this.latestShape.get(identity) !== key
+        ) {
+          this.options.destroy(entry.pool).catch(() => {})
+          closeTunnel(entry.tunnel)
+          throw new Error('Pool was closed before initialization completed')
+        }
+        this.pools.set(key, entry)
+        return entry
+      })
+      .finally(() => {
+        if (this.pendingPools.get(key) === promise) {
+          this.pendingPools.delete(key)
+        }
+      })
+
+    this.pendingPools.set(key, promise)
+    return promise
+  }
+
+  /**
+   * Close the pool (and its tunnel) for a single connection. Call when the connection is
+   * updated or deleted so subsequent queries pick up the new shape. Awaits any in-flight
+   * creation so we don't leak an entry that appears after this returns.
+   */
+  async close(config: ConnectionConfig): Promise<void> {
+    // Every shape variant goes, not just the one matching the config we were handed: the
+    // caller passes the *pre-edit* config, while a Test Connection during that edit may
+    // already have built a pool from the new shape.
+    const identity = this.identity(config)
+    // Also makes any in-flight creation self-dispose instead of installing itself after
+    // we have finished tearing down.
+    this.latestShape.delete(identity)
+
+    for (const [key, promise] of this.pendingPools) {
+      if (this.identityOf(key) !== identity) continue
+      this.pendingPools.delete(key)
+      // getOrCreate's .then checks pendingPools identity and self-disposes.
+      await promise.catch(() => {})
+    }
+
+    const entries: PoolEntry<TPool>[] = []
+    for (const key of Array.from(this.pools.keys())) {
+      if (this.identityOf(key) !== identity) continue
+      const entry = this.pools.get(key)
+      this.pools.delete(key)
+      if (entry) entries.push(entry)
+    }
+
+    for (const entry of entries) {
+      try {
+        await this.options.destroy(entry.pool)
+      } catch (err) {
+        this.log.warn('error ending pool:', (err as Error).message)
+      }
+      closeTunnel(entry.tunnel)
+    }
+  }
+
+  /** Await destroy() but never longer than POOL_END_TIMEOUT_MS. */
+  private async destroyBounded(pool: TPool): Promise<void> {
+    let timer: ReturnType<typeof setTimeout> | undefined
+    try {
+      await Promise.race([
+        this.options.destroy(pool),
+        new Promise<void>((resolve) => {
+          timer = setTimeout(resolve, POOL_END_TIMEOUT_MS)
+          timer.unref?.()
+        })
+      ])
+    } finally {
+      if (timer) clearTimeout(timer)
+    }
+  }
+
+  /**
+   * Close every pool. Call on app shutdown.
+   *
+   * `shuttingDown` is a *transient* guard, not a permanent latch: it blocks new pool
+   * creation only while teardown is in flight (so a pool created mid-teardown can't be
+   * orphaned by the snapshot below), then clears. This matters on macOS, where the
+   * process routinely outlives a cleanup pass — the last window hides instead of
+   * quitting, and a raced/aborted quit (e.g. an auto-update `quitAndInstall` whose quit
+   * is preventDefault-ed) can run this without the process dying. If the flag stayed
+   * latched, every later acquisition would fail with "Pool manager is shutting down"
+   * until relaunch.
+   */
+  async closeAll(): Promise<void> {
+    // Coalesce concurrent calls onto one teardown, so a second call's `finally` can't
+    // flip `shuttingDown` back to false while the first is still tearing down.
+    if (this.teardownInFlight) return this.teardownInFlight
+    this.shuttingDown = true
+    this.teardownInFlight = (async () => {
+      try {
+        // Let in-flight creations settle first. Each resolves through getOrCreate's
+        // post-create check, which destroys the pool and closes its tunnel while
+        // `shuttingDown` is true — so awaiting them here tears them down too instead of
+        // leaking a half-created pool + tunnel. New creations can't start during
+        // teardown (the guard in getOrCreate rejects them).
+        await Promise.allSettled(Array.from(this.pendingPools.values()))
+        const entries = Array.from(this.pools.values())
+        this.pools.clear()
+        this.latestShape.clear()
+        await Promise.all(
+          entries.map(async (entry) => {
+            try {
+              await this.destroyBounded(entry.pool)
+            } catch (err) {
+              this.log.warn('error ending pool:', (err as Error).message)
+            }
+            closeTunnel(entry.tunnel)
+          })
+        )
+      } finally {
+        this.shuttingDown = false
+        this.teardownInFlight = null
+      }
+    })()
+    return this.teardownInFlight
+  }
+}

--- a/apps/desktop/src/main/adapters/postgres-adapter.ts
+++ b/apps/desktop/src/main/adapters/postgres-adapter.ts
@@ -40,7 +40,12 @@ import type {
 import { registerQuery, unregisterQuery } from '../query-tracker'
 import { splitStatements } from '../lib/sql-parser'
 import { telemetryCollector, TELEMETRY_PHASES } from '../telemetry-collector'
-import { withPgClient, withPgTransaction, getOrCreatePool } from './pg-pool-manager'
+import {
+  withPgClient,
+  withPgTransaction,
+  acquirePgSessionClient,
+  type PgSessionLease
+} from './pg-pool-manager'
 
 export { buildClientConfig } from './pg-client-config'
 
@@ -123,7 +128,7 @@ export function isDataReturningStatement(sql: string): boolean {
  */
 export class PostgresAdapter implements DatabaseAdapter {
   readonly dbType = 'postgresql' as const
-  private sessions = new Map<string, import('pg').PoolClient>()
+  private sessions = new Map<string, PgSessionLease>()
   private pendingSessions = new Set<string>()
 
   async connect(config: ConnectionConfig): Promise<void> {
@@ -292,8 +297,7 @@ export class PostgresAdapter implements DatabaseAdapter {
     }
 
     if (options?.sessionId && this.sessions.has(options.sessionId)) {
-      const client = this.sessions.get(options.sessionId)!
-      return runWithClient(client)
+      return runWithClient(this.sessions.get(options.sessionId)!.client)
     } else {
       return withPgClient(config, runWithClient)
     }
@@ -334,13 +338,14 @@ export class PostgresAdapter implements DatabaseAdapter {
     }
     this.pendingSessions.add(sessionId)
     try {
-      const poolEntry = await getOrCreatePool(_config)
-      const client = await poolEntry.pool.connect()
+      // Session clients come from a pool of their own — an open transaction holds its
+      // client until the user commits, which would otherwise starve ad-hoc queries.
+      const lease = await acquirePgSessionClient(_config)
       try {
-        await client.query('BEGIN')
-        this.sessions.set(sessionId, client)
+        await lease.client.query('BEGIN')
+        this.sessions.set(sessionId, lease)
       } catch (error) {
-        client.release(true)
+        lease.release(true)
         throw error
       }
     } finally {
@@ -354,11 +359,11 @@ export class PostgresAdapter implements DatabaseAdapter {
     sql: string,
     params?: unknown[]
   ): Promise<AdapterQueryResult> {
-    const client = this.sessions.get(sessionId)
-    if (!client) {
+    const lease = this.sessions.get(sessionId)
+    if (!lease) {
       throw new Error(`Session ${sessionId} does not have an active transaction`)
     }
-    const res = await client.query(sql, params)
+    const res = await lease.client.query(sql, params)
     const fields: QueryField[] = res.fields.map((f) => ({
       name: f.name,
       dataType: resolvePostgresType(f.dataTypeID),
@@ -372,17 +377,17 @@ export class PostgresAdapter implements DatabaseAdapter {
   }
 
   async commitTransaction(_config: ConnectionConfig, sessionId: string): Promise<void> {
-    const client = this.sessions.get(sessionId)
-    if (!client) return
+    const lease = this.sessions.get(sessionId)
+    if (!lease) return
     this.sessions.delete(sessionId)
     try {
-      await client.query('COMMIT')
+      await lease.client.query('COMMIT')
     } catch (error) {
       // A failed COMMIT leaves the connection in an unknown state — discard it.
-      client.release(true)
+      lease.release(true)
       throw error
     }
-    client.release()
+    lease.release()
   }
 
   /**
@@ -397,16 +402,16 @@ export class PostgresAdapter implements DatabaseAdapter {
   }
 
   async rollbackTransaction(_config: ConnectionConfig, sessionId: string): Promise<void> {
-    const client = this.sessions.get(sessionId)
-    if (!client) return
+    const lease = this.sessions.get(sessionId)
+    if (!lease) return
     this.sessions.delete(sessionId)
     let poisoned = false
     try {
-      await client.query('ROLLBACK')
+      await lease.client.query('ROLLBACK')
     } catch {
       poisoned = true
     } finally {
-      client.release(poisoned ? true : undefined)
+      lease.release(poisoned ? true : undefined)
     }
   }
 

--- a/apps/desktop/src/main/adapters/postgres-adapter.ts
+++ b/apps/desktop/src/main/adapters/postgres-adapter.ts
@@ -44,6 +44,7 @@ import {
   withPgClient,
   withPgTransaction,
   acquirePgSessionClient,
+  pgPoolIdentity,
   type PgSessionLease
 } from './pg-pool-manager'
 
@@ -128,7 +129,9 @@ export function isDataReturningStatement(sql: string): boolean {
  */
 export class PostgresAdapter implements DatabaseAdapter {
   readonly dbType = 'postgresql' as const
-  private sessions = new Map<string, PgSessionLease>()
+  // Sessions carry the identity of the connection they were opened against so a
+  // connection being edited or deleted can drain just its own parked transactions.
+  private sessions = new Map<string, { lease: PgSessionLease; poolIdentity: string }>()
   private pendingSessions = new Set<string>()
 
   async connect(config: ConnectionConfig): Promise<void> {
@@ -170,10 +173,11 @@ export class PostgresAdapter implements DatabaseAdapter {
     }
 
     const runWithClient = async (client: import('pg').PoolClient) => {
+      // Closes over the pool acquisition, which is the only connection-level cost left
+      // now that pooling amortises the handshake — and the one worth seeing, since it
+      // spikes when the pool saturates. There is no per-query DB handshake to report.
       if (collectTelemetry) {
         telemetryCollector.endPhase(executionId, TELEMETRY_PHASES.TCP_HANDSHAKE)
-        telemetryCollector.startPhase(executionId, TELEMETRY_PHASES.DB_HANDSHAKE)
-        telemetryCollector.endPhase(executionId, TELEMETRY_PHASES.DB_HANDSHAKE)
       }
 
       const queryTimeoutMs = options?.queryTimeoutMs
@@ -297,7 +301,7 @@ export class PostgresAdapter implements DatabaseAdapter {
     }
 
     if (options?.sessionId && this.sessions.has(options.sessionId)) {
-      return runWithClient(this.sessions.get(options.sessionId)!.client)
+      return runWithClient(this.sessions.get(options.sessionId)!.lease.client)
     } else {
       return withPgClient(config, runWithClient)
     }
@@ -343,7 +347,7 @@ export class PostgresAdapter implements DatabaseAdapter {
       const lease = await acquirePgSessionClient(_config)
       try {
         await lease.client.query('BEGIN')
-        this.sessions.set(sessionId, lease)
+        this.sessions.set(sessionId, { lease, poolIdentity: pgPoolIdentity(_config) })
       } catch (error) {
         lease.release(true)
         throw error
@@ -359,7 +363,7 @@ export class PostgresAdapter implements DatabaseAdapter {
     sql: string,
     params?: unknown[]
   ): Promise<AdapterQueryResult> {
-    const lease = this.sessions.get(sessionId)
+    const lease = this.sessions.get(sessionId)?.lease
     if (!lease) {
       throw new Error(`Session ${sessionId} does not have an active transaction`)
     }
@@ -377,7 +381,7 @@ export class PostgresAdapter implements DatabaseAdapter {
   }
 
   async commitTransaction(_config: ConnectionConfig, sessionId: string): Promise<void> {
-    const lease = this.sessions.get(sessionId)
+    const lease = this.sessions.get(sessionId)?.lease
     if (!lease) return
     this.sessions.delete(sessionId)
     try {
@@ -401,8 +405,26 @@ export class PostgresAdapter implements DatabaseAdapter {
     )
   }
 
+  /**
+   * Roll back the open sessions belonging to one connection.
+   *
+   * Called before tearing that connection's pool down on edit/delete, mirroring what
+   * quit does globally. A parked session client keeps `sessionPool.end()` pending
+   * forever, so without this the teardown hits its timeout and the transaction is left
+   * open server-side holding whatever locks it had taken.
+   */
+  async drainSessions(config: ConnectionConfig): Promise<void> {
+    const identity = pgPoolIdentity(config)
+    const sessionIds = [...this.sessions.entries()]
+      .filter(([, session]) => session.poolIdentity === identity)
+      .map(([id]) => id)
+    await Promise.allSettled(
+      sessionIds.map((id) => this.rollbackTransaction(undefined as never, id))
+    )
+  }
+
   async rollbackTransaction(_config: ConnectionConfig, sessionId: string): Promise<void> {
-    const lease = this.sessions.get(sessionId)
+    const lease = this.sessions.get(sessionId)?.lease
     if (!lease) return
     this.sessions.delete(sessionId)
     let poisoned = false

--- a/apps/desktop/src/main/db-adapter.ts
+++ b/apps/desktop/src/main/db-adapter.ts
@@ -109,6 +109,15 @@ export interface DatabaseAdapter {
   /** Rollback a stateful transaction */
   rollbackTransaction?(config: ConnectionConfig, sessionId: string): Promise<void>
 
+  /**
+   * Roll back any stateful transactions still open against this connection.
+   *
+   * Called before the connection's pool is torn down (edit/delete) so a parked session
+   * client can't keep the pool's teardown pending and leave a transaction open
+   * server-side. Adapters that don't park clients don't need to implement it.
+   */
+  drainSessions?(config: ConnectionConfig): Promise<void>
+
   /** Fetch database schemas, tables, and columns */
   getSchemas(config: ConnectionConfig): Promise<SchemaInfo[]>
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -38,6 +38,8 @@ import { initSchedulerService, stopAllSchedules } from './scheduler-service'
 import { initDashboardService } from './dashboard-service'
 import { cleanup as cleanupPgNotify } from './pg-notification-listener'
 import { closeAllPgPools } from './adapters/pg-pool-manager'
+import { closeAllMySQLPools } from './adapters/mysql-pool-manager'
+import { closeAllMSSQLPools } from './adapters/mssql-pool-manager'
 import { PostgresAdapter } from './adapters/postgres-adapter'
 import { getAdapterByType } from './db-adapter'
 import { StepSessionRegistry } from './step-session'
@@ -351,7 +353,9 @@ app.on('before-quit', (event) => {
   Promise.race([
     Promise.all([
       stepSessionRegistry.cleanupAll(),
-      drainPgSessions().then(() => closeAllPgPools())
+      drainPgSessions().then(() => closeAllPgPools()),
+      closeAllMySQLPools(),
+      closeAllMSSQLPools()
     ]),
     new Promise((resolve) => setTimeout(resolve, 3000))
   ])

--- a/apps/desktop/src/main/ipc/connection-handlers.ts
+++ b/apps/desktop/src/main/ipc/connection-handlers.ts
@@ -3,19 +3,29 @@ import type { ConnectionConfig } from '@shared/index'
 import type { PersistentStore } from '../storage'
 import { windowManager } from '../window-manager'
 import { closePgPool } from '../adapters/pg-pool-manager'
+import { closeMySQLPool } from '../adapters/mysql-pool-manager'
+import { closeMSSQLPool } from '../adapters/mssql-pool-manager'
 import { invalidateSchemaCache } from '../schema-cache'
 import { createLogger } from '../lib/logger'
 
 const log = createLogger('connection-handlers')
+
+// Every pooled driver. SQLite opens the file per call and holds nothing to tear down.
+const POOL_CLOSERS: Partial<Record<string, (config: ConnectionConfig) => Promise<void>>> = {
+  postgresql: closePgPool,
+  mysql: closeMySQLPool,
+  mssql: closeMSSQLPool
+}
 
 // Pool teardown happens after the IPC has already returned success — the connection is
 // already persisted, the renderer has been notified, and a stale pool failing to close
 // shouldn't poison the response with a misleading error.
 function teardownConnection(connection: ConnectionConfig): void {
   invalidateSchemaCache(connection)
-  if (connection.dbType === 'postgresql') {
-    closePgPool(connection).catch((err) => {
-      log.warn('closePgPool failed:', (err as Error).message)
+  const close = POOL_CLOSERS[connection.dbType ?? 'postgresql']
+  if (close) {
+    close(connection).catch((err) => {
+      log.warn(`closing ${connection.dbType} pool failed:`, (err as Error).message)
     })
   }
 }

--- a/apps/desktop/src/main/ipc/connection-handlers.ts
+++ b/apps/desktop/src/main/ipc/connection-handlers.ts
@@ -3,6 +3,7 @@ import type { ConnectionConfig } from '@shared/index'
 import type { PersistentStore } from '../storage'
 import { windowManager } from '../window-manager'
 import { closePgPool } from '../adapters/pg-pool-manager'
+import { getAdapterByType } from '../db-adapter'
 import { closeMySQLPool } from '../adapters/mysql-pool-manager'
 import { closeMSSQLPool } from '../adapters/mssql-pool-manager'
 import { invalidateSchemaCache } from '../schema-cache'
@@ -22,12 +23,26 @@ const POOL_CLOSERS: Partial<Record<string, (config: ConnectionConfig) => Promise
 // shouldn't poison the response with a misleading error.
 function teardownConnection(connection: ConnectionConfig): void {
   invalidateSchemaCache(connection)
-  const close = POOL_CLOSERS[connection.dbType ?? 'postgresql']
-  if (close) {
-    close(connection).catch((err) => {
-      log.warn(`closing ${connection.dbType} pool failed:`, (err as Error).message)
-    })
+  const dbType = connection.dbType ?? 'postgresql'
+  const close = POOL_CLOSERS[dbType]
+  if (!close) return
+
+  // Drain this connection's manual transactions before its pool goes, mirroring what
+  // quit does globally: a parked session client keeps the pool's teardown pending, so
+  // closing without this leaves the transaction open server-side holding its locks.
+  const drain = async (): Promise<void> => {
+    await getAdapterByType(dbType).drainSessions?.(connection)
   }
+
+  drain()
+    .catch((err) => {
+      // A failed drain must not skip the teardown — the pool still has to go.
+      log.warn(`draining ${dbType} sessions failed:`, (err as Error).message)
+    })
+    .then(() => close(connection))
+    .catch((err) => {
+      log.warn(`closing ${dbType} pool failed:`, (err as Error).message)
+    })
 }
 
 /**

--- a/apps/desktop/src/main/ssh-tunnel-service.ts
+++ b/apps/desktop/src/main/ssh-tunnel-service.ts
@@ -6,11 +6,25 @@ import fs from 'fs'
 export interface TunnelSession {
   ssh: SSHClient | null
   server: net.Server | null
+  /**
+   * Sockets currently forwarded through this tunnel.
+   *
+   * `net.Server#close()` only stops the listener accepting new connections; established
+   * sockets keep running and keep the local port bound. (`closeAllConnections()` would do
+   * this for us, but it exists on `http.Server`, not `net.Server`.) Tracking them makes
+   * teardown deterministic, so a rebuilt tunnel never races a half-dead predecessor
+   * still holding its port.
+   */
+  sockets: Set<net.Socket>
   /** The local proxy host to connect through (always 127.0.0.1) */
   localHost: string
   /** The local proxy port to connect through */
   localPort: number
 }
+
+/** The parts of a tunnel needed to tear it down; accepts partially-built sessions. */
+type ClosableTunnel = Pick<TunnelSession, 'ssh' | 'server'> &
+  Partial<Pick<TunnelSession, 'sockets'>>
 
 export async function createTunnel(config: ConnectionConfig): Promise<TunnelSession> {
   const sshConfig = config.sshConfig
@@ -32,11 +46,14 @@ export async function createTunnel(config: ConnectionConfig): Promise<TunnelSess
 
   let server: net.Server | null = null
   let ssh: SSHClient | null = null
+  const sockets = new Set<net.Socket>()
   return new Promise<TunnelSession>((resolve, reject) => {
     try {
       ssh = new SSHClient()
       ssh.once('ready', () => {
         server = net.createServer((socket) => {
+          sockets.add(socket)
+          socket.once('close', () => sockets.delete(socket))
           ssh!.forwardOut('127.0.0.1', 0, dstHost, dstPort, (err, stream) => {
             if (err) {
               console.error('SSH tunnel forward error:', err)
@@ -61,25 +78,25 @@ export async function createTunnel(config: ConnectionConfig): Promise<TunnelSess
 
         server.on('error', (error) => {
           console.error('SSH tunnel server error:', error)
-          closeTunnel({ ssh, server })
+          closeTunnel({ ssh, server, sockets })
           reject(error)
         })
 
         server.listen(0, '127.0.0.1', () => {
           const proxyPort = (server!.address() as net.AddressInfo).port
           console.log(`SSH tunnel ready: localhost:${proxyPort} → ${dstHost}:${dstPort}`)
-          resolve({ ssh, server, localHost: '127.0.0.1', localPort: proxyPort })
+          resolve({ ssh, server, sockets, localHost: '127.0.0.1', localPort: proxyPort })
         })
       })
 
       ssh.once('error', (error) => {
         console.error('SSH connection error:', error)
-        closeTunnel({ ssh, server })
+        closeTunnel({ ssh, server, sockets })
         reject(error)
       })
 
       ssh.on('close', () => {
-        closeTunnel({ ssh, server })
+        closeTunnel({ ssh, server, sockets })
       })
 
       ssh.connect({
@@ -93,15 +110,15 @@ export async function createTunnel(config: ConnectionConfig): Promise<TunnelSess
       })
     } catch (err) {
       console.error('Failed to create SSH tunnel:', err)
-      closeTunnel({ ssh, server })
+      closeTunnel({ ssh, server, sockets })
       reject(err)
     }
   })
 }
 
-export function closeTunnel(tunnelSession: Pick<TunnelSession, 'ssh' | 'server'> | null) {
+export function closeTunnel(tunnelSession: ClosableTunnel | null) {
   if (!tunnelSession) return
-  closeServer(tunnelSession.server)
+  closeServer(tunnelSession.server, tunnelSession.sockets)
   closeSSHSession(tunnelSession.ssh)
 }
 
@@ -111,12 +128,20 @@ function closeSSHSession(ssh: SSHClient | null) {
   }
 }
 
-function closeServer(server: net.Server | null) {
-  if (server) {
-    server.close((err) => {
-      if (err) {
-        console.error('Error closing SSH tunnel server:', err)
-      }
-    })
+function closeServer(server: net.Server | null, sockets?: Set<net.Socket>) {
+  if (!server) return
+  server.close((err) => {
+    if (err) {
+      console.error('Error closing SSH tunnel server:', err)
+    }
+  })
+  // close() only stops the listener accepting new sockets; already-established ones keep
+  // running and keep the port bound. Ending the SSH client usually collapses them through
+  // the pipe, but only as a side effect and only once the remote half notices.
+  if (sockets) {
+    for (const socket of sockets) {
+      socket.destroy()
+    }
+    sockets.clear()
   }
 }


### PR DESCRIPTION
Tightens up connection lifecycle across all three drivers. Two commits, each reviewable on its own.

## 1. Manual transactions no longer starve the Postgres pool

A manual `BEGIN`-and-hold transaction parks its client until the user commits. Those came out of the same pool serving ordinary queries, so `POOL_MAX` (5) open transactions consumed every slot — after which every other query on that connection, including background work like schema refresh, blocked on `pool.connect()` and failed after 15s with pg's generic `timeout exceeded when trying to connect`.

Session clients now come from a second pool (`SESSION_POOL_MAX = 4`), built lazily from the same client config and riding the same tunnel. Ad-hoc queries keep all 5 of their own slots regardless, and saturating the session pool is a local failure with an actionable message rather than a connect timeout. `acquirePgSessionClient` returns an idempotent lease so a cancellation path that already destroyed the client can't free a slot twice.

## 2. MySQL and SQL Server are actually pooled now

Every adapter method in both drivers opened its own connection and, over SSH, its own tunnel — then tore both down. A full SSH handshake plus driver auth per schema refresh, per autocomplete lookup, per query. SQL Server was building and closing an `mssql.ConnectionPool` per call, so its pooling never applied at all.

The pool lifecycle is extracted into a driver-agnostic `PoolRegistry` — shape-fingerprinted keys, in-flight creation coalescing, tunnel sharing, tunnel-death eviction, bounded teardown, transient shutdown guard. All of that existed only for Postgres; all three drivers now share one implementation instead of three divergent ones. Postgres is ported onto it with its existing 26 tests as the safety net.

Two bugs pooling would have introduced, fixed in passing:
- MySQL's `SET SESSION max_execution_time` resets before the connection returns to the pool — otherwise the next unrelated query silently inherits it.
- MSSQL `explain()` runs on a pinned connection. `SET SHOWPLAN_XML` configures the statement after it, but `pool.request()` may land on any pooled connection — this worked by luck with a fresh per-query pool and would have gone flaky with a shared one.

## Smaller lifecycle fixes

- **TCP keepalive** on Postgres and MySQL. pg leaves it off, which makes a pooled socket that died while idle (laptop sleep, NAT reap, server restart) look healthy until a query is handed to it and hangs instead of erroring.
- **SSH tunnel teardown** destroys its forwarded sockets. `net.Server#close()` only stops the listener accepting; established sockets keep the local port bound, so a rebuilt tunnel could race a half-dead predecessor. (`closeAllConnections()` would handle this, but it's `http.Server`-only.)
- Pool teardown on connection edit/delete and app quit now covers all three drivers, not just Postgres.

## Verification

- 1303 tests pass (21 new: 13 for `PoolRegistry`, 8 for session-pool isolation)
- `pnpm typecheck` (node + web), prettier, eslint, and a full `electron-vite build`
- `toMySQLConfig` / `toMSSQLConfig` verified byte-identical after moving into their own modules (needed to break the adapter↔pool-manager import cycle); re-exported from the adapters to preserve their surface
- Every non-boilerplate line removed by the scripted adapter rewrite audited against the diff

Net −495 lines across the adapters.

## Reviewer note

**The MySQL and SQL Server rewrites have no runtime test coverage.** Those adapters' test files only exercise pure helpers (`resolveMySQLType`, `toMSSQLConfig`, …) — nothing touches a connection path. ~32 methods changed shape with only the compiler and the build behind them. This wants a pass against live MySQL and SQL Server instances before it ships; `seeds/acme_saas_mysql_seed.sql` covers the MySQL half.

Also left alone deliberately: MSSQL's `requestTimeout = 0` is a documented choice to allow long-running queries. It's less dangerous now (a hung query holds one pooled connection out of five rather than an unmanaged one) but it's still unbounded — worth a separate decision.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved connection pooling for PostgreSQL, MySQL, and MSSQL.
  * Added safer transaction handling, connection reuse, and dedicated session support.
  * Added automatic cleanup when connections, application sessions, or SSH tunnels close.
  * Improved connection validation, timeout handling, keepalive support, and SSL configuration.
* **Bug Fixes**
  * Prevented stale connections and failed tunnel resources from remaining active.
  * Added clearer errors for pool capacity limits and certificate-loading failures.
  * Improved recovery after failed transactions and connection operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->