### PR TITLE
refactor(desktop): route dedicated Postgres connections through the adapter

### DIFF
--- a/apps/desktop/src/main/__tests__/pg-dedicated-client.test.ts
+++ b/apps/desktop/src/main/__tests__/pg-dedicated-client.test.ts
@@ -4,10 +4,14 @@ import type { ConnectionConfig } from '@shared/index'
 
 const { ClientCtor } = vi.hoisted(() => ({ ClientCtor: vi.fn() }))
 
-vi.mock('pg', () => ({ Client: ClientCtor }))
+// `types` is needed because opening a connection registers the shared type parsers.
+vi.mock('pg', () => ({ Client: ClientCtor, types: { setTypeParser: vi.fn() } }))
 vi.mock('../ssh-tunnel-service', () => ({
   createTunnel: vi.fn(),
   closeTunnel: vi.fn()
+}))
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
 }))
 
 import { createTunnel, closeTunnel, type TunnelSession } from '../ssh-tunnel-service'
@@ -167,6 +171,49 @@ describe('createPgDedicatedClient', () => {
     ])
   })
 
+  it('opens no tunnel when the connection is not over SSH', async () => {
+    const client = await createPgDedicatedClient(makeConfig())
+    expect(createTunnel).not.toHaveBeenCalled()
+    await client.close()
+    expect(closeTunnel).toHaveBeenCalledWith(null)
+  })
+
+  it('releases the tunnel even when end() rejects, and replays the rejection', async () => {
+    const client = await createPgDedicatedClient(makeConfig({ ssh: true }))
+    const c = onlyClient()
+    c.end = async () => {
+      c.endCalls++
+      throw new Error('socket already gone')
+    }
+
+    await expect(client.close()).rejects.toThrow('socket already gone')
+    // The tunnel must not survive a dirty close, or its bound local port leaks for the
+    // life of the process.
+    expect(closeTunnel).toHaveBeenCalledWith(tunnel)
+    // A failed teardown stays failed rather than silently retrying end().
+    await expect(client.close()).rejects.toThrow('socket already gone')
+    expect(c.endCalls).toBe(1)
+  })
+
+  it('makes concurrent close() calls await one teardown', async () => {
+    let release: () => void = () => {}
+    const client = await createPgDedicatedClient(makeConfig())
+    const c = onlyClient()
+    c.end = async () => {
+      c.endCalls++
+      await new Promise<void>((resolve) => {
+        release = resolve
+      })
+    }
+
+    const first = client.close()
+    const second = client.close()
+    release()
+    await Promise.all([first, second])
+    // A boolean guard would have let the second caller return before the socket closed.
+    expect(c.endCalls).toBe(1)
+  })
+
   it('closes idempotently', async () => {
     const client = await createPgDedicatedClient(makeConfig({ ssh: true }))
     await client.close()
@@ -224,14 +271,15 @@ describe('onDisconnect', () => {
     ClientCtor.mockImplementation(function (config: Record<string, unknown>) {
       const c = new FakePgClient(config)
       c.connectImpl = async () => {
-        c.emit('error', new Error('SSL negotiation failed'))
+        // Deliberately different text from the rejection: an EventEmitter with no
+        // 'error' listener throws the emitted error synchronously, so if the listener
+        // were not attached before connect(), *this* is the message that would surface.
+        c.emit('error', new Error('raw unhandled emit'))
         throw new Error('SSL negotiation failed')
       }
       return c
     })
 
-    // An EventEmitter with no 'error' listener throws on emit, so this rejecting with
-    // the connect error (rather than the raw emit) is the assertion.
     await expect(createPgDedicatedClient(makeConfig())).rejects.toThrow('SSL negotiation failed')
   })
 })
@@ -249,6 +297,20 @@ describe('createPgNotificationClient', () => {
       ['jobs', '{"id":1}'],
       ['ping', '']
     ])
