### PR TITLE
docs: restore the star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,11 +279,11 @@ pnpm build
 
 ## Star History
 
-<a href="https://www.star-history.com/#Rohithgilla12/data-peek&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#Rohithgilla12/data-peek&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=Rohithgilla12/data-peek&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=Rohithgilla12/data-peek&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=Rohithgilla12/data-peek&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=Rohithgilla12/data-peek&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=Rohithgilla12/data-peek&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=Rohithgilla12/data-peek&type=date&legend=top-left" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart on the README is currently broken and does not render for visitors, which is a shame given the project's growing community. This change swaps it to a reliable mirror that keeps the chart up to date with our stargazers. No visual changes: the existing dark/light theming and the link to the full history are preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Star History embeds to use the current `star-history.dera.page` URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->