+  })
+
+  it('replaces the notification handler rather than adding a second', async () => {
+    const client = await createPgNotificationClient(makeConfig())
+    const first: string[] = []
+    const second: string[] = []
+    client.onNotification((channel) => first.push(channel))
+    client.onNotification((channel) => second.push(channel))
+
+    onlyClient().emit('notification', { channel: 'jobs', payload: '' })
+
+    // Accumulating would persist and broadcast the same event once per registration.
+    expect(first).toEqual([])
+    expect(second).toEqual(['jobs'])
   })
 
   it('carries the same disconnect and close contract', async () => {

--- a/apps/desktop/src/main/__tests__/pg-dedicated-client.test.ts
+++ b/apps/desktop/src/main/__tests__/pg-dedicated-client.test.ts
@@ -1,0 +1,265 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { EventEmitter } from 'events'
+import type { ConnectionConfig } from '@shared/index'
+
+const { ClientCtor } = vi.hoisted(() => ({ ClientCtor: vi.fn() }))
+
+vi.mock('pg', () => ({ Client: ClientCtor }))
+vi.mock('../ssh-tunnel-service', () => ({
+  createTunnel: vi.fn(),
+  closeTunnel: vi.fn()
+}))
+
+import { createTunnel, closeTunnel, type TunnelSession } from '../ssh-tunnel-service'
+import {
+  createPgDedicatedClient,
+  createPgNotificationClient
+} from '../adapters/pg-dedicated-client'
+
+/**
+ * A stand-in for pg.Client that keeps the event surface real — the module's whole job
+ * is wiring 'error'/'end'/'notification' into one contract, so the emitter has to
+ * behave like the driver's does.
+ */
+class FakePgClient extends EventEmitter {
+  static created: FakePgClient[] = []
+  config: Record<string, unknown>
+  connectImpl: () => Promise<void> = async () => {}
+  endCalls = 0
+  queryImpl: (sql: string, params?: unknown[]) => Promise<unknown> = async () => ({
+    rows: [],
+    fields: [],
+    rowCount: 0
+  })
+
+  constructor(config: Record<string, unknown>) {
+    super()
+    this.config = config
+    FakePgClient.created.push(this)
+  }
+
+  connect(): Promise<void> {
+    return this.connectImpl()
+  }
+
+  query(sql: string, params?: unknown[]): Promise<unknown> {
+    return this.queryImpl(sql, params)
+  }
+
+  async end(): Promise<void> {
+    this.endCalls++
+  }
+}
+
+function makeConfig(overrides: Partial<ConnectionConfig> = {}): ConnectionConfig {
+  return {
+    id: 'cfg-1',
+    name: 'test',
+    dbType: 'postgresql',
+    host: 'db.example.com',
+    port: 5432,
+    database: 'app',
+    user: 'u',
+    password: 'p',
+    ...overrides
+  } as ConnectionConfig
+}
+
+const tunnel = {
+  localHost: '127.0.0.1',
+  localPort: 61234,
+  ssh: undefined
+} as unknown as TunnelSession
+
+beforeEach(() => {
+  FakePgClient.created = []
+  ClientCtor.mockReset()
+  // A plain function, not an arrow: the module calls this with `new`, and returning an
+  // object from a constructor call is what substitutes the fake for the real client.
+  ClientCtor.mockImplementation(function (config: Record<string, unknown>) {
+    return new FakePgClient(config)
+  })
+  vi.mocked(createTunnel).mockReset().mockResolvedValue(tunnel)
+  vi.mocked(closeTunnel).mockReset()
+})
+
+/** The single client the module built for this test. */
+function onlyClient(): FakePgClient {
+  expect(FakePgClient.created).toHaveLength(1)
+  return FakePgClient.created[0]
+}
+
+describe('createPgDedicatedClient', () => {
+  it('builds the connection from the shared client config', async () => {
+    await createPgDedicatedClient(makeConfig({ schema: 'bbl', ssl: true }))
+    const { config } = onlyClient()
+    // The canonical builder is what adds keepalive and the search_path startup option;
+    // a hand-rolled config in this file is exactly what issue #249 was about.
+    expect(config).toMatchObject({
+      host: 'db.example.com',
+      port: 5432,
+      database: 'app',
+      keepAlive: true,
+      options: '-c search_path="bbl"'
+    })
+    expect(config.ssl).toEqual({ rejectUnauthorized: false })
+  })
+
+  it('routes through an SSH tunnel and closes it with the client', async () => {
+    const client = await createPgDedicatedClient(makeConfig({ ssh: true }))
+    expect(createTunnel).toHaveBeenCalledOnce()
+    expect(onlyClient().config).toMatchObject({ host: '127.0.0.1', port: 61234 })
+    expect(closeTunnel).not.toHaveBeenCalled()
+
+    await client.close()
+    expect(onlyClient().endCalls).toBe(1)
+    expect(closeTunnel).toHaveBeenCalledWith(tunnel)
+  })
+
+  it('closes the tunnel when the dial fails', async () => {
+    ClientCtor.mockImplementation(function (config: Record<string, unknown>) {
+      const c = new FakePgClient(config)
+      c.connectImpl = async () => {
+        throw new Error('connection refused')
+      }
+      return c
+    })
+
+    await expect(createPgDedicatedClient(makeConfig({ ssh: true }))).rejects.toThrow(
+      'connection refused'
+    )
+    expect(closeTunnel).toHaveBeenCalledWith(tunnel)
+  })
+
+  it('resolves field types instead of leaving them unknown', async () => {
+    const client = await createPgDedicatedClient(makeConfig())
+    onlyClient().queryImpl = async () => ({
+      rows: [{ id: 1 }],
+      // 23 = int4, 25 = text
+      fields: [
+        { name: 'id', dataTypeID: 23 },
+        { name: 'label', dataTypeID: 25 }
+      ],
+      rowCount: 1
+    })
+
+    const result = await client.query('SELECT id, label FROM t')
+    expect(result.fields).toEqual([
+      { name: 'id', dataType: 'integer', dataTypeID: 23 },
+      { name: 'label', dataType: 'text', dataTypeID: 25 }
+    ])
+    expect(result.rowCount).toBe(1)
+  })
+
+  it('passes parameters through only when given', async () => {
+    const client = await createPgDedicatedClient(makeConfig())
+    const seen: Array<[string, unknown[] | undefined]> = []
+    onlyClient().queryImpl = async (sql, params) => {
+      seen.push([sql, params])
+      return { rows: [], fields: [], rowCount: 0 }
+    }
+
+    await client.query('SELECT 1')
+    await client.query('SELECT pg_notify($1, $2)', ['ch', 'body'])
+    expect(seen).toEqual([
+      ['SELECT 1', undefined],
+      ['SELECT pg_notify($1, $2)', ['ch', 'body']]
+    ])
+  })
+
+  it('closes idempotently', async () => {
+    const client = await createPgDedicatedClient(makeConfig({ ssh: true }))
+    await client.close()
+    await client.close()
+    expect(onlyClient().endCalls).toBe(1)
+    expect(closeTunnel).toHaveBeenCalledOnce()
+  })
+})
+
+describe('onDisconnect', () => {
+  it('reports a socket error once, not again on the trailing end', async () => {
+    const client = await createPgDedicatedClient(makeConfig())
+    const seen: Array<Error | null> = []
+    client.onDisconnect((err) => seen.push(err))
+
+    // pg emits both for one death; a listener that reconnected twice over a single
+    // failure would double its backoff for no reason.
+    onlyClient().emit('error', new Error('read ECONNRESET'))
+    onlyClient().emit('end')
+
+    expect(seen).toHaveLength(1)
+    expect(seen[0]?.message).toBe('read ECONNRESET')
+  })
+
+  it('reports a clean server-side close as a null error', async () => {
+    const client = await createPgDedicatedClient(makeConfig())
+    const seen: Array<Error | null> = []
+    client.onDisconnect((err) => seen.push(err))
+
+    onlyClient().emit('end')
+    expect(seen).toEqual([null])
+  })
+
+  it('replays a death that happened before the handler was registered', async () => {
+    const client = await createPgDedicatedClient(makeConfig())
+    onlyClient().emit('error', new Error('server closed the connection'))
+
+    const seen: Array<Error | null> = []
+    client.onDisconnect((err) => seen.push(err))
+    expect(seen).toHaveLength(1)
+    expect(seen[0]?.message).toBe('server closed the connection')
+  })
+
+  it('stays silent for a close the owner asked for', async () => {
+    const client = await createPgDedicatedClient(makeConfig())
+    const seen: Array<Error | null> = []
+    client.onDisconnect((err) => seen.push(err))
+
+    await client.close()
+    onlyClient().emit('end')
+    expect(seen).toEqual([])
+  })
+
+  it('does not let a mid-handshake error escape as an unhandled event', async () => {
+    ClientCtor.mockImplementation(function (config: Record<string, unknown>) {
+      const c = new FakePgClient(config)
+      c.connectImpl = async () => {
+        c.emit('error', new Error('SSL negotiation failed'))
+        throw new Error('SSL negotiation failed')
+      }
+      return c
+    })
+
+    // An EventEmitter with no 'error' listener throws on emit, so this rejecting with
+    // the connect error (rather than the raw emit) is the assertion.
+    await expect(createPgDedicatedClient(makeConfig())).rejects.toThrow('SSL negotiation failed')
+  })
+})
+
+describe('createPgNotificationClient', () => {
+  it('forwards notifications with an empty payload defaulted', async () => {
+    const client = await createPgNotificationClient(makeConfig())
+    const seen: Array<[string, string]> = []
+    client.onNotification((channel, payload) => seen.push([channel, payload]))
+
+    onlyClient().emit('notification', { channel: 'jobs', payload: '{"id":1}' })
+    onlyClient().emit('notification', { channel: 'ping' })
+
+    expect(seen).toEqual([
+      ['jobs', '{"id":1}'],
+      ['ping', '']
+    ])
+  })
+
+  it('carries the same disconnect and close contract', async () => {
+    const client = await createPgNotificationClient(makeConfig({ ssh: true }))
+    const seen: Array<Error | null> = []
+    client.onDisconnect((err) => seen.push(err))
+
+    onlyClient().emit('error', new Error('boom'))
+    expect(seen).toHaveLength(1)
+
+    await client.close()
+    expect(closeTunnel).toHaveBeenCalledWith(tunnel)
+  })
+})

--- a/apps/desktop/src/main/__tests__/pg-notification-listener.test.ts
+++ b/apps/desktop/src/main/__tests__/pg-notification-listener.test.ts
@@ -1,0 +1,304 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { ConnectionConfig } from '@shared/index'
+import type { NotificationClient } from '../db-adapter'
+
+const { getAdapter, execute } = vi.hoisted(() => ({
+  getAdapter: vi.fn(),
+  execute: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  BrowserWindow: { getAllWindows: () => [] },
+  app: { getPath: () => '/tmp/data-peek-test' }
+}))
+vi.mock('../db-adapter', () => ({ getAdapter }))
+vi.mock('../lib/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}))
+// getDb() is lazy and only reached by event persistence, which these tests avoid; the
+// stub keeps an accidental call from touching the filesystem.
+vi.mock('better-sqlite3', () => ({
+  default: class {
+    exec() {
+      /* schema setup is a no-op here */
+    }
+    prepare() {
+      return { run: () => {}, get: () => ({ cnt: 0, last: null }), all: () => [] }
+    }
+    close() {
+      /* nothing to release */
+    }
+  }
+}))
+
+import { subscribe, send, cleanup, getStatus, forceReconnect } from '../pg-notification-listener'
+
+/** A NotificationClient whose LISTEN behaviour and death each test drives directly. */
+class FakeNotificationClient implements NotificationClient {
+  queries: string[] = []
+  closed = 0
+  listenError: Error | null = null
+  private disconnect: ((error: Error | null) => void) | null = null
+
+  async query(sql: string) {
+    this.queries.push(sql)
+    if (this.listenError && sql.startsWith('LISTEN')) throw this.listenError
+    return { rows: [], fields: [], rowCount: 0 }
+  }
+  onDisconnect(handler: (error: Error | null) => void) {
+    this.disconnect = handler
+  }
+  onNotification() {
+    /* not exercised here */
+  }
+  async close() {
+    this.closed++
+  }
+  /** Simulate the socket dying underneath the listener. */
+  die(error: Error | null = new Error('read ECONNRESET')) {
+    this.disconnect?.(error)
+  }
+}
+
+const config = {
+  id: 'conn-1',
+  name: 'test',
+  dbType: 'postgresql',
+  host: 'localhost',
+  port: 5432,
+  database: 'app',
+  user: 'u',
+  password: 'p'
+} as ConnectionConfig
+
+/** Queued outcomes for successive createNotificationClient calls. */
+let dials: Array<FakeNotificationClient | Error>
+let dialCount: number
+
+function nextDial(): FakeNotificationClient | Error {
+  const outcome = dials[Math.min(dialCount, dials.length - 1)]
+  dialCount++
+  return outcome
+}
+
+beforeEach(async () => {
+  vi.useFakeTimers()
+  dials = []
+  dialCount = 0
+  execute.mockReset().mockResolvedValue({ rowCount: 1 })
+  getAdapter.mockReset().mockReturnValue({
+    dbType: 'postgresql',
+    execute,
+    createNotificationClient: vi.fn(async () => {
+      const outcome = nextDial()
+      if (outcome instanceof Error) throw outcome
+      return outcome
+    })
+  })
+})
+
+afterEach(async () => {
+  await cleanup()
+  vi.useRealTimers()
+})
+
+describe('reconnect state machine', () => {
+  it('retries when LISTEN fails after a successful dial', async () => {
+    // The regression this file exists for: retiring the failed attempt used to disarm
+    // its own retry, parking the listener in `error` forever.
+    const failing = new FakeNotificationClient()
+    failing.listenError = new Error('permission denied for channel')
+    const healthy = new FakeNotificationClient()
+    dials = [failing, healthy]
+
+    await subscribe('conn-1', config, 'jobs')
+    // 'reconnecting', not 'error': the catch reports the failure and then arms a retry,
+    // which is the whole point. Parking in 'error' is the regression this guards.
+    expect(getStatus('conn-1')?.state).toBe('reconnecting')
+    expect(failing.closed).toBe(1)
+
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(dialCount).toBe(2)
+    expect(getStatus('conn-1')?.state).toBe('connected')
+  })
+
+  it('keeps retrying with growing backoff while the dial keeps failing', async () => {
+    // A tombstone entry left by the previous attempt used to veto every retry after the
+    // first, so the backoff ladder never got past one rung.
+    const healthy = new FakeNotificationClient()
+    dials = [
+      new Error('ECONNREFUSED'),
+      new Error('ECONNREFUSED'),
+      new Error('ECONNREFUSED'),
+      healthy
+    ]
+
+    await subscribe('conn-1', config, 'jobs')
+    expect(dialCount).toBe(1)
+
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(dialCount).toBe(2)
+
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(dialCount).toBe(3)
+
+    await vi.advanceTimersByTimeAsync(4000)
+    expect(dialCount).toBe(4)
+    expect(getStatus('conn-1')?.state).toBe('connected')
+  })
+
+  it('keeps retrying when the dial after a live connection dies also fails', async () => {
+    // The tombstone path: a connection that was up leaves a retired entry behind, and a
+    // failed re-dial has no fresh entry to replace it. That stale entry used to veto
+    // every further retry, so the listener gave up one attempt after the socket died —
+    // exactly the case the keepalive change is meant to recover from.
+    const first = new FakeNotificationClient()
+    const healthy = new FakeNotificationClient()
+    dials = [first, new Error('ECONNREFUSED'), new Error('ECONNREFUSED'), healthy]
+
+    await subscribe('conn-1', config, 'jobs')
+    first.die()
+
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(dialCount).toBe(2)
+
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(dialCount).toBe(3)
+
+    await vi.advanceTimersByTimeAsync(4000)
+    expect(dialCount).toBe(4)
+    expect(getStatus('conn-1')?.state).toBe('connected')
+  })
+
+  it('caps the backoff at MAX_BACKOFF_MS', async () => {
+    dials = [new Error('down')]
+    await subscribe('conn-1', config, 'jobs')
+
+    // 1s, 2s, 4s ... doubling until it saturates. Advance well past the ceiling.
+    for (const wait of [1000, 2000, 4000, 8000, 16000, 30000, 30000]) {
+      await vi.advanceTimersByTimeAsync(wait)
+    }
+    expect(getStatus('conn-1')?.backoffMs).toBe(30_000)
+  })
+
+  it('arms exactly one retry when a socket death also fails the in-flight LISTEN', async () => {
+    // pg reports the death through onDisconnect and rejects the pending query; both
+    // reach scheduleReconnect, and two armed timers would double the dial rate.
+    const dying = new FakeNotificationClient()
+    dying.listenError = new Error('Client has encountered a connection error')
+    const healthy = new FakeNotificationClient()
+    dials = [dying, healthy]
+
+    const listenQuery = dying.query.bind(dying)
+    dying.query = async (sql: string) => {
+      if (sql.startsWith('LISTEN')) dying.die()
+      return listenQuery(sql)
+    }
+
+    await subscribe('conn-1', config, 'jobs')
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(dialCount).toBe(2)
+
+    // If a second timer were armed it would fire here against the same backoff window.
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(dialCount).toBe(2)
+  })
+
+  it('reconnects after the connection drops', async () => {
+    const first = new FakeNotificationClient()
+    const second = new FakeNotificationClient()
+    dials = [first, second]
+
+    await subscribe('conn-1', config, 'jobs')
+    expect(getStatus('conn-1')?.state).toBe('connected')
+
+    first.die()
+    expect(getStatus('conn-1')?.state).toBe('reconnecting')
+
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(getStatus('conn-1')?.state).toBe('connected')
+    expect(second.queries).toContain('LISTEN "jobs"')
+  })
+
+  it('reports a clean server-side close as disconnected, then recovers', async () => {
+    const first = new FakeNotificationClient()
+    dials = [first, new FakeNotificationClient()]
+
+    await subscribe('conn-1', config, 'jobs')
+    first.die(null)
+
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(getStatus('conn-1')?.state).toBe('connected')
+  })
+
+  it('cancels a pending retry on cleanup', async () => {
+    dials = [new Error('down')]
+    await subscribe('conn-1', config, 'jobs')
+    expect(dialCount).toBe(1)
+
+    await cleanup()
+    await vi.advanceTimersByTimeAsync(60_000)
+    // A timer armed with no live entry to hang it from still has to be cancellable.
+    expect(dialCount).toBe(1)
+  })
+
+  it('carries channels added by a later subscribe into the retry', async () => {
+    const first = new FakeNotificationClient()
+    const second = new FakeNotificationClient()
+    dials = [first, second]
+
+    await subscribe('conn-1', config, 'jobs')
+    await subscribe('conn-1', config, 'alerts')
+
+    first.die()
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(second.queries).toEqual(expect.arrayContaining(['LISTEN "jobs"', 'LISTEN "alerts"']))
+  })
+})
+
+describe('connection failures close what they opened', () => {
+  it('closes the client when LISTEN fails', async () => {
+    const failing = new FakeNotificationClient()
+    failing.listenError = new Error('nope')
+    dials = [failing, new FakeNotificationClient()]
+
+    await subscribe('conn-1', config, 'jobs')
+    expect(failing.closed).toBe(1)
+  })
+
+  it('closes the superseded client on a forced reconnect', async () => {
+    const first = new FakeNotificationClient()
+    dials = [first, new FakeNotificationClient()]
+
+    await subscribe('conn-1', config, 'jobs')
+    await forceReconnect('conn-1')
+    expect(first.closed).toBe(1)
+  })
+})
+
+describe('capability guard', () => {
+  it('rejects subscribe on an adapter without LISTEN/NOTIFY', async () => {
+    getAdapter.mockReturnValue({ dbType: 'mysql', execute })
+    await expect(subscribe('conn-1', config, 'jobs')).rejects.toThrow(/not supported for mysql/)
+  })
+
+  it('rejects send on an adapter without LISTEN/NOTIFY instead of emitting pg_notify', async () => {
+    getAdapter.mockReturnValue({ dbType: 'mysql', execute })
+    await expect(send(config, 'jobs', 'hi')).rejects.toThrow(/not supported for mysql/)
+    expect(execute).not.toHaveBeenCalled()
+  })
+})
+
+describe('send', () => {
+  it('goes through the pooled adapter.execute with positional params', async () => {
+    await send(config, 'jobs', '{"id":1}')
+    // The signature is positional; a silent argument-order drift here means every
+    // notification the app sends vanishes.
+    expect(execute).toHaveBeenCalledWith(config, 'SELECT pg_notify($1, $2)', ['jobs', '{"id":1}'])
+  })
+
+  it('opens no dedicated client', async () => {
+    await send(config, 'jobs', 'hi')
+    expect(dialCount).toBe(0)
+  })
+})

--- a/apps/desktop/src/main/__tests__/step-session.test.ts
+++ b/apps/desktop/src/main/__tests__/step-session.test.ts
@@ -31,7 +31,7 @@ class MockClient {
   responses: Array<{
     rows?: Record<string, unknown>[]
     fields?: QueryField[]
-    rowCount?: number
+    rowCount?: number | null
     error?: Error
   }> = []
   closed = false
@@ -44,14 +44,21 @@ class MockClient {
     return {
       rows: response.rows ?? [],
       fields: response.fields ?? [],
-      rowCount: response.rowCount ?? 0
+      // `in` rather than `??` so a deliberate null reaches the registry — pg reports a
+      // null rowCount for some commands and the fallback path depends on it.
+      rowCount: 'rowCount' in response ? (response.rowCount ?? null) : 0
     }
   }
-  onDisconnect() {
-    /* the registry surfaces connection death through the next query instead */
+  private disconnect: ((error: Error | null) => void) | null = null
+  onDisconnect(handler: (error: Error | null) => void) {
+    this.disconnect = handler
   }
   async close() {
     this.closed = true
+  }
+  /** Simulate the backend going away underneath the session. */
+  die(error: Error | null = new Error('read ECONNRESET')) {
+    this.disconnect?.(error)
   }
 }
 
@@ -521,6 +528,136 @@ describe('StepSessionRegistry', () => {
       await registry.stop(sessionId)
       const result = await registry.stop(sessionId)
       expect(result.rolledBack).toBe(false)
+    })
+  })
+
+  describe('statement result shape', () => {
+    it('labels a non-data-returning statement as affected rather than rows', async () => {
+      // Previously computed from the result (`rows.length > 0 || Array.isArray(fields)`),
+      // which pg makes unconditionally true — every stepped statement claimed to return
+      // data. Now derived from the SQL, like the normal query path.
+      const { sessionId } = await registry.start({
+        config: mockConfig,
+        tabId: 'tab-1',
+        windowId: 1,
+        sql: "UPDATE users SET name = 'x';",
+        inTransaction: false
+      })
+      mockClients[0].responses.push({ rowCount: 3 })
+
+      const response = await registry.next(sessionId)
+      expect(response.result.isDataReturning).toBe(false)
+      expect(response.result.rowCount).toBe(3)
+    })
+
+    it('labels a SELECT as data-returning', async () => {
+      const { sessionId } = await registry.start({
+        config: mockConfig,
+        tabId: 'tab-1',
+        windowId: 1,
+        sql: 'SELECT * FROM users;',
+        inTransaction: false
+      })
+      mockClients[0].responses.push({ rows: [{ id: 1 }], rowCount: 1 })
+
+      const response = await registry.next(sessionId)
+      expect(response.result.isDataReturning).toBe(true)
+    })
+
+    it('labels UPDATE ... RETURNING as data-returning', async () => {
+      const { sessionId } = await registry.start({
+        config: mockConfig,
+        tabId: 'tab-1',
+        windowId: 1,
+        sql: 'UPDATE users SET name = $1 RETURNING id;',
+        inTransaction: false
+      })
+      mockClients[0].responses.push({ rows: [{ id: 1 }], rowCount: 1 })
+
+      const response = await registry.next(sessionId)
+      expect(response.result.isDataReturning).toBe(true)
+    })
+
+    it('passes the adapter-resolved field types straight through', async () => {
+      const { sessionId } = await registry.start({
+        config: mockConfig,
+        tabId: 'tab-1',
+        windowId: 1,
+        sql: 'SELECT id FROM users;',
+        inTransaction: false
+      })
+      mockClients[0].responses.push({
+        rows: [{ id: 1 }],
+        fields: [{ name: 'id', dataType: 'integer', dataTypeID: 23 }],
+        rowCount: 1
+      })
+
+      const response = await registry.next(sessionId)
+      // Used to be flattened to dataType: 'unknown' for every column.
+      expect(response.result.fields).toEqual([{ name: 'id', dataType: 'integer', dataTypeID: 23 }])
+    })
+
+    it('falls back to the row count when the driver reports a null rowCount', async () => {
+      const { sessionId } = await registry.start({
+        config: mockConfig,
+        tabId: 'tab-1',
+        windowId: 1,
+        sql: 'SELECT 1;',
+        inTransaction: false
+      })
+      mockClients[0].responses.push({ rows: [{ a: 1 }, { a: 2 }], rowCount: null })
+
+      const response = await registry.next(sessionId)
+      expect(response.result.rowCount).toBe(2)
+    })
+  })
+
+  describe('connection loss', () => {
+    it('marks the session errored with a connection message, not a statement error', async () => {
+      const { sessionId } = await registry.start({
+        config: mockConfig,
+        tabId: 'tab-1',
+        windowId: 1,
+        sql: 'SELECT 1; SELECT 2;',
+        inTransaction: false
+      })
+
+      mockClients[0].die(new Error('read ECONNRESET'))
+
+      await expect(registry.next(sessionId)).rejects.toThrow(/Cannot advance session in state/)
+      const stopped = await registry.stop(sessionId)
+      expect(stopped.rolledBack).toBe(false)
+    })
+
+    it('does not ROLLBACK down a dead socket', async () => {
+      const { sessionId } = await registry.start({
+        config: mockConfig,
+        tabId: 'tab-1',
+        windowId: 1,
+        sql: 'SELECT 1;',
+        inTransaction: true
+      })
+      const callsBefore = [...mockClients[0].calls]
+
+      mockClients[0].die()
+      const stopped = await registry.stop(sessionId)
+
+      expect(stopped.rolledBack).toBe(false)
+      expect(mockClients[0].calls).toEqual(callsBefore)
+      expect(mockClients[0].closed).toBe(true)
+    })
+
+    it('still rolls back when the connection is healthy', async () => {
+      const { sessionId } = await registry.start({
+        config: mockConfig,
+        tabId: 'tab-1',
+        windowId: 1,
+        sql: 'SELECT 1;',
+        inTransaction: true
+      })
+      const stopped = await registry.stop(sessionId)
+      expect(stopped.rolledBack).toBe(true)
+      expect(mockClients[0].calls).toContain('ROLLBACK')
     })
   })
 

--- a/apps/desktop/src/main/__tests__/step-session.test.ts
+++ b/apps/desktop/src/main/__tests__/step-session.test.ts
@@ -23,16 +23,19 @@ vi.mock('electron', () => ({
 }))
 
 import { StepSessionRegistry } from '../step-session'
-import type { ConnectionConfig } from '@shared/index'
+import type { ConnectionConfig, QueryField } from '@shared/index'
 
+/** Stands in for the connected DedicatedClient the adapter hands the registry. */
 class MockClient {
   calls: string[] = []
-  responses: Array<{ rows?: unknown[]; fields?: unknown[]; rowCount?: number; error?: Error }> = []
-  ended = false
+  responses: Array<{
+    rows?: Record<string, unknown>[]
+    fields?: QueryField[]
+    rowCount?: number
+    error?: Error
+  }> = []
+  closed = false
 
-  async connect() {
-    /* no-op mock */
-  }
   async query(sql: string) {
     this.calls.push(sql)
     const response = this.responses.shift()
@@ -44,8 +47,11 @@ class MockClient {
       rowCount: response.rowCount ?? 0
     }
   }
-  async end() {
-    this.ended = true
+  onDisconnect() {
+    /* the registry surfaces connection death through the next query instead */
+  }
+  async close() {
+    this.closed = true
   }
 }
 
@@ -67,7 +73,7 @@ describe('StepSessionRegistry', () => {
   beforeEach(() => {
     mockClients = []
     registry = new StepSessionRegistry({
-      createClient: (() => {
+      createClient: (async () => {
         const client = new MockClient()
         mockClients.push(client)
         return client
@@ -112,15 +118,13 @@ describe('StepSessionRegistry', () => {
   })
 
   describe('start error handling', () => {
-    it('rejects and cleans up client when connect fails', async () => {
+    it('rejects when the connection cannot be opened', async () => {
+      // The factory hands back an already-connected client, so a dial failure surfaces
+      // here with nothing for the registry to clean up — the factory unwinds its own
+      // socket and tunnel.
       const failingRegistry = new StepSessionRegistry({
-        createClient: (() => {
-          const c = new MockClient()
-          c.connect = async () => {
-            throw new Error('connection refused')
-          }
-          mockClients.push(c)
-          return c
+        createClient: (async () => {
+          throw new Error('connection refused')
         }) as never
       })
       await expect(
@@ -132,12 +136,12 @@ describe('StepSessionRegistry', () => {
           inTransaction: false
         })
       ).rejects.toThrow('connection refused')
-      expect(mockClients[0].ended).toBe(true)
+      expect(mockClients).toHaveLength(0)
     })
 
     it('rejects and cleans up client when BEGIN fails in transaction mode', async () => {
       const failingRegistry = new StepSessionRegistry({
-        createClient: (() => {
+        createClient: (async () => {
           const c = new MockClient()
           c.responses.push({ error: new Error('permission denied for BEGIN') })
           mockClients.push(c)
@@ -153,13 +157,13 @@ describe('StepSessionRegistry', () => {
           inTransaction: true
         })
       ).rejects.toThrow('permission denied')
-      expect(mockClients[0].ended).toBe(true)
+      expect(mockClients[0].closed).toBe(true)
     })
 
     it('rejects on empty SQL without creating a client', async () => {
       const capturedClients: MockClient[] = []
       const emptyRegistry = new StepSessionRegistry({
-        createClient: (() => {
+        createClient: (async () => {
           const c = new MockClient()
           capturedClients.push(c)
           return c
@@ -180,7 +184,7 @@ describe('StepSessionRegistry', () => {
     it('rejects on whitespace-only SQL without creating a client', async () => {
       const capturedClients: MockClient[] = []
       const wsRegistry = new StepSessionRegistry({
-        createClient: (() => {
+        createClient: (async () => {
           const c = new MockClient()
           capturedClients.push(c)
           return c
@@ -475,7 +479,7 @@ describe('StepSessionRegistry', () => {
       const response = await registry.stop(sessionId)
       expect(response.rolledBack).toBe(true)
       expect(mockClients[0].calls).toContain('ROLLBACK')
-      expect(mockClients[0].ended).toBe(true)
+      expect(mockClients[0].closed).toBe(true)
     })
 
     it('just closes client in auto-commit mode', async () => {
@@ -489,7 +493,7 @@ describe('StepSessionRegistry', () => {
       const response = await registry.stop(sessionId)
       expect(response.rolledBack).toBe(false)
       expect(mockClients[0].calls).not.toContain('ROLLBACK')
-      expect(mockClients[0].ended).toBe(true)
+      expect(mockClients[0].closed).toBe(true)
     })
 
     it('removes session from registry', async () => {

--- a/apps/desktop/src/main/adapters/pg-client-config.ts
+++ b/apps/desktop/src/main/adapters/pg-client-config.ts
@@ -1,6 +1,22 @@
 import { readFileSync } from 'fs'
-import type { ClientConfig } from 'pg'
+import { types as pgTypes, type ClientConfig } from 'pg'
 import type { ConnectionConfig } from '@shared/index'
+
+/**
+ * Register the type parsers every Postgres connection in the app depends on.
+ *
+ * Return `timestamp without time zone` (OID 1114) as a raw ISO string so JavaScript's
+ * Date conversion can't shift a UTC-stored value to local time. (1184, timestamptz,
+ * is left alone — that one *should* shift.)
+ *
+ * pg keeps parsers in process-global state, so this is idempotent but every connection
+ * path has to call it: registration used to be a side effect of building the first
+ * pool, which meant a dedicated client opened before any pool existed rendered the same
+ * column differently from the pooled path.
+ */
+export function registerPgTypeParsers(): void {
+  pgTypes.setTypeParser(1114, (val: string) => val)
+}
 
 /**
  * Split a user-entered default schema into individual schema names.

--- a/apps/desktop/src/main/adapters/pg-dedicated-client.ts
+++ b/apps/desktop/src/main/adapters/pg-dedicated-client.ts
@@ -1,0 +1,122 @@
+import { Client } from 'pg'
+import { resolvePostgresType, type ConnectionConfig, type QueryField } from '@shared/index'
+import type { AdapterQueryResult, DedicatedClient, NotificationClient } from '../db-adapter'
+import { closeTunnel, createTunnel, type TunnelSession } from '../ssh-tunnel-service'
+import { buildClientConfig } from './pg-client-config'
+
+/**
+ * Dedicated (unpooled) Postgres connections.
+ *
+ * `pg-pool-manager` covers everything that borrows a connection for the length of one
+ * call. This covers the opposite: a connection a feature owns until it is finished with
+ * it, because server-side state lives on it — a stepped script's open transaction, a
+ * LISTEN registration. Neither can come out of a pool, so each gets its own socket and,
+ * when the connection rides SSH, its own tunnel.
+ *
+ * Everything else about the connection — TLS, keepalive, the `search_path` startup
+ * option — comes from the same `buildClientConfig` the pools use, so a dedicated
+ * connection can't drift from a pooled one.
+ */
+
+/** The shared plumbing behind every dedicated client, before a client shape is put on it. */
+interface PgConnection {
+  client: Client
+  onDisconnect(handler: (error: Error | null) => void): void
+  close(): Promise<void>
+}
+
+async function openConnection(config: ConnectionConfig): Promise<PgConnection> {
+  let tunnel: TunnelSession | null = null
+  if (config.ssh) {
+    tunnel = await createTunnel(config)
+  }
+
+  const overrides = tunnel ? { host: tunnel.localHost, port: tunnel.localPort } : undefined
+  const client = new Client(buildClientConfig(config, overrides))
+
+  let handler: ((error: Error | null) => void) | null = null
+  let died = false
+  let cause: Error | null = null
+  let closed = false
+
+  const reportDeath = (error: Error | null): void => {
+    // pg emits 'error' and then 'end' for one socket death. Reporting once keeps the
+    // owner from running its recovery path twice over a single failure.
+    if (died || closed) return
+    died = true
+    cause = error
+    handler?.(error)
+  }
+
+  // Attached before connect() so a socket that dies mid-handshake reaches us rather
+  // than Node's unhandled-'error' path, which would take the process down.
+  client.on('error', reportDeath)
+  client.on('end', () => reportDeath(null))
+
+  try {
+    await client.connect()
+  } catch (err) {
+    // A failed connect() leaves nothing to end(), but the tunnel is still ours.
+    closeTunnel(tunnel)
+    throw err
+  }
+
+  return {
+    client,
+    onDisconnect(next) {
+      handler = next
+      // The connection can die between connect() resolving and the owner registering.
+      // Without this replay that death would go unreported and the owner would sit on
+      // a connection it believes is live.
+      if (died) next(cause)
+    },
+    async close() {
+      if (closed) return
+      closed = true
+      try {
+        await client.end()
+      } finally {
+        closeTunnel(tunnel)
+      }
+    }
+  }
+}
+
+async function runQuery(
+  client: Client,
+  sql: string,
+  params?: unknown[]
+): Promise<AdapterQueryResult> {
+  const res = params ? await client.query(sql, params) : await client.query(sql)
+  const fields: QueryField[] = (res.fields ?? []).map((f) => ({
+    name: f.name,
+    dataType: resolvePostgresType(f.dataTypeID),
+    dataTypeID: f.dataTypeID
+  }))
+  return { rows: res.rows ?? [], fields, rowCount: res.rowCount }
+}
+
+/** Open a dedicated connection the caller drives and closes itself. */
+export async function createPgDedicatedClient(config: ConnectionConfig): Promise<DedicatedClient> {
+  const conn = await openConnection(config)
+  return {
+    query: (sql, params) => runQuery(conn.client, sql, params),
+    onDisconnect: conn.onDisconnect,
+    close: conn.close
+  }
+}
+
+/** Open a dedicated connection that also surfaces LISTEN/NOTIFY traffic. */
+export async function createPgNotificationClient(
+  config: ConnectionConfig
+): Promise<NotificationClient> {
+  const conn = await openConnection(config)
+  return {
+    query: (sql, params) => runQuery(conn.client, sql, params),
+    onDisconnect: conn.onDisconnect,
+    close: conn.close,
+    onNotification(handler) {
+      conn.client.on('notification', (msg) => handler(msg.channel, msg.payload ?? ''))
+    }
+  }
+}

--- a/apps/desktop/src/main/adapters/pg-dedicated-client.ts
+++ b/apps/desktop/src/main/adapters/pg-dedicated-client.ts
@@ -2,21 +2,26 @@ import { Client } from 'pg'
 import { resolvePostgresType, type ConnectionConfig, type QueryField } from '@shared/index'
 import type { AdapterQueryResult, DedicatedClient, NotificationClient } from '../db-adapter'
 import { closeTunnel, createTunnel, type TunnelSession } from '../ssh-tunnel-service'
-import { buildClientConfig } from './pg-client-config'
+import { buildClientConfig, registerPgTypeParsers } from './pg-client-config'
+import { createLogger } from '../lib/logger'
 
 /**
  * Dedicated (unpooled) Postgres connections.
  *
  * `pg-pool-manager` covers everything that borrows a connection for the length of one
- * call. This covers the opposite: a connection a feature owns until it is finished with
- * it, because server-side state lives on it — a stepped script's open transaction, a
- * LISTEN registration. Neither can come out of a pool, so each gets its own socket and,
- * when the connection rides SSH, its own tunnel.
+ * call. This covers connections a feature owns outright, because state the caller
+ * depends on lives on the backend session: a LISTEN registration, which is bound to one
+ * session and cannot be pooled at all, and a stepped script, which holds a transaction
+ * and other session state across many IPC calls. (A `BEGIN`-and-hold transaction *can*
+ * come from the session pool — see `acquirePgSessionClient` — but step sessions stay
+ * open for as long as a user leaves the panel up, and parking them in that pool would
+ * spend its small budget on connections that are idle almost all the time.)
  *
- * Everything else about the connection — TLS, keepalive, the `search_path` startup
- * option — comes from the same `buildClientConfig` the pools use, so a dedicated
- * connection can't drift from a pooled one.
+ * Client config comes from the same `buildClientConfig` the pools use, so TLS,
+ * keepalive and the `search_path` startup option can't drift between the two paths.
  */
+
+const log = createLogger('pg-dedicated-client')
 
 /** The shared plumbing behind every dedicated client, before a client shape is put on it. */
 interface PgConnection {
@@ -27,58 +32,92 @@ interface PgConnection {
 
 async function openConnection(config: ConnectionConfig): Promise<PgConnection> {
   let tunnel: TunnelSession | null = null
-  if (config.ssh) {
-    tunnel = await createTunnel(config)
-  }
-
-  const overrides = tunnel ? { host: tunnel.localHost, port: tunnel.localPort } : undefined
-  const client = new Client(buildClientConfig(config, overrides))
+  let client: Client | null = null
 
   let handler: ((error: Error | null) => void) | null = null
   let died = false
   let cause: Error | null = null
-  let closed = false
+  let closeRequested = false
+  let closing: Promise<void> | null = null
 
   const reportDeath = (error: Error | null): void => {
     // pg emits 'error' and then 'end' for one socket death. Reporting once keeps the
     // owner from running its recovery path twice over a single failure.
-    if (died || closed) return
+    if (died || closeRequested) return
     died = true
     cause = error
-    handler?.(error)
+    if (!handler) {
+      // Held for replay in onDisconnect, but if nobody ever registers, a connection
+      // died and no one was told — say so rather than losing it to a closure.
+      log.error('Dedicated Postgres connection died with no disconnect handler:', error)
+      return
+    }
+    handler(error)
   }
 
-  // Attached before connect() so a socket that dies mid-handshake reaches us rather
-  // than Node's unhandled-'error' path, which would take the process down.
-  client.on('error', reportDeath)
-  client.on('end', () => reportDeath(null))
-
+  // One try from the first resource acquired: the tunnel is ours the moment createTunnel
+  // resolves, and buildClientConfig can still throw after that (an unreadable CA file).
   try {
-    await client.connect()
-  } catch (err) {
-    // A failed connect() leaves nothing to end(), but the tunnel is still ours.
-    closeTunnel(tunnel)
-    throw err
-  }
+    if (config.ssh) {
+      tunnel = await createTunnel(config)
+    }
 
-  return {
-    client,
-    onDisconnect(next) {
-      handler = next
-      // The connection can die between connect() resolving and the owner registering.
-      // Without this replay that death would go unreported and the owner would sit on
-      // a connection it believes is live.
-      if (died) next(cause)
-    },
-    async close() {
-      if (closed) return
-      closed = true
-      try {
-        await client.end()
-      } finally {
-        closeTunnel(tunnel)
+    const overrides = tunnel ? { host: tunnel.localHost, port: tunnel.localPort } : undefined
+    registerPgTypeParsers()
+    // Two bindings for one object: the outer `client` lets the catch reclaim a socket
+    // whatever stage the open failed at, `pgClient` is the non-null one the returned
+    // closures capture.
+    const pgClient = new Client(buildClientConfig(config, overrides))
+    client = pgClient
+
+    // Attached before connect() so there is no window between the handshake completing
+    // and a listener existing. pg routes most handshake failures through connect()'s
+    // rejection rather than this event, but an 'error' that arrives with no listener is
+    // an uncaught exception in the main process, so the window has to be closed.
+    pgClient.on('error', reportDeath)
+    pgClient.on('end', () => reportDeath(null))
+
+    await pgClient.connect()
+
+    return {
+      client: pgClient,
+      onDisconnect(next) {
+        // Single-handler, like onNotification: a later registration replaces the earlier
+        // one rather than adding to it.
+        handler = next
+        // The connection can die between connect() resolving and the owner registering.
+        // Without this replay that death would go unreported and the owner would sit on
+        // a connection it believes is live.
+        if (died) next(cause)
+      },
+      close() {
+        // Set before the teardown starts so a death caused by our own end() is not
+        // reported as a surprise disconnect.
+        closeRequested = true
+        // Memoised rather than guarded by a boolean: a second caller has to await the
+        // same teardown, not race past a half-finished one.
+        closing ??= (async () => {
+          try {
+            await pgClient.end()
+          } catch (err) {
+            log.error('Dedicated Postgres connection did not close cleanly:', err)
+            throw err
+          } finally {
+            closeTunnel(tunnel)
+          }
+        })()
+        return closing
       }
     }
+  } catch (err) {
+    // end() is a no-op on a client whose socket already died, which is how connect()
+    // usually fails — but a few rejection paths leave the stream open, and that socket
+    // is only reclaimable here.
+    await client?.end().catch(() => {
+      // Already dead; the throw below is the failure worth reporting.
+    })
+    closeTunnel(tunnel)
+    throw err
   }
 }
 
@@ -111,12 +150,19 @@ export async function createPgNotificationClient(
   config: ConnectionConfig
 ): Promise<NotificationClient> {
   const conn = await openConnection(config)
+
+  // The pg listener is attached once here rather than inside onNotification: pg's `on`
+  // accumulates, so registering per call would deliver every notification once per
+  // registration.
+  let notify: ((channel: string, payload: string) => void) | null = null
+  conn.client.on('notification', (msg) => notify?.(msg.channel, msg.payload ?? ''))
+
   return {
     query: (sql, params) => runQuery(conn.client, sql, params),
     onDisconnect: conn.onDisconnect,
     close: conn.close,
     onNotification(handler) {
-      conn.client.on('notification', (msg) => handler(msg.channel, msg.payload ?? ''))
+      notify = handler
     }
   }
 }

--- a/apps/desktop/src/main/adapters/pg-pool-manager.ts
+++ b/apps/desktop/src/main/adapters/pg-pool-manager.ts
@@ -1,7 +1,7 @@
-import { types as pgTypes, Pool, type ClientConfig, type PoolClient } from 'pg'
+import { Pool, type ClientConfig, type PoolClient } from 'pg'
 import type { ConnectionConfig } from '@shared/index'
 import { createLogger } from '../lib/logger'
-import { buildClientConfig } from './pg-client-config'
+import { buildClientConfig, registerPgTypeParsers } from './pg-client-config'
 import { PoolRegistry, poolIdentity } from './pool-registry'
 
 const log = createLogger('pg-pool')
@@ -49,10 +49,7 @@ const registry = new PoolRegistry<PgPools>({
       connectionTimeoutMillis: CONNECT_TIMEOUT_MS
     })
 
-    // Return timestamp (without tz) values as raw ISO strings so JavaScript's Date
-    // auto-conversion doesn't shift UTC-stored timestamps to local time.
-    // OID 1114 = timestamp, 1184 = timestamptz (timestamptz SHOULD be shifted).
-    pgTypes.setTypeParser(1114, (val: string) => val)
+    registerPgTypeParsers()
 
     // pg.Pool emits 'error' for idle clients that die between checkouts (e.g. server-side
     // timeout). Without a listener the process crashes on unhandled error.

--- a/apps/desktop/src/main/adapters/postgres-adapter.ts
+++ b/apps/desktop/src/main/adapters/postgres-adapter.ts
@@ -34,7 +34,9 @@ import type {
   DatabaseAdapter,
   AdapterQueryResult,
   AdapterMultiQueryResult,
+  DedicatedClient,
   ExplainResult,
+  NotificationClient,
   QueryOptions
 } from '../db-adapter'
 import { registerQuery, unregisterQuery } from '../query-tracker'
@@ -47,6 +49,8 @@ import {
   pgPoolIdentity,
   type PgSessionLease
 } from './pg-pool-manager'
+
+import { createPgDedicatedClient, createPgNotificationClient } from './pg-dedicated-client'
 
 export { buildClientConfig } from './pg-client-config'
 
@@ -435,6 +439,14 @@ export class PostgresAdapter implements DatabaseAdapter {
     } finally {
       lease.release(poisoned ? true : undefined)
     }
+  }
+
+  createDedicatedClient(config: ConnectionConfig): Promise<DedicatedClient> {
+    return createPgDedicatedClient(config)
+  }
+
+  createNotificationClient(config: ConnectionConfig): Promise<NotificationClient> {
+    return createPgNotificationClient(config)
   }
 
   async getSchemas(config: ConnectionConfig): Promise<SchemaInfo[]> {

--- a/apps/desktop/src/main/db-adapter.ts
+++ b/apps/desktop/src/main/db-adapter.ts
@@ -52,6 +52,38 @@ export interface QueryOptions {
 }
 
 /**
+ * A connection the caller holds open and drives itself, outside any pool.
+ *
+ * Pooled access (`query`, `execute`, `executeTransaction`) borrows a client for the
+ * length of one call. Some features need the opposite: a connection that stays put
+ * across many calls because server-side state lives on it — a stepped script's open
+ * transaction, a LISTEN registration. Those get one of these, and own closing it.
+ */
+export interface DedicatedClient {
+  /** Run one statement on this connection. */
+  query(sql: string, params?: unknown[]): Promise<AdapterQueryResult>
+
+  /**
+   * Register the handler for this connection dying underneath the caller — a socket
+   * error, or a clean close from the server, which arrives as a null error.
+   *
+   * Fires at most once per connection, and never for a `close()` the caller asked for.
+   * If the connection already died before the handler was registered, it fires
+   * immediately with whatever killed it.
+   */
+  onDisconnect(handler: (error: Error | null) => void): void
+
+  /** Close the connection and release whatever it rode on (SSH tunnel). Idempotent. */
+  close(): Promise<void>
+}
+
+/** A dedicated client that also delivers asynchronous notifications from the server. */
+export interface NotificationClient extends DedicatedClient {
+  /** Register the handler for notifications on any channel this client is LISTENing to. */
+  onNotification(handler: (channel: string, payload: string) => void): void
+}
+
+/**
  * Explain plan result
  */
 export interface ExplainResult {
@@ -117,6 +149,19 @@ export interface DatabaseAdapter {
    * server-side. Adapters that don't park clients don't need to implement it.
    */
   drainSessions?(config: ConnectionConfig): Promise<void>
+
+  /**
+   * Open a dedicated, unpooled connection for a caller that needs server-side session
+   * state to survive across calls. Adapters that only ever serve pooled queries don't
+   * implement it, and callers must handle its absence.
+   */
+  createDedicatedClient?(config: ConnectionConfig): Promise<DedicatedClient>
+
+  /**
+   * Open a dedicated connection that also delivers asynchronous notifications
+   * (PostgreSQL LISTEN/NOTIFY). Only implemented where the server has the feature.
+   */
+  createNotificationClient?(config: ConnectionConfig): Promise<NotificationClient>
 
   /** Fetch database schemas, tables, and columns */
   getSchemas(config: ConnectionConfig): Promise<SchemaInfo[]>

--- a/apps/desktop/src/main/db-adapter.ts
+++ b/apps/desktop/src/main/db-adapter.ts
@@ -67,19 +67,31 @@ export interface DedicatedClient {
    * Register the handler for this connection dying underneath the caller — a socket
    * error, or a clean close from the server, which arrives as a null error.
    *
-   * Fires at most once per connection, and never for a `close()` the caller asked for.
-   * If the connection already died before the handler was registered, it fires
-   * immediately with whatever killed it.
+   * Single-handler: a later registration replaces the earlier one. The connection
+   * reports its death at most once, and never for a `close()` the caller asked for. A
+   * death that happened before registration is replayed to the handler immediately, so
+   * there is no window in which it can be missed.
    */
   onDisconnect(handler: (error: Error | null) => void): void
 
-  /** Close the connection and release whatever it rode on (SSH tunnel). Idempotent. */
+  /**
+   * Close the connection and release whatever it rode on (SSH tunnel).
+   *
+   * Idempotent: repeat calls await the same teardown rather than starting another. A
+   * teardown that failed stays failed — the rejection is replayed, not retried.
+   */
   close(): Promise<void>
 }
 
 /** A dedicated client that also delivers asynchronous notifications from the server. */
 export interface NotificationClient extends DedicatedClient {
-  /** Register the handler for notifications on any channel this client is LISTENing to. */
+  /**
+   * Register the handler for notifications on any channel this client is LISTENing to.
+   *
+   * Single-handler, like `onDisconnect`: a later registration replaces the earlier one.
+   * Unlike a disconnect, a notification that arrives before registration is dropped —
+   * register before issuing `LISTEN`.
+   */
   onNotification(handler: (channel: string, payload: string) => void): void
 }
 
@@ -154,6 +166,10 @@ export interface DatabaseAdapter {
    * Open a dedicated, unpooled connection for a caller that needs server-side session
    * state to survive across calls. Adapters that only ever serve pooled queries don't
    * implement it, and callers must handle its absence.
+   *
+   * The returned client is already connected — there is no separate connect step — and
+   * an implementation that fails partway releases whatever it had acquired (socket, SSH
+   * tunnel) before rejecting, so a caller has nothing to clean up on failure.
    */
   createDedicatedClient?(config: ConnectionConfig): Promise<DedicatedClient>
 

--- a/apps/desktop/src/main/pg-notification-listener.ts
+++ b/apps/desktop/src/main/pg-notification-listener.ts
@@ -9,7 +9,7 @@ import type {
   PgNotificationConnectionStatus,
   PgNotificationConnectionState
 } from '@shared/index'
-import { getAdapter, type NotificationClient } from './db-adapter'
+import { getAdapter, type DatabaseAdapter, type NotificationClient } from './db-adapter'
 import { createLogger } from './lib/logger'
 
 const log = createLogger('pg-notification-listener')
@@ -18,25 +18,38 @@ const MAX_EVENTS_PER_CONNECTION = 10000
 const MAX_BACKOFF_MS = 30_000
 
 /**
- * Open the long-lived connection a listener parks on.
+ * The factory for the long-lived connection a listener parks on.
  *
  * LISTEN registers against one backend session, so this connection can't come out of
  * the pool. The adapter owns building it — SSL, SSH tunnel, `search_path` — so a
  * listener connects exactly the way a query does.
+ *
+ * Callers resolve this *before* entering the reconnect loop: an adapter that doesn't
+ * speak LISTEN/NOTIFY is a permanent failure, and feeding it to the backoff ladder
+ * would spin forever instead of telling the user.
  */
-async function openNotificationClient(config: ConnectionConfig): Promise<NotificationClient> {
+function requireNotificationSupport(
+  config: ConnectionConfig
+): NonNullable<DatabaseAdapter['createNotificationClient']> {
   const adapter = getAdapter(config)
-  if (!adapter.createNotificationClient) {
+  const create = adapter.createNotificationClient
+  if (!create) {
     throw new Error(`LISTEN/NOTIFY is not supported for ${adapter.dbType} connections`)
   }
-  return adapter.createNotificationClient(config)
+  return create.bind(adapter)
 }
 
+/**
+ * One connection attempt: the client it opened and the channels it carries.
+ *
+ * `destroyed` means "this attempt is retired, ignore its callbacks". It deliberately
+ * says nothing about whether the *connection* should keep retrying — that used to be
+ * conflated, and retiring a failed attempt silently switched off its own recovery.
+ */
 interface ListenerEntry {
   client: NotificationClient
   channels: Set<string>
   connectedSince: number
-  reconnectTimer?: ReturnType<typeof setTimeout>
   destroyed: boolean
   config: ConnectionConfig
   status: PgNotificationConnectionStatus
@@ -105,18 +118,45 @@ function getDb(): Database.Database {
 
 const listeners = new Map<string, ListenerEntry>()
 
+/**
+ * Pending reconnect timers, held per connection rather than on the entry.
+ *
+ * An entry is one attempt and dies with it; recovery outlives any single attempt, so a
+ * timer parked on the entry was unreachable exactly when it mattered — after a failed
+ * dial, when there is no live entry to hang it from.
+ */
+const pendingReconnects = new Map<string, ReturnType<typeof setTimeout>>()
+
+function clearPendingReconnect(connectionId: string): void {
+  const timer = pendingReconnects.get(connectionId)
+  if (!timer) return
+  clearTimeout(timer)
+  pendingReconnects.delete(connectionId)
+}
+
+/**
+ * Connections torn down for good, so a timer that fires during shutdown can't dial a
+ * connection the app has finished with.
+ */
+const abandoned = new Set<string>()
+
 async function connectListener(
   connectionId: string,
   config: ConnectionConfig,
   channels: Set<string>,
   backoffMs = 1000
 ): Promise<void> {
+  abandoned.delete(connectionId)
+  clearPendingReconnect(connectionId)
+
   const existing = listeners.get(connectionId)
   if (existing) {
     existing.destroyed = true
-    if (existing.reconnectTimer) clearTimeout(existing.reconnectTimer)
-    await existing.client.close().catch(() => {
-      // ignore close errors
+    // Removed, not left as a tombstone: a retired entry that stays in the map makes
+    // subscribe() think there is a live listener to add a channel to.
+    listeners.delete(connectionId)
+    await existing.client.close().catch((err) => {
+      log.warn(`Failed to close the previous listener client for ${connectionId}:`, err)
     })
   }
 
@@ -129,7 +169,7 @@ async function connectListener(
 
   let client: NotificationClient | null = null
   try {
-    client = await openNotificationClient(config)
+    client = await requireNotificationSupport(config)(config)
 
     const entry: ListenerEntry = {
       client,
@@ -142,6 +182,9 @@ async function connectListener(
     listeners.set(connectionId, entry)
 
     client.onNotification((channel, payload) => {
+      // A retired client whose close() failed can still be delivering; without this its
+      // events would be persisted and broadcast alongside its replacement's.
+      if (entry.destroyed) return
       const event: PgNotificationEvent = {
         id: randomUUID(),
         connectionId,
@@ -181,19 +224,23 @@ async function connectListener(
     })
   } catch (err) {
     log.error(`Failed to connect listener for ${connectionId}:`, err)
-    // A LISTEN that failed after the dial succeeded leaves a live connection behind.
-    // Retire the entry first so its disconnect handler doesn't schedule a second retry
-    // on top of the one below.
+    // A LISTEN that failed after the dial succeeded leaves a live connection behind, so
+    // this attempt has to be retired and closed. Retiring it must not disarm the retry
+    // below, which is why `destroyed` no longer gates scheduleReconnect.
     const entry = listeners.get(connectionId)
-    if (entry && entry.client === client) entry.destroyed = true
-    await client?.close().catch(() => {
-      // ignore close errors
+    const retryChannels = entry?.client === client ? entry.channels : channels
+    if (entry && entry.client === client) {
+      entry.destroyed = true
+      listeners.delete(connectionId)
+    }
+    await client?.close().catch((closeErr) => {
+      log.warn(`Failed to close the half-built listener client for ${connectionId}:`, closeErr)
     })
     setStatus(connectionId, {
       state: 'error',
       lastError: err instanceof Error ? err.message : String(err)
     })
-    scheduleReconnect(connectionId, config, channels, backoffMs)
+    scheduleReconnect(connectionId, config, retryChannels, backoffMs)
   }
 }
 
@@ -203,8 +250,7 @@ function scheduleReconnect(
   channels: Set<string>,
   backoffMs: number
 ): void {
-  const entry = listeners.get(connectionId)
-  if (entry?.destroyed) return
+  if (abandoned.has(connectionId)) return
 
   const nextBackoff = Math.min(backoffMs * 2, MAX_BACKOFF_MS)
   const nextRetryAt = Date.now() + backoffMs
@@ -218,17 +264,17 @@ function scheduleReconnect(
     backoffMs
   })
 
-  if (entry && entry.reconnectTimer) clearTimeout(entry.reconnectTimer)
+  // At most one timer per connection: a socket death that reaches both the disconnect
+  // handler and a rejected query would otherwise arm two.
+  clearPendingReconnect(connectionId)
 
   const timer = setTimeout(() => {
-    const current = listeners.get(connectionId)
-    if (current?.destroyed) return
+    pendingReconnects.delete(connectionId)
+    if (abandoned.has(connectionId)) return
     connectListener(connectionId, config, channels, nextBackoff)
   }, backoffMs)
 
-  if (entry) {
-    entry.reconnectTimer = timer
-  }
+  pendingReconnects.set(connectionId, timer)
 }
 
 export async function forceReconnect(connectionId: string): Promise<void> {
@@ -236,10 +282,7 @@ export async function forceReconnect(connectionId: string): Promise<void> {
   if (!entry) {
     throw new Error('No listener registered for this connection')
   }
-  if (entry.reconnectTimer) {
-    clearTimeout(entry.reconnectTimer)
-    entry.reconnectTimer = undefined
-  }
+  clearPendingReconnect(connectionId)
   log.debug(`Force-reconnecting ${connectionId}`)
   await connectListener(connectionId, entry.config, new Set(entry.channels), 1000)
 }
@@ -293,6 +336,10 @@ export async function subscribe(
   config: ConnectionConfig,
   channel: string
 ): Promise<void> {
+  // Up front, so an unsupported driver rejects the IPC call instead of disappearing
+  // into connectListener's catch and retrying on a ladder that can never succeed.
+  requireNotificationSupport(config)
+
   const existing = listeners.get(connectionId)
 
   if (existing && !existing.destroyed) {
@@ -331,9 +378,15 @@ export async function send(
   channel: string,
   payload: string
 ): Promise<void> {
+  const adapter = getAdapter(config)
+  // Checked rather than left to the server so a non-Postgres connection gets the same
+  // message the subscribe path gives, not a driver syntax error about pg_notify.
+  if (!adapter.createNotificationClient) {
+    throw new Error(`LISTEN/NOTIFY is not supported for ${adapter.dbType} connections`)
+  }
   // One-shot, so this goes through the pool rather than opening (and tunnelling) a
   // connection of its own. Only a listener needs a session it can park on.
-  await getAdapter(config).execute(config, 'SELECT pg_notify($1, $2)', [channel, payload])
+  await adapter.execute(config, 'SELECT pg_notify($1, $2)', [channel, payload])
 }
 
 export function getChannels(connectionId: string): PgNotificationChannel[] {
@@ -386,11 +439,20 @@ export function clearHistory(connectionId: string): void {
 }
 
 export async function cleanup(): Promise<void> {
+  // Abandon every connection that has a timer parked, not just those with a live entry:
+  // a connection whose last dial failed has no entry but may still have a retry armed.
+  for (const connectionId of pendingReconnects.keys()) {
+    abandoned.add(connectionId)
+  }
+  for (const connectionId of Array.from(pendingReconnects.keys())) {
+    clearPendingReconnect(connectionId)
+  }
+
   for (const [connectionId, entry] of listeners.entries()) {
+    abandoned.add(connectionId)
     entry.destroyed = true
-    if (entry.reconnectTimer) clearTimeout(entry.reconnectTimer)
-    await entry.client.close().catch(() => {
-      // ignore close errors
+    await entry.client.close().catch((err) => {
+      log.warn(`Failed to close listener client for ${connectionId} during cleanup:`, err)
     })
     listeners.delete(connectionId)
     statuses.delete(connectionId)

--- a/apps/desktop/src/main/pg-notification-listener.ts
+++ b/apps/desktop/src/main/pg-notification-listener.ts
@@ -1,8 +1,6 @@
 import { randomUUID } from 'crypto'
-import { Client, type ClientConfig } from 'pg'
 import { BrowserWindow, app } from 'electron'
 import { join } from 'path'
-import { readFileSync } from 'fs'
 import Database from 'better-sqlite3'
 import type {
   ConnectionConfig,
@@ -11,8 +9,7 @@ import type {
   PgNotificationConnectionStatus,
   PgNotificationConnectionState
 } from '@shared/index'
-import { createTunnel, closeTunnel, TunnelSession } from './ssh-tunnel-service'
-import { buildSearchPathOption } from './adapters/pg-client-config'
+import { getAdapter, type NotificationClient } from './db-adapter'
 import { createLogger } from './lib/logger'
 
 const log = createLogger('pg-notification-listener')
@@ -20,52 +17,23 @@ const log = createLogger('pg-notification-listener')
 const MAX_EVENTS_PER_CONNECTION = 10000
 const MAX_BACKOFF_MS = 30_000
 
-function buildClientConfig(
-  config: ConnectionConfig,
-  overrides?: { host: string; port: number }
-): ClientConfig {
-  const clientConfig: ClientConfig = {
-    host: overrides?.host ?? config.host,
-    port: overrides?.port ?? config.port,
-    database: config.database,
-    user: config.user,
-    password: config.password
+/**
+ * Open the long-lived connection a listener parks on.
+ *
+ * LISTEN registers against one backend session, so this connection can't come out of
+ * the pool. The adapter owns building it — SSL, SSH tunnel, `search_path` — so a
+ * listener connects exactly the way a query does.
+ */
+async function openNotificationClient(config: ConnectionConfig): Promise<NotificationClient> {
+  const adapter = getAdapter(config)
+  if (!adapter.createNotificationClient) {
+    throw new Error(`LISTEN/NOTIFY is not supported for ${adapter.dbType} connections`)
   }
-
-  const searchPathOption = buildSearchPathOption(config.schema)
-  if (searchPathOption) {
-    clientConfig.options = searchPathOption
-  }
-
-  if (config.ssl) {
-    const sslOptions = config.sslOptions || {}
-
-    if (sslOptions.ca) {
-      try {
-        clientConfig.ssl = {
-          rejectUnauthorized: sslOptions.rejectUnauthorized !== false,
-          ca: readFileSync(sslOptions.ca, 'utf-8')
-        }
-      } catch (err) {
-        throw new Error(
-          `Failed to read CA certificate file: ${sslOptions.ca}. ${(err as Error).message}`
-        )
-      }
-    } else {
-      // Default to rejectUnauthorized: false (matches adapters) so cloud DBs
-      // with self-signed certs work. Opt-in strict verification via UI.
-      clientConfig.ssl = {
-        rejectUnauthorized: sslOptions.rejectUnauthorized === true
-      }
-    }
-  }
-
-  return clientConfig
+  return adapter.createNotificationClient(config)
 }
 
 interface ListenerEntry {
-  client: Client
-  tunnelSession: TunnelSession | null
+  client: NotificationClient
   channels: Set<string>
   connectedSince: number
   reconnectTimer?: ReturnType<typeof setTimeout>
@@ -147,12 +115,9 @@ async function connectListener(
   if (existing) {
     existing.destroyed = true
     if (existing.reconnectTimer) clearTimeout(existing.reconnectTimer)
-    try {
-      await existing.client.end()
-    } catch {
+    await existing.client.close().catch(() => {
       // ignore close errors
-    }
-    closeTunnel(existing.tunnelSession)
+    })
   }
 
   const prior = statuses.get(connectionId)
@@ -162,21 +127,12 @@ async function connectListener(
     backoffMs: undefined
   })
 
-  let tunnelSession: TunnelSession | null = null
+  let client: NotificationClient | null = null
   try {
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-
-    const overrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-
-    const client = new Client(buildClientConfig(config, overrides))
+    client = await openNotificationClient(config)
 
     const entry: ListenerEntry = {
       client,
-      tunnelSession,
       channels: new Set(channels),
       connectedSince: Date.now(),
       destroyed: false,
@@ -185,12 +141,12 @@ async function connectListener(
     }
     listeners.set(connectionId, entry)
 
-    client.on('notification', (msg) => {
+    client.onNotification((channel, payload) => {
       const event: PgNotificationEvent = {
         id: randomUUID(),
         connectionId,
-        channel: msg.channel,
-        payload: msg.payload ?? '',
+        channel,
+        payload,
         receivedAt: Date.now()
       }
 
@@ -198,24 +154,17 @@ async function connectListener(
       broadcastEvent(event)
     })
 
-    client.on('error', (err) => {
+    client.onDisconnect((err) => {
       if (entry.destroyed) return
-      log.error(`pg notification client error for ${connectionId}:`, err)
-      setStatus(connectionId, {
-        state: 'error',
-        lastError: err instanceof Error ? err.message : String(err)
-      })
+      if (err) {
+        log.error(`pg notification client error for ${connectionId}:`, err)
+        setStatus(connectionId, { state: 'error', lastError: err.message })
+      } else {
+        log.warn(`pg notification client disconnected for ${connectionId}, reconnecting...`)
+        setStatus(connectionId, { state: 'disconnected' })
+      }
       scheduleReconnect(connectionId, config, entry.channels, backoffMs)
     })
-
-    client.on('end', () => {
-      if (entry.destroyed) return
-      log.warn(`pg notification client disconnected for ${connectionId}, reconnecting...`)
-      setStatus(connectionId, { state: 'disconnected' })
-      scheduleReconnect(connectionId, config, entry.channels, backoffMs)
-    })
-
-    await client.connect()
 
     for (const channel of channels) {
       await client.query(`LISTEN ${quoteIdent(channel)}`)
@@ -232,7 +181,14 @@ async function connectListener(
     })
   } catch (err) {
     log.error(`Failed to connect listener for ${connectionId}:`, err)
-    closeTunnel(tunnelSession)
+    // A LISTEN that failed after the dial succeeded leaves a live connection behind.
+    // Retire the entry first so its disconnect handler doesn't schedule a second retry
+    // on top of the one below.
+    const entry = listeners.get(connectionId)
+    if (entry && entry.client === client) entry.destroyed = true
+    await client?.close().catch(() => {
+      // ignore close errors
+    })
     setStatus(connectionId, {
       state: 'error',
       lastError: err instanceof Error ? err.message : String(err)
@@ -375,26 +331,9 @@ export async function send(
   channel: string,
   payload: string
 ): Promise<void> {
-  let tunnelSession: TunnelSession | null = null
-  try {
-    if (config.ssh) {
-      tunnelSession = await createTunnel(config)
-    }
-
-    const overrides = tunnelSession
-      ? { host: tunnelSession.localHost, port: tunnelSession.localPort }
-      : undefined
-
-    const client = new Client(buildClientConfig(config, overrides))
-    await client.connect()
-    try {
-      await client.query('SELECT pg_notify($1, $2)', [channel, payload])
-    } finally {
-      await client.end().catch(() => {})
-    }
-  } finally {
-    closeTunnel(tunnelSession)
-  }
+  // One-shot, so this goes through the pool rather than opening (and tunnelling) a
+  // connection of its own. Only a listener needs a session it can park on.
+  await getAdapter(config).execute(config, 'SELECT pg_notify($1, $2)', [channel, payload])
 }
 
 export function getChannels(connectionId: string): PgNotificationChannel[] {
@@ -450,12 +389,9 @@ export async function cleanup(): Promise<void> {
   for (const [connectionId, entry] of listeners.entries()) {
     entry.destroyed = true
     if (entry.reconnectTimer) clearTimeout(entry.reconnectTimer)
-    try {
-      await entry.client.end()
-    } catch {
+    await entry.client.close().catch(() => {
       // ignore close errors
-    }
-    closeTunnel(entry.tunnelSession)
+    })
     listeners.delete(connectionId)
     statuses.delete(connectionId)
   }

--- a/apps/desktop/src/main/step-session.ts
+++ b/apps/desktop/src/main/step-session.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from 'crypto'
-import { Client } from 'pg'
 import type {
   ConnectionConfig,
   StatementResult,
@@ -13,29 +12,20 @@ import type {
   RetryStepResponse,
   StopStepResponse
 } from '@shared/index'
-import { buildSearchPathOption } from './adapters/pg-client-config'
 import { STEP_SESSION_IDLE_TIMEOUT_MS, STEP_SESSION_CLEANUP_INTERVAL_MS } from '@shared/index'
+import { getAdapter, type DedicatedClient } from './db-adapter'
+import { isDataReturningStatement } from './adapters/postgres-adapter'
 import { parseStatementsWithLines } from './lib/parse-statements'
 import { createLogger } from './lib/logger'
 
 const log = createLogger('step-session')
-
-export interface MinimalDbClient {
-  connect(): Promise<void>
-  query(sql: string): Promise<{
-    rows: unknown[]
-    fields?: Array<{ name: string; dataTypeID?: number }>
-    rowCount: number | null
-  }>
-  end(): Promise<void>
-}
 
 interface StepSession {
   id: string
   windowId: number
   tabId: string
   config: ConnectionConfig
-  client: MinimalDbClient
+  client: DedicatedClient
   statements: ParsedStatement[]
   cursorIndex: number
   breakpoints: Set<number>
@@ -47,13 +37,14 @@ interface StepSession {
 }
 
 export interface StepSessionRegistryOptions {
-  createClient?: (config: ConnectionConfig) => MinimalDbClient
+  /** Injection seam for tests. Production opens a dedicated client via the adapter. */
+  createClient?: (config: ConnectionConfig) => Promise<DedicatedClient>
 }
 
 export class StepSessionRegistry {
   private sessions = new Map<string, StepSession>()
   private cleanupTimer: ReturnType<typeof setInterval> | null = null
-  private createClient: (config: ConnectionConfig) => MinimalDbClient
+  private createClient: (config: ConnectionConfig) => Promise<DedicatedClient>
 
   constructor(options: StepSessionRegistryOptions = {}) {
     this.createClient = options.createClient ?? defaultClientFactory
@@ -85,15 +76,16 @@ export class StepSessionRegistry {
       throw new Error('No statements found in SQL')
     }
 
-    const client = this.createClient(input.config)
+    // The client arrives connected, so a dial failure throws here with nothing to
+    // clean up — the factory unwinds its own tunnel.
+    const client = await this.createClient(input.config)
     try {
-      await client.connect()
       if (input.inTransaction) {
         await client.query('BEGIN')
       }
     } catch (err) {
-      await client.end().catch((endErr) => {
-        log.warn(`Cleanup after failed start: client.end() also failed:`, endErr)
+      await client.close().catch((closeErr) => {
+        log.warn(`Cleanup after failed start: client.close() also failed:`, closeErr)
       })
       throw err
     }
@@ -238,8 +230,8 @@ export class StepSessionRegistry {
       }
     }
 
-    await session.client.end().catch((err) => {
-      log.warn(`Client.end() failed for session ${sessionId}:`, err)
+    await session.client.close().catch((err) => {
+      log.warn(`Client.close() failed for session ${sessionId}:`, err)
     })
 
     this.sessions.delete(sessionId)
@@ -297,20 +289,15 @@ export class StepSessionRegistry {
     try {
       const res = await session.client.query(statement.sql)
       const durationMs = Date.now() - stmtStart
-      const fields = (res.fields ?? []).map((f) => ({
-        name: f.name,
-        dataType: 'unknown',
-        dataTypeID: f.dataTypeID ?? 0
-      }))
 
       const result: StatementResult = {
         statement: statement.sql,
         statementIndex,
-        rows: (res.rows ?? []) as Record<string, unknown>[],
-        fields,
-        rowCount: res.rowCount ?? res.rows?.length ?? 0,
+        rows: res.rows,
+        fields: res.fields,
+        rowCount: res.rowCount ?? res.rows.length,
         durationMs,
-        isDataReturning: (res.rows ?? []).length > 0 || Array.isArray(res.fields)
+        isDataReturning: isDataReturningStatement(statement.sql)
       }
 
       if (opts.advance) {
@@ -348,28 +335,18 @@ export class StepSessionRegistry {
   }
 }
 
-function defaultClientFactory(config: ConnectionConfig): MinimalDbClient {
-  const client = new Client({
-    host: config.host,
-    port: config.port,
-    database: config.database,
-    user: config.user,
-    password: config.password,
-    options: buildSearchPathOption(config.schema),
-    ssl: config.ssl ? { rejectUnauthorized: false } : undefined
-  })
-  return {
-    connect: async () => {
-      await client.connect()
-    },
-    query: async (sql: string) => {
-      const res = await client.query(sql)
-      return {
-        rows: res.rows,
-        fields: res.fields as unknown as Array<{ name: string; dataTypeID?: number }>,
-        rowCount: res.rowCount
-      }
-    },
-    end: () => client.end()
+/**
+ * Open the connection a step session runs on.
+ *
+ * It has to be dedicated: the session holds a transaction open across many IPC calls,
+ * so a pooled client — handed back after each call — would lose it. The adapter owns
+ * how that connection is built, which is what keeps step sessions honouring the SSL,
+ * SSH and `search_path` settings the rest of the app does.
+ */
+async function defaultClientFactory(config: ConnectionConfig): Promise<DedicatedClient> {
+  const adapter = getAdapter(config)
+  if (!adapter.createDedicatedClient) {
+    throw new Error(`Step-through execution is not supported for ${adapter.dbType} connections`)
   }
+  return adapter.createDedicatedClient(config)
 }

--- a/apps/desktop/src/main/step-session.ts
+++ b/apps/desktop/src/main/step-session.ts
@@ -34,6 +34,12 @@ interface StepSession {
   lastError: StepSessionError | null
   lastActivity: number
   startedAt: number
+  /**
+   * The backend went away underneath this session. Anything it had open — the
+   * transaction included — is already gone server-side, so teardown must not try to
+   * talk to it.
+   */
+  connectionLost: boolean
 }
 
 export interface StepSessionRegistryOptions {
@@ -76,8 +82,8 @@ export class StepSessionRegistry {
       throw new Error('No statements found in SQL')
     }
 
-    // The client arrives connected, so a dial failure throws here with nothing to
-    // clean up — the factory unwinds its own tunnel.
+    // The client arrives connected — see `createDedicatedClient` for the guarantee — so
+    // a dial failure throws here with nothing to clean up.
     const client = await this.createClient(input.config)
     try {
       if (input.inTransaction) {
@@ -85,7 +91,10 @@ export class StepSessionRegistry {
       }
     } catch (err) {
       await client.close().catch((closeErr) => {
-        log.warn(`Cleanup after failed start: client.close() also failed:`, closeErr)
+        log.error(
+          `Cleanup after failed start: client.close() also failed; connection may be orphaned:`,
+          closeErr
+        )
       })
       throw err
     }
@@ -105,7 +114,25 @@ export class StepSessionRegistry {
       state: 'paused',
       lastError: null,
       lastActivity: now,
-      startedAt: now
+      startedAt: now,
+      connectionLost: false
+    })
+
+    // Without this the session sits in the map looking paused, and the next step blames
+    // whichever statement the cursor happens to be on for a connection that had already
+    // died.
+    client.onDisconnect((err) => {
+      const session = this.sessions.get(sessionId)
+      if (!session) return
+      log.error(`Step session ${sessionId} lost its connection:`, err)
+      session.connectionLost = true
+      session.state = 'errored'
+      session.lastError = {
+        statementIndex: session.cursorIndex,
+        message: err
+          ? `Connection lost: ${err.message}. Stop and restart the session.`
+          : 'The database closed this connection. Stop and restart the session.'
+      }
     })
 
     log.debug(`Started step session ${sessionId} (tab=${input.tabId}, window=${input.windowId})`)
@@ -220,7 +247,11 @@ export class StepSessionRegistry {
     let rolledBack = false
     let rollbackError: string | undefined
 
-    if (session.inTransaction && (session.state === 'paused' || session.state === 'errored')) {
+    if (
+      session.inTransaction &&
+      !session.connectionLost &&
+      (session.state === 'paused' || session.state === 'errored')
+    ) {
       try {
         await session.client.query('ROLLBACK')
         rolledBack = true
@@ -231,7 +262,10 @@ export class StepSessionRegistry {
     }
 
     await session.client.close().catch((err) => {
-      log.warn(`Client.close() failed for session ${sessionId}:`, err)
+      log.error(
+        `Client.close() failed for session ${sessionId} (${session.config.host}/${session.config.database}); connection may be orphaned:`,
+        err
+      )
     })
 
     this.sessions.delete(sessionId)
@@ -338,10 +372,13 @@ export class StepSessionRegistry {
 /**
  * Open the connection a step session runs on.
  *
- * It has to be dedicated: the session holds a transaction open across many IPC calls,
- * so a pooled client — handed back after each call — would lose it. The adapter owns
- * how that connection is built, which is what keeps step sessions honouring the SSL,
- * SSH and `search_path` settings the rest of the app does.
+ * It is dedicated because the session accumulates backend state — an open transaction,
+ * temp tables, `SET`s — that has to survive between IPC calls, and because it stays
+ * open for as long as the user leaves the panel up. (`acquirePgSessionClient` also
+ * holds a client across calls, but its budget is small and meant for transactions the
+ * user is actively driving.) The adapter owns how the connection is built, which is
+ * what keeps step sessions honouring the SSL, SSH and `search_path` settings the rest
+ * of the app does.
  */
 async function defaultClientFactory(config: ConnectionConfig): Promise<DedicatedClient> {
   const adapter = getAdapter(config)


### PR DESCRIPTION
Closes #248
Closes #249

## The problem

`pg-notification-listener.ts` and `step-session.ts` each built their own `pg.Client`. The listener carried a near-copy of `buildClientConfig`; step-session hand-rolled a config from scratch. Both sat outside the `DatabaseAdapter` boundary, so every future connection setting had to land in three places — and the two copies had already drifted from the canonical one.

## The boundary

Two optional capability methods on `DatabaseAdapter`, in the same style as the existing `beginTransaction?` / `drainSessions?`:

| Method | Returns |
|---|---|
| `createDedicatedClient?(config)` | `DedicatedClient` — `query` / `onDisconnect` / `close` |
| `createNotificationClient?(config)` | `NotificationClient` — the above plus `onNotification` |

New `adapters/pg-dedicated-client.ts` implements both and is now the only place outside the pool manager that constructs a `pg.Client`. It owns the SSH tunnel for the connection's lifetime, builds config via the canonical `buildClientConfig`, and collapses pg's `error`/`end` pair into a single `onDisconnect(error | null)` that fires at most once.

Callers check the capability rather than assuming Postgres, so a non-pg connection gets a clear message instead of a driver error.

## Bugs this fixed on the way

All of them consequences of the hand-rolled configs:

- **Step sessions ignored SSH entirely** — dialled `config.host`/`config.port` raw, so step-through against a tunnelled connection reached for an unreachable host.
- **Step sessions silently downgraded TLS** — hardcoded `ssl: { rejectUnauthorized: false }`, discarding a configured CA and any strict-verify opt-in.
- **The listener set no TCP keepalive** — a socket killed by laptop sleep or a NAT idle reap stayed silent instead of erroring, so the reconnect loop, whose whole job is to notice that, never fired.
- **Double reconnect** — pg emits `error` then `end` for one socket death; the listener treated them as two and scheduled two retries, inflating its own backoff.
- **Leaked connection** — a `LISTEN` that failed after a successful dial closed the tunnel but never the client.

`send()` now goes through the pooled `adapter.execute`; a one-shot `pg_notify` never needed a connection and tunnel of its own.

## Behaviour change worth a look

Step-session's `StatementResult` carried `dataType: 'unknown'` for every column, and computed `isDataReturning` as `rows.length > 0 || Array.isArray(fields)` — always true, since pg returns `fields: []` for everything. Types now resolve properly, and `isDataReturning` uses `isDataReturningStatement(sql)`, the same helper the normal query path uses. So a stepped `UPDATE` labels its count "affected" rather than "rows".

## Deliberately out of scope

`pg-export.ts` and `pg-import.ts` still construct `pg.Client` directly. Neither issue names them, and both drive `pg-copy-streams`, which needs the raw driver client rather than an abstract query interface — routing them means widening the boundary with a streaming capability. Worth its own issue.

## Testing

- New `pg-dedicated-client.test.ts` — 13 cases covering config derivation, tunnel setup and teardown (including on a failed dial), idempotent close, field-type resolution, parameter passthrough, and the full `onDisconnect` contract: error-then-end reported once, clean close as `null`, replay for a handler registered after the death, silence for an owner-requested close, and no unhandled-`error` escape mid-handshake.
- `step-session.test.ts` updated for the connected-on-create factory.
- Full suite: 1368 passing. `pnpm typecheck` clean, lint clean on every touched file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added persistent PostgreSQL connections for database sessions.
  * Added real-time PostgreSQL LISTEN/NOTIFY support with reconnect handling.
  * Added optional SSH tunneling for dedicated connections.

* **Bug Fixes**
  * Improved disconnect detection, cleanup, and shutdown reliability.
  * Improved recovery after failed connections and connection loss.
  * Standardized query results and row-count handling.
  * Preserved PostgreSQL timestamp values consistently across connection types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->